### PR TITLE
Add dynamic date converstion for any date-like value

### DIFF
--- a/lib/RestClient.js
+++ b/lib/RestClient.js
@@ -66,11 +66,16 @@ function RestClient(sid, tkn, options) {
 }
 
 //process data and make available in a more JavaScripty format
-function processKeys(source) {
+RestClient.dateRegex = /^\w+,\s\d+\s\w+\s\d{4}\s\d{2}:\d{2}:\d{2}\s\+\d{4}$/;
+RestClient.prototype.processKeys = function (source) {
     if (_.isObject(source)) {
         Object.keys(source).forEach(function(key) {
+            //if this value looks like a date, convert it to a date object
+            if(RestClient.dateRegex.test(source[key])) {
+                source[key] = new Date(source[key]);
+            }
 
-            //Supplement underscore values with camel-case
+            //Supplement underscore_values with camelCase
             if (key.indexOf('_') > 0) {
                 var cc = key.replace(/_([a-z])/g, function (g) {
                     return g[1].toUpperCase()
@@ -80,17 +85,10 @@ function processKeys(source) {
 
             //process any nested arrays...
             if (Array.isArray(source[key])) {
-                source[key].forEach(processKeys);
+                source[key].forEach(RestClient.prototype.processKeys);
             }
             else if (_.isObject(source[key])) {
-                processKeys(source[key]);
-            }
-        });
-
-        //Look for and convert date strings for specific keys
-        ['startDate', 'endDate', 'dateCreated', 'dateUpdated', 'startTime', 'endTime', 'dateSent'].forEach(function(dateKey) {
-            if (source[dateKey]) {
-                source[dateKey] = new Date(source[dateKey]);
+                RestClient.prototype.processKeys(source[key]);
             }
         });
     }
@@ -171,7 +169,7 @@ RestClient.prototype.request = function (options, callback) {
 
         // Massage data payload if it exists
         if (data) {
-            processKeys(data);
+            RestClient.prototype.processKeys(data);
             Object.defineProperty(data, 'nodeClientResponse', {
                 value: response,
                 configurable: true,

--- a/test/restclient.js
+++ b/test/restclient.js
@@ -1,0 +1,84 @@
+var assert = require("assert");
+var twilio = require('../lib');
+
+describe('RestClient', function(){
+    var client = new twilio.RestClient('AC123', '123');
+
+    describe('#processKeys()', function(){
+        it('should convert underscored_keys to camelCase', function(){
+            var source = {
+                'foo_bar': 23,
+                'bar_foo': 32
+            };
+            client.processKeys(source);
+
+            assert.equal(23, source.foo_bar);
+            assert.equal(23, source.fooBar);
+            assert.equal(32, source.bar_foo);
+            assert.equal(32, source.barFoo);
+        });
+
+        it('should process nested arrays', function(){
+            var source = {
+                'foo': [
+                    {
+                        'foo_number': 23,
+                        'bar': [
+                            {
+                                'bar_number': 32
+                            }
+                        ]
+                    }
+                ]
+            };
+            client.processKeys(source);
+
+            assert.equal(23, source.foo[0].fooNumber);
+            assert.equal(32, source.foo[0].bar[0].barNumber);
+        });
+
+        var dateString = 'Wed, 21 Jan 2015 22:51:45 +0000';
+        var dateObject = new Date(dateString);
+
+        it('should parse and convert strings that look like dates', function(){
+            var source = {
+                'date': dateString,
+            };
+            client.processKeys(source);
+
+            assert.equal('[object Date]', Object.prototype.toString.call(source.date));
+            assert.equal(dateObject.getTime(), source.date.getTime());
+        });
+
+        it('should parse and convert dates with underscored_keys', function(){
+            var source = {
+                'date_sent': dateString,
+            };
+            client.processKeys(source);
+
+            assert.equal('[object Date]', Object.prototype.toString.call(source.date_sent));
+            assert.equal(dateObject.getTime(), source.date_sent.getTime());
+        });
+
+        it('should parse and convert dates with automaticallyCamelcasedKeys', function(){
+            var source = {
+                'date_sent': dateString,
+            };
+            client.processKeys(source);
+
+            assert.equal('[object Date]', Object.prototype.toString.call(source.dateSent));
+            assert.equal(dateObject.getTime(), source.dateSent.getTime());
+        });
+
+        it('should parse and convert dates with unexpected keys', function(){
+            // random unexpected key!
+            var key = ''+Math.random();
+            var source = {};
+            source[key] = dateString;
+            client.processKeys(source);
+
+            assert.equal('[object Date]', Object.prototype.toString.call(source[key]));
+            assert.equal(dateObject.getTime(), source[key].getTime());
+        });
+    });
+});


### PR DESCRIPTION
This will convert any string value that matches the regex `/^\w+,\s\d+\s\w+\s\d{4}\s\d{2}:\d{2}:\d{2}\s\+\d{4}$/` to a date with `new Date(value)`.

Note that this diverges from the current functionality by converting both the original `underscored_key` and the aliased `camelCasedKey` (the previous version only converted the later).

Also: I couldn't for the life of me create a failing test in the current test framework. I noted that there was an open issue to switch to mocha, so I wrote my tests in that instead. They can be run with `mocha` in the project directory.
