### PR TITLE
(NextGen) Updates request to 2.79.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lodash": "4.0.0",
     "moment": "2.14.1",
     "q": "2.0.x",
-    "request": "2.74.x",
+    "request": "2.79.x",
     "rootpath": "0.1.2",
     "scmp": "0.0.3"
   },


### PR DESCRIPTION
Replaces dependency on deprecated node-uuid with uuid.

Fixes #209 