### PR TITLE
Add ability to mock twillio

### DIFF
--- a/lib/rest/Api.js
+++ b/lib/rest/Api.js
@@ -67,7 +67,7 @@ var V2010 = require('./api/V2010');  /* jshint ignore:line */
  */
 /* jshint ignore:end */
 function Api(twilio) {
-  Domain.prototype.constructor.call(this, twilio, 'https://api.twilio.com');
+  Domain.prototype.constructor.call(this, twilio, twillio.baseUrl);
 
   // Versions
   this._v2010 = undefined;

--- a/lib/rest/Twilio.js
+++ b/lib/rest/Twilio.js
@@ -121,6 +121,7 @@ function Twilio(username, password, opts) {
   this.username = username || env.TWILIO_ACCOUNT_SID;
   this.password = password || env.TWILIO_AUTH_TOKEN;
   this.accountSid = opts.accountSid || this.username;
+  this.baseUrl = opts.baseUrl || 'https://api.twilio.com';
   this.httpClient = opts.httpClient || new RequestClient();
   this.region = opts.region;
 


### PR DESCRIPTION
As a QA, I want to be able, to change twillio url to forward requests to mock server to test different responses from twillio. This change will give access to set twillio base url to mock server