### PR TITLE
Adds ChatGrant to jwt. Deprecates IpMessagingGrant.

### DIFF
--- a/lib/jwt/AccessToken.js
+++ b/lib/jwt/AccessToken.js
@@ -41,7 +41,7 @@ _.extend(TaskRouterGrant.prototype, {
  *                 assigned to the user
  * @param {string} options.pushCredentialSid - The Push Credentials SID
  */
-function IpMessagingGrant(options) {
+function ChatGrant(options) {
   options = options || {};
   this.serviceSid = options.serviceSid;
   this.endpointId = options.endpointId;
@@ -49,7 +49,7 @@ function IpMessagingGrant(options) {
   this.pushCredentialSid = options.pushCredentialSid;
 }
 
-_.extend(IpMessagingGrant.prototype, {
+_.extend(ChatGrant.prototype, {
   key: 'ip_messaging',
 
   toPayload: function() {
@@ -65,6 +65,25 @@ _.extend(IpMessagingGrant.prototype, {
     return grant;
   }
 });
+
+/**
+ * @constructor
+ * @param {object} options - ...
+ * @param {string} options.serviceSid - The service unique ID
+ * @param {string} options.endpointId - The endpoint ID
+ * @param {string} options.deploymentRoleSid - SID of the deployment role to be
+ *                 assigned to the user
+ * @param {string} options.pushCredentialSid - The Push Credentials SID
+ */
+function IpMessagingGrant(options) {
+  deprecate('IpMessagingGrant is deprecated, use ChatGrant instead.');
+  ChatGrant.call(this, options);
+}
+
+IpMessagingGrant.prototype = _.create(ChatGrant.prototype, _.assign({
+  '_super': ChatGrant.prototype,
+  'constructor': ChatGrant
+}));
 
 /**
   * @constructor
@@ -197,6 +216,7 @@ function AccessToken(accountSid, keySid, secret, options) {
 
 // Class level properties
 AccessToken.IpMessagingGrant = IpMessagingGrant;
+AccessToken.ChatGrant = ChatGrant;
 AccessToken.VoiceGrant = VoiceGrant;
 AccessToken.SyncGrant = SyncGrant;
 AccessToken.VideoGrant = VideoGrant;

--- a/lib/jwt/AccessToken.js
+++ b/lib/jwt/AccessToken.js
@@ -50,7 +50,7 @@ function ChatGrant(options) {
 }
 
 _.extend(ChatGrant.prototype, {
-  key: 'ip_messaging',
+  key: 'chat',
 
   toPayload: function() {
     var grant = {};
@@ -84,6 +84,8 @@ IpMessagingGrant.prototype = _.create(ChatGrant.prototype, _.assign({
   '_super': ChatGrant.prototype,
   'constructor': ChatGrant
 }));
+
+IpMessagingGrant.prototype.key = 'ip_messaging';
 
 /**
   * @constructor

--- a/spec/unit/jwt/AccessToken.spec.js
+++ b/spec/unit/jwt/AccessToken.spec.js
@@ -111,6 +111,29 @@ describe('AccessToken', function() {
       expect(decoded.exp - decoded.iat).toBe(100);
     });
 
+    it('should create token with chat grant', function() {
+      var token = new twilio.jwt.AccessToken(accountSid, keySid, 'secret');
+      token.identity = 'ID@example.com';
+
+      var grant = new twilio.jwt.AccessToken.ChatGrant();
+      grant.serviceSid = 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      grant.endpointId = 'endpointId';
+      grant.pushCredentialSid = 'CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      grant.deploymentRoleSid = 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      token.addGrant(grant);
+
+      var decoded = jwt.verify(token.toJwt(), 'secret');
+      expect(decoded.grants).toEqual({
+        identity: 'ID@example.com',
+        chat: {
+          service_sid: 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          deployment_role_sid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          endpoint_id: 'endpointId',
+          push_credential_sid: 'CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        }
+      });
+    });
+
     it('should create token with ip messaging grant', function() {
       var token = new twilio.jwt.AccessToken(accountSid, keySid, 'secret');
       token.identity = 'ID@example.com';
@@ -212,7 +235,7 @@ describe('AccessToken', function() {
       var token = new twilio.jwt.AccessToken(accountSid, keySid, 'secret');
       token.identity = 'ID@example.com';
 
-      var grant = new twilio.jwt.AccessToken.IpMessagingGrant();
+      var grant = new twilio.jwt.AccessToken.ChatGrant();
       grant.serviceSid = 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
       grant.endpointId = 'endpointId';
       grant.pushCredentialSid = 'CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -237,7 +260,7 @@ describe('AccessToken', function() {
       var decoded = jwt.verify(token.toJwt(), 'secret');
       expect(decoded.grants).toEqual({
         identity: 'ID@example.com',
-        ip_messaging: {
+        chat: {
           service_sid: 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           deployment_role_sid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           endpoint_id: 'endpointId',

--- a/spec/unit/jwt/AccessToken.spec.js
+++ b/spec/unit/jwt/AccessToken.spec.js
@@ -1,5 +1,8 @@
 var twilio = require('../../../index');
 var jwt = require('jsonwebtoken');
+var deprecate = require('deprecate');
+
+deprecate.silence = true;
 
 describe('AccessToken', function() {
   var accountSid = 'ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -257,8 +260,81 @@ describe('AccessToken', function() {
 
     describe('IpMessagingGrant', function() {
       describe('toPayload', function() {
+        it('should set properties in the constructor', function() {
+          var grant = new twilio.jwt.AccessToken.IpMessagingGrant({
+            deploymentRoleSid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            serviceSid: 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            endpointId: 'endpointId',
+            pushCredentialSid: 'CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          });
+          expect(grant.toPayload()).toEqual({
+            service_sid: 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            deployment_role_sid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            endpoint_id: 'endpointId',
+            push_credential_sid: 'CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          });
+        });
+
         it('should only populate set properties', function() {
           var grant = new twilio.jwt.AccessToken.IpMessagingGrant();
+          expect(grant.toPayload()).toEqual({});
+
+          grant.deploymentRoleSid = 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+          expect(grant.toPayload()).toEqual({
+            deployment_role_sid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          });
+
+          grant.serviceSid = 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+          expect(grant.toPayload()).toEqual({
+            service_sid: 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            deployment_role_sid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          });
+
+          grant.endpointId = 'endpointId';
+          expect(grant.toPayload()).toEqual({
+            service_sid: 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            deployment_role_sid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            endpoint_id: 'endpointId'
+          });
+
+          grant.endpointId = undefined;
+          grant.pushCredentialSid = 'CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+          expect(grant.toPayload()).toEqual({
+            service_sid: 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            deployment_role_sid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            push_credential_sid: 'CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          });
+
+          grant.endpointId = 'endpointId';
+          expect(grant.toPayload()).toEqual({
+            service_sid: 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            deployment_role_sid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            endpoint_id: 'endpointId',
+            push_credential_sid: 'CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          });
+        });
+      });
+    });
+
+    describe('ChatGrant', function() {
+      describe('toPayload', function() {
+        it('should set properties in the constructor', function() {
+          var grant = new twilio.jwt.AccessToken.ChatGrant({
+            deploymentRoleSid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            serviceSid: 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            endpointId: 'endpointId',
+            pushCredentialSid: 'CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          });
+          expect(grant.toPayload()).toEqual({
+            service_sid: 'SRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            deployment_role_sid: 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            endpoint_id: 'endpointId',
+            push_credential_sid: 'CRaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+          });
+        });
+
+        it('should only populate set properties', function() {
+          var grant = new twilio.jwt.AccessToken.ChatGrant();
           expect(grant.toPayload()).toEqual({});
 
           grant.deploymentRoleSid = 'RLaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';


### PR DESCRIPTION
As the name IpMessaging has been deprecated, this changes the grant to the name `ChatGrant`. It is the same as the existing `IpMessagingGrant` so is just a straight name swap for developers.

`IpMessagingGrant` will continue to work and now inherits from `ChatGrant`. It will spit out a deprecation notice though.

I also silenced deprecations in test output as part of this. 