### PR TITLE
deps: bump request version to 2.83.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "4.0.0",
     "moment": "2.18.1",
     "q": "2.0.x",
-    "request": "2.81.x",
+    "request": "2.83.x",
     "rootpath": "0.1.2",
     "scmp": "0.0.3",
     "xmlbuilder": "9.0.1",


### PR DESCRIPTION
Updates the request version to 2.83.x to get rid of the uuid deprecation
warning on install.  Request was updated almost a year ago to use a new
uuid module.  Since twilio depends on an older version of request, the
installation continues to emit a deprecation warning.  This commit fixes
the deprecation warning on install.

[It looks like there were no breaking changes](https://github.com/request/request/compare/v2.81.1...master) to request in this upgrade.