### PR TITLE
Bug: POST requests being sent with wrong Content-Type.

### DIFF
--- a/lib/rest/Twilio.js
+++ b/lib/rest/Twilio.js
@@ -156,10 +156,6 @@ Twilio.prototype.request = function request(opts) {
   headers['User-Agent'] = 'twilio-node/' + moduleInfo.version;
   headers['Accept-Charset'] = 'utf-8';
 
-  if (opts.method === 'POST' && !headers['Content-Type']) {
-    headers['Content-Type'] = 'application/x-www-form-urlencoded';
-  }
-
   if (!headers.Accept) {
     headers.Accept = 'application/json';
   }


### PR DESCRIPTION
POST requests are multipart, so setting it to `application/x-www-form-urlencoded` is wrong.

Request library takes care of setting the header to the right value.