### PR TITLE
Improved .gitignore and .npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,28 @@
-.idea
-.DS_Store
-config.js
+### Dot files ###
+.*
+
+### Git ###
+!/.gitignore
+!/.gitmodules
+
+### Logs ###
+logs
+*.log
+
+### Runtime data ###
+pids
+*.pid
+*.seed
+
+### NPM modules ###
 node_modules
+
+### Travis ###
+!/.travis.yml
+
+### Test coverage ###
+spec/coverage
+
+### Custom ignores ###
+config.js
+.idea

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,28 @@
-.idea
-.DS_Store
-config.js
+### Dot files ###
+.*
+
+### Git ###
+!/.gitignore
+!/.gitmodules
+
+### Logs ###
+logs
+*.log
+
+### Runtime data ###
+pids
+*.pid
+*.seed
+
+### NPM modules ###
 node_modules
+
+### Travis ###
+!/.travis.yml
+
+### Spec and test coverage ###
 spec
+
+### Custom ignores ###
+config.js
+.idea


### PR DESCRIPTION
This commit improves the `.gitignore` and `.npmignore` files.
Here are the two main changes:

1. dot files are now in a white-list rather than a black-list
2. log files are by default ignored (like the `npm-debug.log` file)

This shouldn't add any breaking changes but could cause a conflict with one of my earlier pull-requests (#60) where I also modified the `.gitignore` file so as to not commit test coverage files (the whole `spec/coverage` folder).
If this is the case, the `.gitignore` file this commit is newer and should prevail.