### PR TITLE
Make nodeClientResponse unenumerable to allow for stringification of the data object.

### DIFF
--- a/lib/RestClient.js
+++ b/lib/RestClient.js
@@ -179,8 +179,13 @@ RestClient.prototype.request = function (options, callback) {
         }
         processKeys(data);
 
-        //hang response off the JSON-serialized data
-        data.nodeClientResponse = response;
+        //hang response off the JSON-serialized data, as unenumerable to allow for stringify. 
+        Object.defineProperty(data, 'nodeClientResponse', {
+            value: response,
+            configurable: true,
+            writeable: true,
+            enumerable: false
+        });
 
         // Resolve promise
         if (error) {


### PR DESCRIPTION
Having the entire response on the data object could lead to unexpected consequences.
When making requests for a single object in a resource the data can't be stringified directly since stringifying the nodeClientResponse is too big an operation. (and what would the purpose be?)
If the property is defined with enumerable set to false, then it won't be included when stringified.
An example is using a get for a single call:

```
client.calls('CA123...').get(function(err, data){
  var json = JSON.stringify(data); //this would be a very heavy operation.
});
```
