### PR TITLE
A quick fix to validateExpressRequest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,8 @@ initializer.validateRequest = function(authToken, twilioHeader, url, params) {
  */
 initializer.validateExpressRequest = function(request, authToken) {
     var url = request.protocol + '://' + request.headers.host + request.url;
-    return initializer.validateRequest(authToken, request.header('X-Twilio-Signature'), url, request.body);
+    var body = (request.body ? request.body : {});
+    return initializer.validateRequest(authToken, request.header('X-Twilio-Signature'), url, body);
 };
 
 //public module interface is a function, which passes through to RestClient constructor


### PR DESCRIPTION
If there is no request.body, the method would cause validateRequest to
crash.  Literally a two line fix, but makes it incredibly easy to use validateExpressRequest in middleware to verify all requests are being made by Twilio.  Enjoy!
