### PR TITLE
Support surrogate characters in xml builder, e.g. emoji’s

### DIFF
--- a/lib/twiml/MessagingResponse.js
+++ b/lib/twiml/MessagingResponse.js
@@ -8,7 +8,7 @@ var builder = require('xmlbuilder');
  * @constructor
  */
 function MessagingResponse() {
-  this.response = builder.create('Response').dec('1.0', 'UTF-8');
+  this.response = builder.create('Response', { allowSurrogateChars: true }).dec('1.0', 'UTF-8');
 }
 
 /**

--- a/spec/unit/twiml/MessagingResponse.spec.js
+++ b/spec/unit/twiml/MessagingResponse.spec.js
@@ -45,4 +45,13 @@ describe('create messaging response TwiML', function() {
     expect(actual.toString()).toEqual('<?xml version="1.0" encoding="UTF-8"?><Response><Redirect>https://twilio.com</Redirect></Response>');
   });
 
+  it('should allow surrogate chars in a message', function() {
+    var actual = new MessagingResponse();
+    actual.message({
+      to: '18885551234',
+      from: '18885554321'
+    }, '😀');
+    expect(actual.toString()).toEqual('<?xml version="1.0" encoding="UTF-8"?><Response><Message to="18885551234" from="18885554321">😀</Message></Response>');
+  });
+
 });


### PR DESCRIPTION
Attempting to send emoji characters from inside a twiml message e.g. `twiml.message('😀');` will fail in the xml builder code due to a validation check against surrogate characters.  In order to make these supported we can edit the `MessagingResponse.js` to create the builder with support for these characters.