### PR TITLE
http://twilio.com/docs/rest is a 404

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,7 +414,7 @@ client.listSms({
         <p id="structure">
             <b class="header">How This API is Structured</b><br/>
             The <tt>RestClient</tt> API is intended to be self-documenting, mapping very closely to the actual
-            <a href="http://twilio.com/docs/rest">REST API</a>.  Once you have created a client object,
+            <a href="https://www.twilio.com/docs/api/rest">REST API</a>.  Once you have created a client object,
             the object structure looks very much like the Twilio REST URIs, using a chained JavaScript syntax:
         </p>
 <pre>


### PR DESCRIPTION
I think it should be https://www.twilio.com/docs/api/rest
