### PR TITLE
chore(package): bump moment to 2.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "jsonwebtoken": "5.4.x",
     "lodash": "4.0.0",
-    "moment": "2.14.1",
+    "moment": "2.18.1",
     "q": "2.0.x",
     "request": "2.81.x",
     "rootpath": "0.1.2",


### PR DESCRIPTION
Currently, tools like Snyk report `twilio` as vulnerable via its `moment` dependency (https://snyk.io/test/npm/moment/2.14.1).