### PR TITLE
Fix verification for messages that contain emoji

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,8 +32,8 @@ initializer.validateRequest = function(authToken, twilioHeader, url, params) {
     Object.keys(params).sort().forEach(function(key, i) {
         url = url + key + params[key];
     });
-    var computed = crypto.createHmac('sha1', authToken).update(url).digest('Base64');
-    return twilioHeader === crypto.createHmac('sha1', authToken).update(url).digest('Base64');
+
+    return twilioHeader === crypto.createHmac('sha1', authToken).update(new Buffer(url, 'utf-8')).digest('Base64');
 };
 
 /**

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -9,20 +9,9 @@ var twimlString = '<?xml version="1.0" encoding="UTF-8"?><Response><Message>hi</
     params = { 
         To:'+16515556677', 
         From:'+16515556699',
-        Body:'hello'
+        Body:'hello áçčëñtš 😃'
     },
     fakeToken = 'abcdefghijklmnopqrstuvwxyz1234567890';
-
-function createTestSig(signUrl) {
-    Object.keys(params).sort().forEach(function(key, i) {
-        signUrl = signUrl + key + params[key];
-    });
-    var testSig = crypto.createHmac('sha1', fakeToken)
-                        .update(signUrl)
-                        .digest('Base64');
-
-    return testSig;
-}
 
 describe('Testing Express request validation', function() {
     // create a local express app
@@ -79,7 +68,7 @@ describe('Testing Express request validation', function() {
     it('should act okay if the request is signed the Twilio way', function(done) {
         // Manually create a Twilio signature
         var signUrl = testUrl+'/sms';
-        var testSig = createTestSig(signUrl);
+        var testSig = 'FUjfbzy5aqpVEYoCcThCAKmctVo=';
 
         // Hit our webhook with a "Twilio signed" request
         request({
@@ -120,7 +109,7 @@ describe('Testing Express request validation', function() {
     it('should validate with middleware', function(done) {
         // Manually create a Twilio signature
         var signUrl = testUrl+'/middleware';
-        var testSig = createTestSig(signUrl);
+        var testSig = 'Eh17e3p7Yu48aMIa+yHk++1+L5s=';
 
         // Hit our webhook with a "Twilio signed" request
         request({


### PR DESCRIPTION
It was generating the incorrect hmac for any request that contains any emoji or accented characters.

This PR contains 2 changes
1) remove line 35 (it seems to be computing the hmac for nothing)
2) change the hmac to be computer based of a utf-8 buffer so that it computes correctly
