### PR TITLE
Node Security Project - Add nsp check script to warn for dependency vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ node_js:
     - "5"
     - "4"
     - "0.12"
+script: npm run ci
 notifications:
   slack:
     on_success: change

--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
   "devDependencies": {
     "express": "3.x",
     "jasmine-node": "1.14.5",
-    "jshint": "2.8.x",
     "jscs": "3.0.7",
     "jsdoc": "3.4.x",
+    "jshint": "2.8.x",
+    "nsp": "2.8.0",
     "proxyquire": "1.8.0"
   },
   "scripts": {
@@ -43,7 +44,9 @@
     "jshint": "jshint lib/rest/** lib/base/** lib/http/**",
     "jscs": "jscs -c .jscsrc lib/base/** lib/http/** --fix",
     "check": "npm run jshint; npm run jscs",
-    "jsdoc": "jsdoc -r lib -d docs"
+    "ci": "npm test; npm run nsp",
+    "jsdoc": "jsdoc -r lib -d docs",
+    "nsp": "nsp check"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Why?
To verify that there are not known security vulnerabilities in our dependencies so we can actively address them when found.

Changes:
- add nsp as dev dependency (jshint was moved to be alphabetical by npm
cli)
- add nsp script to package.json
- add nsp to the make test command