### PR TITLE
Added test coverage support using instanbul.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 config.js
 node_modules
+spec/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+before_script:
+  - npm update -g npm
 node_js:
     - "0.10"
     - "0.8"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,59 @@
+function GruntTasks (grunt) {
+	'use strict';
+
+	grunt.initConfig({
+		clean: {
+			coverage: [
+				'spec/coverage'
+			]
+		},
+		copy: {
+			package: {
+				src: 'package.json',
+				dest: 'spec/coverage/instrument/package.json'
+			}
+		},
+		instrument: {
+			files: [
+				'lib/**/*.js',
+				'index.js'
+			],
+			options: {
+				basePath: 'spec/coverage/instrument/',
+				lazy: false
+			}
+		},
+		jasmine_node: {
+			options: {},
+			spec: [
+				'spec/'
+			]
+		},
+		storeCoverage: {
+			options: {
+				dir: 'spec/coverage/reports'
+			}
+		},
+		makeReport: {
+			src: 'spec/coverage/reports/**/*.json',
+			options: {
+				type: 'lcov',
+				dir: 'spec/coverage/reports',
+				print: 'detail'
+			}
+		}
+	});
+
+	require('load-grunt-tasks')(grunt);
+
+	grunt.registerTask('test', [
+		'clean:coverage',
+		'instrument',
+		'copy:package',
+		'jasmine_node:spec',
+		'storeCoverage',
+		'makeReport'
+	]);
+}
+
+module.exports = GruntTasks;

--- a/package.json
+++ b/package.json
@@ -22,10 +22,17 @@
   },
   "devDependencies": {
     "express": "3.x",
-    "jasmine-node": "*"
+
+    "grunt": "~0.4.5",
+    "grunt-cli": "~0.1.13",
+    "grunt-istanbul": "~0.3.0",
+    "load-grunt-tasks": "~1.0.0",
+    "grunt-jasmine-node": "~0.2.1",
+    "grunt-contrib-copy": "~0.7.0",
+    "grunt-contrib-clean": "~0.6.0"
   },
   "scripts": {
-    "test": "jasmine-node spec"
+    "test": "grunt test"
   },
   "main": "./lib",
   "engines": {

--- a/spec/capability.spec.js
+++ b/spec/capability.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The TwiML Capability Token Object', function () {
 

--- a/spec/client.accounts.spec.js
+++ b/spec/client.accounts.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Client Accounts resource', function () {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.applications.spec.js
+++ b/spec/client.applications.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Client Applications resource', function () {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.availablenumbers.spec.js
+++ b/spec/client.availablenumbers.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Client AvailablePhoneNumbers resource', function() {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.calls.spec.js
+++ b/spec/client.calls.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Client Calls resource', function () {
     var accountSid = 'AC123';

--- a/spec/client.conference.spec.js
+++ b/spec/client.conference.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Conference resource', function () {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.connect.spec.js
+++ b/spec/client.connect.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Connect Apps resource', function () {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.core.spec.js
+++ b/spec/client.core.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Client constructor', function () {
     //mess with the constructor options

--- a/spec/client.incoming.spec.js
+++ b/spec/client.incoming.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Client IncomingPhoneNumbers resource', function () {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.live.spec.js
+++ b/spec/client.live.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../lib');
+var twilio = require('./coverage/instrument/lib');
 
 describe('Live Twilio API smoke tests', function() {
     try {

--- a/spec/client.media.spec.js
+++ b/spec/client.media.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('Twilio Media resource', function() {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.messages.spec.js
+++ b/spec/client.messages.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('Twilio Messages resource', function() {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.outgoing.spec.js
+++ b/spec/client.outgoing.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Client OutgoingCallerIds resource', function () {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.queue.spec.js
+++ b/spec/client.queue.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Client Queues resource', function () {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.sms.spec.js
+++ b/spec/client.sms.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Client SMS resource', function () {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.transcriptions.spec.js
+++ b/spec/client.transcriptions.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('Twilio Transcription resource', function() {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/client.usage.spec.js
+++ b/spec/client.usage.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The Twilio REST Client Usage Records resource', function () {
     var client = new twilio.RestClient('AC123', '123');

--- a/spec/twiml.spec.js
+++ b/spec/twiml.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../index');
+var twilio = require('./coverage/instrument/lib');
 
 describe('The TwiML Response Object', function () {
 

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -1,4 +1,4 @@
-var twilio = require('../lib'),
+var twilio = require('./coverage/instrument/lib'),
     express = require('express'),
     request = require('request'),
     http = require('http'),


### PR DESCRIPTION
This pull request adds test coverage support with `istanbul` and `Grunt.js`. Imported modules are:

- `istanbul`, for `LCOV` format report generation
- `grunt`, task runner
-  `grunt-cli`, run locally installed `Grunt.js` version
- `load-grunt-tasks`, practical util that imports task providers from NPM modules
- `grunt-istanbul`, task that runs the `istanbul` NPM module on the spec,
-  `grunt-jasmine-node`, task that runs the `jasmine-node` NPM module to launch the tests
- `grunt-contrib-copy`, task that copies the `package.json` file needed by the `RestClient.js` file into the `coverage` directory so as not to break the relative `require()` path
- `grunt-contrib-clean`, task that deletes the previous test coverage `reports` and `instruments`

Even though the Twilio team itself doesn't use test coverage, I thought that it could be a cool addition.
In my opinion, test coverages make it easier for new-comers to contribute to the project.

If you guys like the idea, I can also create a second pull-request that would add support for a badge (in the `README.md` file) and test coverage visualisation using [Coveralls](https://coveralls.io/). Coveralls is free because the project is open-source. You only need to GitHub-connect to the site.

