### PR TITLE
Adding sim method for Sim noun in Dial

### DIFF
--- a/lib/twiml/VoiceResponse.js
+++ b/lib/twiml/VoiceResponse.js
@@ -286,6 +286,14 @@ Dial.prototype.queue = function(attributes, queue) {
   this.dial.ele('Queue', attributes, queue);
 };
 
+/**
+ * TwiML wrapper for https://www.twilio.com/docs/api/twiml/sim
+ * @param {object} attributes
+ * @param {string} sim sid of sim
+ */
+Dial.prototype.sim = function(attributes, sim) {
+  this.dial.ele('Sim', attributes, sim);
+};
 
 /**
  * TwiML wrapper for https://www.twilio.com/docs/api/twiml/enqueue


### PR DESCRIPTION
Dial is missing this method currently, probably because it is in beta.