### PR TITLE
Add sub node TaskAttributes to Enqueue node

### DIFF
--- a/lib/TwimlResponse.js
+++ b/lib/TwimlResponse.js
@@ -32,6 +32,7 @@ function addTwimlFunction(node, twimlName) {
             case 'Gather': legalNodes = ['Say','Play','Pause']; break;
             case 'Dial': legalNodes = ['Number','Client','Conference','Queue','Sip']; break;
             case 'Message': legalNodes = ['Media', 'Body']; break;
+            case 'Enqueue': legalNodes = ['TaskAttributes']; break;
             default: break;
         }
 

--- a/spec/twiml.spec.js
+++ b/spec/twiml.spec.js
@@ -44,6 +44,23 @@ describe('The TwiML Response Object', function () {
         expect(xml).toBe(test);
     });
 
+    it('should support a flat document with enqueue nodes, with task attributes', function() {
+        var response = new twilio.TwimlResponse();
+        response.enqueue({workflowSid: '123456789'}, function(node) {
+            node.taskAttributes({selected_language: 'en'});
+        });
+        var xml = response.toString(),
+            test = [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<Response>',
+                '<Enqueue workflowSid="123456789"><TaskAttributes selected_language="en"></TaskAttributes></Enqueue>',
+                '</Response>'
+            ].join('');
+
+        expect(xml).toBe(test);
+    });
+
+
     it('should support chaining syntax with supported verbs', function() {
         var resp = new twilio.TwimlResponse();
 


### PR DESCRIPTION
Whilst doing the TaskRouter getting started tutorial (in node) I found that it was not possible to do the step requiring an Enqueue node in the response as the TaskAttributes was not recognised as a valid sub node of the Enqueue node. I therefore added it as a legal sub node in the TwimlRepsponse class.
