### PR TITLE
error passed to the callback in RestClient.js contains too much data

### DIFF
--- a/lib/RestClient.js
+++ b/lib/RestClient.js
@@ -103,11 +103,16 @@ RestClient.prototype.request = function (options, callback) {
     //Initiate HTTP request
     request(options, function (err, response, body) {
         if (callback) {
-            var data = err  || !body ? {} : JSON.parse(body);
+            var data;
+            try {
+                data = err || !body ? {status: 500, message: 'Empty body'} : JSON.parse(body);
+            } catch (e) {
+                data = { status: 500, message: (e.message || 'Invalid JSON body') };
+            }
 
             //request doesn't think 4xx is an error - we want an error for any non-2xx status codes
             if (!err && (response.statusCode < 200 || response.statusCode > 206)) {
-                err = data ? data : {
+                err = data ? data.message : {
                     status: response.statusCode,
                     message:'HTTP request error, check response for more info'
                 };


### PR DESCRIPTION
Passing back the `request` body in case of errors causes massive problems if there is a logger such as bunyan listening for errors. In fact it tries to log all the body object which contains a binary buffer. resulting into 259M of crap

I have also added a try catch around the JSON.parse() method as good practice since it can throw.

I am not 100% sure why JSON.parse() is used in first place since `request` should parse the body if the right response header is sent from the twilio endpoint. Anyway I didn't want to change too much the library since there is no test.
