### PR TITLE
Update request library to last minor

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/twilio/twilio-node.git"
   },
   "dependencies": {
-    "request": "2.55.x",
+    "request": "2.72.x",
     "underscore": "1.x",
     "jsonwebtoken": "5.4.x",
     "jwt-simple": "0.1.x",


### PR DESCRIPTION
There is a minor security bug on Hawk version
used by current request version. Updated to last
minor version for requests that hast an updated Hawk
version.

Bug https://nodesecurity.io/advisories/77