### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "type": "git",
     "url": "https://github.com/twilio/twilio-node.git"
   },
+  "files": [
+    "lib",
+    "index.js"
+  ],
   "dependencies": {
     "deprecate": "^0.1.0",
     "jsonwebtoken": "5.4.x",


### PR DESCRIPTION
When using [cost-of-modules](https://github.com/siddharthkp/cost-of-modules) to inspect my projects.
Found out Twilio is top of it:
│ name        │ children     │ size   │
├─────────────┼──────────────┼────────┤
│ twilio      │ 89           │ 42.45M │
Further investigate show docs directories taken 33.2mb
Can we exclude the doc directories to fasten up install process? Especially for production.