### PR TITLE
Add validateSslCertificate to node client

### DIFF
--- a/lib/rest/Twilio.js
+++ b/lib/rest/Twilio.js
@@ -231,7 +231,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._accounts = this._accounts || new Accounts(this);
     return this._accounts;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -239,7 +239,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._api = this._api || new Api(this);
     return this._api;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -247,7 +247,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._chat = this._chat || new Chat(this);
     return this._chat;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -255,7 +255,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._fax = this._fax || new Fax(this);
     return this._fax;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -263,7 +263,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._ipMessaging = this._ipMessaging || new IpMessaging(this);
     return this._ipMessaging;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -271,7 +271,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._lookups = this._lookups || new Lookups(this);
     return this._lookups;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -279,7 +279,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._monitor = this._monitor || new Monitor(this);
     return this._monitor;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -287,7 +287,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._notify = this._notify || new Notify(this);
     return this._notify;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -295,7 +295,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._preview = this._preview || new Preview(this);
     return this._preview;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -303,7 +303,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._pricing = this._pricing || new Pricing(this);
     return this._pricing;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -311,7 +311,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._proxy = this._proxy || new Proxy(this);
     return this._proxy;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -319,7 +319,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._taskrouter = this._taskrouter || new Taskrouter(this);
     return this._taskrouter;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -327,7 +327,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._trunking = this._trunking || new Trunking(this);
     return this._trunking;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -335,7 +335,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._video = this._video || new Video(this);
     return this._video;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -343,7 +343,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._messaging = this._messaging || new Messaging(this);
     return this._messaging;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -351,7 +351,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._wireless = this._wireless || new Wireless(this);
     return this._wireless;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -359,7 +359,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._sync = this._sync || new Sync(this);
     return this._sync;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -367,168 +367,186 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._studio = this._studio || new Studio(this);
     return this._studio;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'addresses', {
   get: function() {
     return this.api.account.addresses;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'applications', {
   get: function() {
     return this.api.account.applications;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'authorizedConnectApps', {
   get: function() {
     return this.api.account.authorizedConnectApps;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'availablePhoneNumbers', {
   get: function() {
     return this.api.account.availablePhoneNumbers;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'calls', {
   get: function() {
     return this.api.account.calls;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'conferences', {
   get: function() {
     return this.api.account.conferences;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'connectApps', {
   get: function() {
     return this.api.account.connectApps;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'incomingPhoneNumbers', {
   get: function() {
     return this.api.account.incomingPhoneNumbers;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'keys', {
   get: function() {
     return this.api.account.keys;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'messages', {
   get: function() {
     return this.api.account.messages;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'newKeys', {
   get: function() {
     return this.api.account.newKeys;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'newSigningKeys', {
   get: function() {
     return this.api.account.newSigningKeys;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'notifications', {
   get: function() {
     return this.api.account.notifications;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'outgoingCallerIds', {
   get: function() {
     return this.api.account.outgoingCallerIds;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'queues', {
   get: function() {
     return this.api.account.queues;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'recordings', {
   get: function() {
     return this.api.account.recordings;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'signingKeys', {
   get: function() {
     return this.api.account.signingKeys;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'sip', {
   get: function() {
     return this.api.account.sip;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'shortCodes', {
   get: function() {
     return this.api.account.shortCodes;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'tokens', {
   get: function() {
     return this.api.account.tokens;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'transcriptions', {
   get: function() {
     return this.api.account.transcriptions;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'usage', {
   get: function() {
     return this.api.account.usage;
-  }
+  },
 });
 
 Object.defineProperty(Twilio.prototype,
   'validationRequests', {
   get: function() {
     return this.api.account.validationRequests;
-  }
+  },
 });
 
+Twilio.prototype.validateSslCert = function validateSslCert() {
+      let client = new RequestClient();
+      let request = client.request({
+            method: 'GET',
+            uri: 'https://api.twilio.com:8443/2010-04-01/.json', // Making the request a bit odd to match the request from v2 lib
+          });
+      request = request.then(response => {
+            if (response.statusCode < 200 || response.statusCode >= 300) {
+              throw new RestException(response);
+            }
+
+            return null;
+          });
+      return request;
+
+    };
+
 module.exports = Twilio;
+

--- a/lib/rest/Twilio.js
+++ b/lib/rest/Twilio.js
@@ -233,19 +233,16 @@ Twilio.prototype.request = function request(opts) {
  */
 /* jshint ignore:end */
 Twilio.prototype.validateSslCert = function validateSslCert() {
-  let client = new RequestClient();
-  let request = client.request({
-        method: 'GET',
-        uri: 'https://api.twilio.com:8443/2010-04-01/.json',
-      });
-  request = request.then(response => {
-        if (response.statusCode < 200 || response.statusCode >= 300) {
-          throw new RestException(response);
-        }
+  return this.httpClient.request({
+       method: 'GET',
+       uri: 'https://api.twilio.com:8443/2010-04-01/.json',
+   }).then((response) => {
+     if (response.statusCode < 200 || response.statusCode >= 300) {
+       throw RestException(response);
+     }
 
-        return null;
-      });
-  return request;
+     return response;
+  });
 };
 
 Object.defineProperty(Twilio.prototype,

--- a/lib/rest/Twilio.js
+++ b/lib/rest/Twilio.js
@@ -226,12 +226,34 @@ Twilio.prototype.request = function request(opts) {
   });
 };
 
+/* jshint ignore:start */
+/**
+ * Validate that a request to the new SSL certificate is successful.
+ * @throws {RestException} if the request fails
+ */
+/* jshint ignore:end */
+Twilio.prototype.validateSslCert = function validateSslCert() {
+  let client = new RequestClient();
+  let request = client.request({
+        method: 'GET',
+        uri: 'https://api.twilio.com:8443/2010-04-01/.json',
+      });
+  request = request.then(response => {
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          throw new RestException(response);
+        }
+
+        return null;
+      });
+  return request;
+};
+
 Object.defineProperty(Twilio.prototype,
   'accounts', {
   get: function() {
     this._accounts = this._accounts || new Accounts(this);
     return this._accounts;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -239,7 +261,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._api = this._api || new Api(this);
     return this._api;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -247,7 +269,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._chat = this._chat || new Chat(this);
     return this._chat;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -255,7 +277,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._fax = this._fax || new Fax(this);
     return this._fax;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -263,7 +285,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._ipMessaging = this._ipMessaging || new IpMessaging(this);
     return this._ipMessaging;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -271,7 +293,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._lookups = this._lookups || new Lookups(this);
     return this._lookups;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -279,7 +301,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._monitor = this._monitor || new Monitor(this);
     return this._monitor;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -287,7 +309,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._notify = this._notify || new Notify(this);
     return this._notify;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -295,7 +317,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._preview = this._preview || new Preview(this);
     return this._preview;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -303,7 +325,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._pricing = this._pricing || new Pricing(this);
     return this._pricing;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -311,7 +333,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._proxy = this._proxy || new Proxy(this);
     return this._proxy;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -319,7 +341,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._taskrouter = this._taskrouter || new Taskrouter(this);
     return this._taskrouter;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -327,7 +349,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._trunking = this._trunking || new Trunking(this);
     return this._trunking;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -335,7 +357,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._video = this._video || new Video(this);
     return this._video;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -343,7 +365,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._messaging = this._messaging || new Messaging(this);
     return this._messaging;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -351,7 +373,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._wireless = this._wireless || new Wireless(this);
     return this._wireless;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -359,7 +381,7 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._sync = this._sync || new Sync(this);
     return this._sync;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
@@ -367,186 +389,168 @@ Object.defineProperty(Twilio.prototype,
   get: function() {
     this._studio = this._studio || new Studio(this);
     return this._studio;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'addresses', {
   get: function() {
     return this.api.account.addresses;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'applications', {
   get: function() {
     return this.api.account.applications;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'authorizedConnectApps', {
   get: function() {
     return this.api.account.authorizedConnectApps;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'availablePhoneNumbers', {
   get: function() {
     return this.api.account.availablePhoneNumbers;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'calls', {
   get: function() {
     return this.api.account.calls;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'conferences', {
   get: function() {
     return this.api.account.conferences;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'connectApps', {
   get: function() {
     return this.api.account.connectApps;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'incomingPhoneNumbers', {
   get: function() {
     return this.api.account.incomingPhoneNumbers;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'keys', {
   get: function() {
     return this.api.account.keys;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'messages', {
   get: function() {
     return this.api.account.messages;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'newKeys', {
   get: function() {
     return this.api.account.newKeys;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'newSigningKeys', {
   get: function() {
     return this.api.account.newSigningKeys;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'notifications', {
   get: function() {
     return this.api.account.notifications;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'outgoingCallerIds', {
   get: function() {
     return this.api.account.outgoingCallerIds;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'queues', {
   get: function() {
     return this.api.account.queues;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'recordings', {
   get: function() {
     return this.api.account.recordings;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'signingKeys', {
   get: function() {
     return this.api.account.signingKeys;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'sip', {
   get: function() {
     return this.api.account.sip;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'shortCodes', {
   get: function() {
     return this.api.account.shortCodes;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'tokens', {
   get: function() {
     return this.api.account.tokens;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'transcriptions', {
   get: function() {
     return this.api.account.transcriptions;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'usage', {
   get: function() {
     return this.api.account.usage;
-  },
+  }
 });
 
 Object.defineProperty(Twilio.prototype,
   'validationRequests', {
   get: function() {
     return this.api.account.validationRequests;
-  },
+  }
 });
 
-Twilio.prototype.validateSslCert = function validateSslCert() {
-      let client = new RequestClient();
-      let request = client.request({
-            method: 'GET',
-            uri: 'https://api.twilio.com:8443/2010-04-01/.json', // Making the request a bit odd to match the request from v2 lib
-          });
-      request = request.then(response => {
-            if (response.statusCode < 200 || response.statusCode >= 300) {
-              throw new RestException(response);
-            }
-
-            return null;
-          });
-      return request;
-
-    };
-
 module.exports = Twilio;
-

--- a/spec/integration/rest/Twilio.spec.js
+++ b/spec/integration/rest/Twilio.spec.js
@@ -19,21 +19,26 @@ describe('validateSslCert', function() {
           });
       });
 
-    it('Should successfully validate a working SSL certificate', function(done) {
+    it('Should successfully validate a working SSL certificate', function() {
         holodeck.mock(new Response(200, ''));
-        client.validateSslCert().then(function(result) {
-            expect(result).toBe(null);
+
+        let resp = client.validateSslCert();
+
+        resp.finally(() => {
+            expect(resp.isFulfilled()).toBe(true);
             done();
-          });
-      });
+
+        });
+    });
 
     it('should fail to validate a broken SSL certificate', function(done) {
         holodeck.mock(new Response(504, ''));
-        let resp = client.validateSslCert().then(function(resp) {
+
+        let resp = client.validateSslCert();
+
+        resp.finally(() => {
+            expect(resp.isRejected()).toBe(true);
             done();
-            expect(resp).toThrow(RestException);
-
-          });
-      });
-
+        });
+    });
   });

--- a/spec/integration/rest/Twilio.spec.js
+++ b/spec/integration/rest/Twilio.spec.js
@@ -1,0 +1,39 @@
+'use strict';
+var proxyquire = require('proxyquire');
+var _ = require('lodash');  /* jshint ignore:line */
+var Holodeck = require('../holodeck');  /* jshint ignore:line */
+var Response = require(
+    '../../../lib/http/response');  /* jshint ignore:line */
+var RestException = require(
+    '../../../lib/base/RestException');  /* jshint ignore:line */
+var Twilio = require('../../../lib');  /* jshint ignore:line */
+
+var client;
+var holodeck;
+
+describe('validateSslCert', function() {
+    beforeEach(function() {
+        holodeck = new Holodeck();
+        client = new Twilio('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'AUTHTOKEN', {
+            httpClient: holodeck,
+          });
+      });
+
+    it('Should successfully validate a working SSL certificate', function(done) {
+        holodeck.mock(new Response(200, ''));
+        client.validateSslCert().then(function(result) {
+            expect(result).toBe(null);
+            done();
+          });
+      });
+
+    it('should fail to validate a broken SSL certificate', function(done) {
+        holodeck.mock(new Response(504, ''));
+        let resp = client.validateSslCert().then(function(resp) {
+            done();
+            expect(resp).toThrow(RestException);
+
+          });
+      });
+
+  });


### PR DESCRIPTION
Add validateSslCertificate to check whether we can successfully make requests to the endpoint that uses the new SSL certificate.
