### PR TITLE
Add 'forever' as an option to RequestClient request method.

### DIFF
--- a/lib/base/RequestClient.js
+++ b/lib/base/RequestClient.js
@@ -20,6 +20,7 @@ var RequestClient = function() {};
  * @param {object} [opts.data] - The request data
  * @param {int} [opts.timeout=30000] - The request timeout in milliseconds
  * @param {boolean} [opts.allowRedirects] - Should the client follow redirects
+ * @param {boolean} [opts.forever] - Set to true to use the forever-agent
  */
 RequestClient.prototype.request = function(opts) {
   opts = opts || {};
@@ -44,7 +45,7 @@ RequestClient.prototype.request = function(opts) {
     url: opts.uri,
     method: opts.method,
     headers: opts.headers,
-    forever: true,
+    forever: opts.forever === false ? false : true,
   };
 
   if (!_.isNull(opts.data)) {


### PR DESCRIPTION
Hey guys.

Is it possible to add this flag 'forever' as an option in your RequestClient class request method? In that case it will be possible to inherit your class and override this option.

Reason: forever: true doesn't work correctly with AWS lambda functions and we need a way how to override this option without rewriting HttpClient from scratch. Execution of your library methods will return a socket hang up exception from time to time in AWS lambdas, because of the lambdas life cycle. 