### PR TITLE
Remove the jwt-simple dependency.

### DIFF
--- a/lib/jwt/Capability.js
+++ b/lib/jwt/Capability.js
@@ -1,4 +1,4 @@
-var jwt = require('jwt-simple'),
+var jwt = require('jsonwebtoken'),
     qs = require('querystring');
 
 function scopeUriFor(service, privilege, params) {
@@ -89,7 +89,7 @@ Capability.prototype.generate = function(timeout) {
         exp: Math.floor(new Date() / 1000) + expires
     };
 
-    return jwt.encode(payload, this.authToken);
+    return jwt.sign(payload, this.authToken);
 };
 
 module.exports = Capability;

--- a/lib/jwt/TaskRouterCapability.js
+++ b/lib/jwt/TaskRouterCapability.js
@@ -1,4 +1,4 @@
-var jwt = require('jwt-simple');
+var jwt = require('jsonwebtoken');
 var _ = require('lodash');
 
 var taskRouterUrlBase = 'https://taskrouter.twilio.com';
@@ -145,7 +145,7 @@ TaskRouterCapability.prototype._generate = function(ttl, extraAttributes) {
         policies: this.policies,
     };
     _.extend(payload, extraAttributes);
-    return jwt.encode(payload, this.authToken);
+    return jwt.sign(payload, this.authToken);
 };
 
 module.exports = TaskRouterCapability;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "jsonwebtoken": "5.4.x",
-    "jwt-simple": "0.1.x",
     "lodash": "4.0.0",
     "moment": "2.14.1",
     "q": "2.0.x",

--- a/spec/unit/jwt/task_router_capability.spec.js
+++ b/spec/unit/jwt/task_router_capability.spec.js
@@ -1,5 +1,5 @@
 var twilio = require('../../../index'),
-    jwt = require('jwt-simple');
+    jwt = require('jsonwebtoken');
 
 describe('The TaskRouter Capability Token Object', function() {
 

--- a/spec/unit/jwt/task_router_capability_taskqueue.spec.js
+++ b/spec/unit/jwt/task_router_capability_taskqueue.spec.js
@@ -1,5 +1,5 @@
 var twilio = require('../../../index'),
-    jwt = require('jwt-simple');
+    jwt = require('jsonwebtoken');
 
 describe('The TaskRouter TaskQueue Capability Token Object', function() {
 

--- a/spec/unit/jwt/task_router_capability_worker.spec.js
+++ b/spec/unit/jwt/task_router_capability_worker.spec.js
@@ -1,5 +1,5 @@
 var twilio = require('../../../index'),
-    jwt = require('jwt-simple');
+    jwt = require('jsonwebtoken');
 
 describe('The TaskRouter Worker Capability Token Object', function() {
 

--- a/spec/unit/jwt/task_router_capability_workspace.spec.js
+++ b/spec/unit/jwt/task_router_capability_workspace.spec.js
@@ -1,5 +1,5 @@
 var twilio = require('../../../index'),
-    jwt = require('jwt-simple');
+    jwt = require('jsonwebtoken');
 
 describe('The TaskRouter Workspace Capability Token Object', function() {
 


### PR DESCRIPTION
We were using two JWT dependencies, jwt-simple and jsonwebtoken. Issue #205 points out a vulnerability in jwt-simple 0.1.0 which lay within the dependencies. Removing it completely in favour of jsonwebtoken was the easiest course of action.

We could probably do this for master and the current version of twilio-node too. Less dependencies and less vulnerabilities would be awesome.