### PR TITLE
Fix flaky client tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "devDependencies": {
     "express": "3.x",
-    "jasmine-node": "^1.14.5"
+    "jasmine-node": "2.0.x"
   },
   "scripts": {
-    "test": "jasmine-node spec"
+    "test": "jasmine-node --captureExceptions spec"
   },
   "main": "./lib",
   "engines": {

--- a/spec/client.core.spec.js
+++ b/spec/client.core.spec.js
@@ -1,6 +1,6 @@
-var twilio = require('../index'),
-    request = require('request'),
-    moduleinfo = require('../package.json');;
+var twilio = require('../index');
+var http = require('http');
+var moduleinfo = require('../package.json');
 
 describe('The Twilio Rest Client', function () {
     describe('constructor', function () {
@@ -79,64 +79,76 @@ describe('The Twilio Rest Client', function () {
     });
 
     describe('request', function() {
-        // Use fake response server to simulate a slow response time
-        // See http://www.seanshadmand.com/2012/06/21/fake-response-server-slow-response-time-generator/
-        var fake_response_host = 'fake-response.appspot.com';
-
         var slowClient = new twilio.RestClient('AC123', '123', {
-            host: fake_response_host,
+            host: 'localhost:9999',
             timeout: 2000 // timeout after 2 seconds
         });
+        slowClient.getBaseUrl = function() {
+            return 'http://localhost:9999';
+        };
 
-        // The fake response url only works when we don't send auth tokens, account id, etc -- otherwise it 404's
-        slowClient.getBaseUrl = function () {
-            return 'http://' + fake_response_host;
+        var startServerWithoutTimeout = function(timeout, callback) {
+            var server = http.createServer(function(request, response) {
+                setTimeout(function() {
+                    response.end(JSON.stringify({
+                        response: 'This request has finished sleeping for '
+                            + timeout + ' seconds.'
+                    }));
+                }, timeout * 1000);
+            });
+            server.listen('9999', function() {
+                callback(server);
+            });
         };
 
         it('should allow for timeout configuration and handle responses faster than the timeout', function (done) {
-            spyOn(slowClient, 'request').andCallThrough();
+            startServerWithoutTimeout(1, function(server) {
+                spyOn(slowClient, 'request').and.callThrough();
 
-            slowClient.request({
-                url: '?sleep=1&', // sleep for 1 second
-                method: 'GET'
-            }, function (err, data, response) {
-                expect(data.response).toBe('This request has finished sleeping for 1 seconds.');
-                done();
+                var promise = slowClient.request({
+                    url: '/blah',
+                    method: 'GET'
+                }, function (err, data, response) {
+                    expect(data.response).toBe('This request has finished sleeping for 1 seconds.');
+                    server.close(done);
+                });
+
+                expect(slowClient.request).toHaveBeenCalledWith({
+                    url: 'http://localhost:9999/blah.json',
+                    method: 'GET',
+                    headers: {
+                        Accept: 'application/json',
+                        'Accept-Charset': 'utf-8',
+                        'User-Agent': 'twilio-node/' + moduleinfo.version
+                    },
+                    timeout: 2000
+                }, any(Function));
             });
-
-            expect(slowClient.request).toHaveBeenCalledWith({
-                url: 'http://fake-response.appspot.com?sleep=1&.json',
-                method: 'GET',
-                headers: {
-                    Accept: 'application/json',
-                    'Accept-Charset': 'utf-8',
-                    'User-Agent': 'twilio-node/' + moduleinfo.version
-                },
-                timeout: 2000
-            }, any(Function));
         });
 
         it('should allow for timeout configuration and handle responses slower than the timeout', function (done) {
-            spyOn(slowClient, 'request').andCallThrough();
+            startServerWithoutTimeout(3, function(server) {
+                spyOn(slowClient, 'request').and.callThrough();
 
-            slowClient.request({
-                url: '?sleep=3&', // sleep for 3 seconds
-                method: 'GET'
-            }, function (err, data, response) {
-                expect(err.status).toBe('ETIMEDOUT');
-                done();
+                slowClient.request({
+                    url: '/blah',
+                    method: 'GET'
+                }, function (err, data, response) {
+                    expect(err.status).toBe('ETIMEDOUT');
+                    server.close(done);
+                });
+
+                expect(slowClient.request).toHaveBeenCalledWith({
+                    url: 'http://localhost:9999/blah.json',
+                    method: 'GET',
+                    headers: {
+                        Accept: 'application/json',
+                        'Accept-Charset': 'utf-8',
+                        'User-Agent': 'twilio-node/' + moduleinfo.version
+                    },
+                    timeout: 2000
+                }, any(Function));
             });
-
-            expect(slowClient.request).toHaveBeenCalledWith({
-                url: 'http://fake-response.appspot.com?sleep=3&.json',
-                method: 'GET',
-                headers: {
-                    Accept: 'application/json',
-                    'Accept-Charset': 'utf-8',
-                    'User-Agent': 'twilio-node/' + moduleinfo.version
-                },
-                timeout: 2000
-            }, any(Function));
         });
     });
 });


### PR DESCRIPTION
1. Use local http server to verify client timeout.
2. Bump jasmine-node to version 2.0.x.