### PR TITLE
Patch 1

### DIFF
--- a/lib/RestClient.js
+++ b/lib/RestClient.js
@@ -89,7 +89,6 @@ function processKeys(source) {
                     return g[1].toUpperCase()
                 });
                 source[cc] = source[key];
-                delete source[key];
             }
 
             //process any nested arrays...


### PR DESCRIPTION
I don't think it makes sense keeping the fields with an underscore in them if you want to return a more "javascripty" format.

Although i can't figure out if it makes sense to rename the fields at all since it could cause confusion when looking at the regular REST API documentation. It's already a bit confusing with the TWIML giving back field names with the first letter being uppercase.

What do you think?

Also i moved the creation of the processKeys function outside the request since it doesn't take advantage of any variables inside the request.. No reason to create it at each request.
