### PR TITLE
Fix security vulnerability with request

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/twilio/twilio-node.git"
   },
   "dependencies": {
-    "request": "2.27.x",
+    "request": "2.40.x",
     "underscore": "1.x",
     "jwt-simple": "0.1.x",
     "q": "0.9.7",


### PR DESCRIPTION
Earlier version of request relied on qs that had a security issue.
Updating request to the newest version uses the newest version of qs.

There is a security vulnerability with qs,

https://nodesecurity.io/advisories/qs_dos_memory_exhaustion

https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking
