### PR TITLE
Upgrade lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio",
-  "version": "3.14.0",
+  "version": "3.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1443,9 +1443,9 @@
       }
     },
     "lodash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.0.0.tgz",
-      "integrity": "sha1-msQ4RMWV4o0wEIt7pYNwM5WSLfw="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "jsonwebtoken": "^8.1.0",
-    "lodash": "4.0.0",
+    "lodash": "^4.17.10",
     "moment": "2.19.3",
     "q": "2.0.x",
     "request": "2.83.x",


### PR DESCRIPTION
Upgrading lodash to resolve https://snyk.io/vuln/npm:lodash:20180130

CVE-2018-3721 
Disclosed: 30 Jan, 2018
Published: 14 Feb, 2018

(The twilio version in package-lock was out of date and `npm install` auto updated it to the current twilio-node version in package.json: 3.15.1)