### PR TITLE
Set timeout to 31 seconds

### DIFF
--- a/lib/RestClient.js
+++ b/lib/RestClient.js
@@ -97,8 +97,10 @@ RestClient.prototype.request = function (options, callback) {
     options.url = client.getBaseUrl() + options.url + '.json';
     options.headers = {
         'Accept':'application/json',
+        'Accept-Charset': 'utf-8',
         'User-Agent':'twilio-node/' + moduleinfo.version
     };
+    options.timeout = 31000;
 
     //Initiate HTTP request
     request(options, function (err, response, body) {


### PR DESCRIPTION
The API should always return in 30 seconds. The system socket timeout may be
shorter than this, so explicitly set the timeout to the value that we want.
