### PR TITLE
Replaces manual url creation by native url formating method

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -1,6 +1,7 @@
 var crypto = require('crypto'),
     _ = require('underscore'),
-    scmp = require('scmp');
+    scmp = require('scmp'),
+    url = require('url');
 
 /**
  Utility function to validate an incoming request is indeed from Twilio
@@ -30,21 +31,25 @@ exports.validateRequest = function(authToken, twilioHeader, url, params) {
     - protocol: manually specify the protocol used by Twilio in a number's webhook config
  */
 exports.validateExpressRequest = function(request, authToken, opts) {
-    var options = opts||{}, url;
+    var options = opts||{}, webhookUrl;
     if (options.url) {
         // Let the user specify the full URL
-        url = options.url;
+        webhookUrl = options.url;
     } else {
         // Use configured host/protocol, or infer based on request
         var protocol = options.protocol||request.protocol;
         var host = options.host||request.headers.host;
-        url = protocol + '://' + host + request.originalUrl;
+        webhookUrl = url.format({
+            protocol: protocol,
+            host: host,
+            pathname: request.originalUrl
+        });
     }
     
     return exports.validateRequest(
         authToken, 
         request.header('X-Twilio-Signature'), 
-        url, 
+        webhookUrl, 
         request.body||{}
     );
 };


### PR DESCRIPTION
It replaces the manual url creation by `string concatenation` with the safer, native, `url.format()` method.

This is not a bug fix, just a slight improvement that delegates url handling to Node.js's core `url` module.