### PR TITLE
updated dependencies - request 2.27.x -> 2.55.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/twilio/twilio-node.git"
   },
   "dependencies": {
-    "request": "2.27.x",
+    "request": "2.55.x",
     "underscore": "1.x",
     "jwt-simple": "0.1.x",
     "q": "0.9.7",


### PR DESCRIPTION
The dependency module request v2.27.x relies on tunnel-agent which does not fully support node 0.12.x.
Testing it with request v2.55.x, everything seems to work fine.