### PR TITLE
updating request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,18 +14,18 @@
     "url": "https://github.com/twilio/twilio-node.git"
   },
   "dependencies": {
-    "request": "2.55.x",
-    "underscore": "1.x",
+    "deprecate": "^0.1.0",
     "jsonwebtoken": "5.4.x",
     "jwt-simple": "0.1.x",
     "q": "0.9.7",
+    "request": "^2.69.0",
     "scmp": "0.0.3",
-    "deprecate": "^0.1.0",
-    "string.prototype.startswith": "^0.2.0"
+    "string.prototype.startswith": "^0.2.0",
+    "underscore": "1.x"
   },
   "devDependencies": {
     "express": "3.x",
-    "jasmine-node": "2.0.x"
+    "jasmine-node": "^2.0.0"
   },
   "scripts": {
     "test": "jasmine-node --captureExceptions spec"


### PR DESCRIPTION
If you run `nsp` against node-twilio there is a security vulnerability within the `hawk` dependency as part of `request`. Updating resolves this. See https://nodesecurity.io/advisories/77 for more info.

