### PR TITLE
Use _.contains instead of _.includes

### DIFF
--- a/lib/AccessToken.js
+++ b/lib/AccessToken.js
@@ -142,7 +142,7 @@ _.extend(AccessToken.prototype, {
 
   toJwt: function(algorithm) {
     algorithm = algorithm || AccessToken.DEFAULT_ALGORITHM;
-    if (!_.includes(AccessToken.ALGORITHMS, algorithm)) {
+    if (!_.contains(AccessToken.ALGORITHMS, algorithm)) {
       throw new Error('Algorithm not supported. Allowed values are ' +
         AccessToken.ALGORITHMS.join(', '));
     }


### PR DESCRIPTION
The package.json for `twilio-node` specifies an `underscore` version of `1.x`. However, the `_.includes` function alias only appeared in `underscore@1.8.x`, so the library is broken for older underscore versions, even those these should be valid according to the package.json.

`_.contains` is a valid alias in all `1.x` versions and so is a better choice to offer the widest compatibility - this is important because underscore may often be included as a peer dependency.
