### PR TITLE
Added chainability to Capability methods for ease-of-use.

### DIFF
--- a/lib/Capability.js
+++ b/lib/Capability.js
@@ -3,6 +3,10 @@ var jwt = require('jwt-simple'),
     utils = require('./utils');
 
 function Capability(sid, tkn) {
+    if(!(this instanceof Capability)) {
+      return new Capability(sid, tkn);
+    }
+
     utils.initializeTokens(this, 'Capability', sid, tkn);
     this.capabilities = [];
 }
@@ -20,6 +24,8 @@ Capability.prototype.allowClientIncoming = function(clientName) {
     this.capabilities.push(scopeUriFor('client', 'incoming', {
         clientName:clientName
     }));
+
+    return this;
 };
 
 Capability.prototype.allowClientOutgoing = function(appSid, params) {
@@ -30,6 +36,8 @@ Capability.prototype.allowClientOutgoing = function(appSid, params) {
     if (params) {
         this.outgoingScopeParams.appParams = qs.stringify(params);
     }
+
+    return this;
 };
 
 Capability.prototype.allowEventStream = function(filters) {
@@ -42,6 +50,7 @@ Capability.prototype.allowEventStream = function(filters) {
     }
 
     this.capabilities.push(scopeUriFor('stream', 'subscribe', scopeParams));
+    return this;
 };
 
 Capability.prototype.generate = function(timeout) {

--- a/spec/capability.spec.js
+++ b/spec/capability.spec.js
@@ -1,7 +1,7 @@
 var twilio = require('../index');
 
 describe('The TwiML Capability Token Object', function () {
-
+  describe('constructor', function() {
     it('should allow for explicit construction of a capability token', function() {
         var c = new twilio.Capability('foo', 'bar');
         c.allowClientIncoming('armpit');
@@ -32,4 +32,30 @@ describe('The TwiML Capability Token Object', function () {
         process.env.TWILIO_ACCOUNT_SID = oldSid;
         process.env.TWILIO_AUTH_TOKEN = oldAuthToken;
     });
+
+    it('should return a new instance of itself if called as a function', function() {
+      expect(twilio.Capability('foo', 'bar') instanceof twilio.Capability).toBe(true);
+    });
+  });
+
+  describe('allowClientIncoming', function() {
+    it('should return the capability object for chainability', function() {
+      var c = new twilio.Capability('foo', 'bar');
+      expect(c.allowClientIncoming('armpit') instanceof twilio.Capability).toBe(true);
+    });
+  });
+
+  describe('allowClientOutgoing', function() {
+    it('should return the capability object for chainability', function() {
+      var c = new twilio.Capability('foo', 'bar');
+      expect(c.allowClientOutgoing('bellybutton') instanceof twilio.Capability).toBe(true);
+    });
+  });
+
+  describe('allowEventStream', function() {
+    it('should return the capability object for chainability', function() {
+      var c = new twilio.Capability('foo', 'bar');
+      expect(c.allowEventStream() instanceof twilio.Capability).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
The changes in this pull request would enable the following ease-of-use functionality:

```
var capToken = twilio.Capability(accountSid, authToken)
  .allowClientIncoming('alice')
  .allowClientOutgoing('app123')
  .generate();
```

This change is non-breaking.