### PR TITLE
Added validation for client name

### DIFF
--- a/lib/Capability.js
+++ b/lib/Capability.js
@@ -20,6 +20,16 @@ function scopeUriFor(service, privilege, params) {
 }
 
 Capability.prototype.allowClientIncoming = function(clientName) {
+    // clientName must be a non-zero lenght alphanumeric string
+    if(clientName == null || clientName == '') {
+        throw 'Client name must not be a zero lenght string or null.';
+    }
+
+    var validator = new RegExp(/\W/);
+    if(validator.test(clientName) == true) {
+        throw 'Only alphanumeric characters allowed in client name.';
+    }
+
     this.clientName = clientName;
     this.capabilities.push(scopeUriFor('client', 'incoming', {
         clientName:clientName


### PR DESCRIPTION
A client name to generate a token for incoming connections should not contain non-alphanumeric characters, most twilio libs check the client name (for instance PHP, Java), the node version does not.