### PR TITLE
Fix flaky client tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "devDependencies": {
     "express": "3.x",
-    "jasmine-node": "^1.14.5"
+    "jasmine-node": "2.0.x"
   },
   "scripts": {
-    "test": "jasmine-node spec"
+    "test": "jasmine-node --captureExceptions spec"
   },
   "main": "./lib",
   "engines": {


### PR DESCRIPTION
1. Use local http server to verify client timeout.
2. Bump jasmine-node to version 2.0.x.