### PR TITLE
use _.isDate to check if object is a Date object

### DIFF
--- a/lib/base/serialize.js
+++ b/lib/base/serialize.js
@@ -19,7 +19,7 @@ module.exports = {};
  * @return {string|object} date formatted in YYYY-MM-DD form
  */
 module.exports.iso8601Date = function(d) {
-  if (_.isUndefined(d) || _.isString(d) || !((d instanceof Date))) {
+  if (_.isUndefined(d) || _.isString(d) || !(_.isDate(d))) {
     return d;
   } else {
     return moment.utc(d).format('YYYY-MM-DD');


### PR DESCRIPTION
When running the snippet below, in some node versions the code fails because twilio-node is unable to format the given `startDate` and `endDate` parameters.
```javascript
// Download the helper library from https://www.twilio.com/docs/node/install
// Your Account Sid and Auth Token from twilio.com/console
const accountSid = 'ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
const authToken = 'your_auth_token';
const client = require('twilio')(accountSid, authToken);

client.calls.feedbackSummaries
            .create({
               startDate: new Date(Date.UTC(2008, 0, 2)),
               endDate: new Date(Date.UTC(2008, 0, 2))
             })
            .then(feedback_summary => console.log(feedback_summary.sid))
            .done();

```
I've narrowed down the issue to the following line:
https://github.com/twilio/twilio-node/blob/master/lib/base/serialize.js#L22
This PR attempts to fix this issue.