### PR TITLE
Do not crash when twilio servers are unreachable

### DIFF
--- a/lib/RestClient.js
+++ b/lib/RestClient.js
@@ -112,6 +112,7 @@ RestClient.prototype.request = function (options, callback) {
 
             //request doesn't think 4xx is an error - we want an error for any non-2xx status codes
             var error = null;
+            response = response || {}; // response is null if the target server is unreachable
             if (err || (response.statusCode < 200 || response.statusCode > 206)) {
                 error = { status: response.statusCode };
                 error.message = data ? data.message : 'HTTP request error, check response for more info';


### PR DESCRIPTION
When a request is made and the target host is unreachable (e.g. network problems, server problems, etc), the `response` object passed to `request`'s callback is `null` (and `err` contains error information). Trying to dereference `response.statusCode` will throw a `TypeError` and crash the host process. Ouch...
