### PR TITLE
Add incoming.allow to AccessToken VoiceGrant

### DIFF
--- a/lib/jwt/AccessToken.js
+++ b/lib/jwt/AccessToken.js
@@ -154,6 +154,7 @@ _.extend(SyncGrant.prototype, {
 /**
  * @constructor
  * @param {object} options - ...
+ * @param {boolean} options.incomingAllow - Whether or not this endpoint is allowed to receive incoming calls as grants.identity
  * @param {string} options.outgoingApplicationSid - application sid to call when placing outgoing call
  * @param {object} options.outgoingApplicationParams - request params to pass to the application
  * @param {string} options.pushCredentialSid - Push Credential Sid to use when registering to receive incoming call notifications
@@ -162,6 +163,7 @@ _.extend(SyncGrant.prototype, {
  */
 function VoiceGrant(options) {
   options = options || {};
+  this.incomingAllow = options.incomingAllow;
   this.outgoingApplicationSid = options.outgoingApplicationSid;
   this.outgoingApplicationParams = options.outgoingApplicationParams;
   this.pushCredentialSid = options.pushCredentialSid;
@@ -172,6 +174,10 @@ _.extend(VoiceGrant.prototype, {
   key: 'voice',
   toPayload: function() {
     var grant = {};
+    if (this.incomingAllow === true) {
+      grant.incoming = { allow: true };
+    }
+
     if (this.outgoingApplicationSid) {
       grant.outgoing = {};
       grant.outgoing.application_sid = this.outgoingApplicationSid;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio",
-  "version": "3.11.3",
+  "version": "3.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/unit/jwt/AccessToken.spec.js
+++ b/spec/unit/jwt/AccessToken.spec.js
@@ -417,6 +417,16 @@ describe('AccessToken', function() {
           endpoint_id: 'id'
         });
       });
+
+      it('should set incoming.allow if incomingAllow === true', function() {
+        var grant = new twilio.jwt.AccessToken.VoiceGrant({ incomingAllow: true });
+        expect(grant.toPayload()).toEqual({ incoming: { allow: true } });
+      });
+
+      it('should not set incoming.allow if incomingAllow !== true', function() {
+        var grant = new twilio.jwt.AccessToken.VoiceGrant({ incomingAllow: 'foo' });
+        expect(grant.toPayload()).toEqual({ });
+      });
     });
 
     describe('VideoGrant', function() {


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/CLIENT-4492

To support JS Clients per this spec:
https://paper.dropbox.com/doc/Proposal-FPA-Token-Format-for-Programmable-Voice-SDKs-xhdFHD6N3aPW9GRp4dXNX