### PR TITLE
Add a request body validator

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,7 @@ initializer.TrunkingClient = obsolete.TrunkingClient;
 
 // Setup webhook helper functionality
 initializer.validateRequest = webhooks.validateRequest;
+initializer.validateRequestWithBody = webhooks.validateRequestWithBody;
 initializer.validateExpressRequest = webhooks.validateExpressRequest;
 initializer.webhook = webhooks.webhook;
 

--- a/lib/webhooks/webhooks.js
+++ b/lib/webhooks/webhooks.js
@@ -18,7 +18,35 @@ function validateRequest(authToken, twilioHeader, url, params) {
       url = url + key + params[key];
   });
 
-  return scmp(twilioHeader, crypto.createHmac('sha1', authToken).update(new Buffer(url, 'utf-8')).digest('Base64'));
+  var signature = crypto
+    .createHmac('sha1', authToken)
+    .update(Buffer.from(url, 'utf-8'))
+    .digest('base64');
+
+  return scmp(twilioHeader, signature);
+}
+
+/**
+ Utility function to validate an incoming request is indeed from Twilio. This also validates
+ the request body against the bodySHA256 post parameter.
+
+ @param {string} authToken - The auth token, as seen in the Twilio portal
+ @param {string} twilioHeader - The value of the X-Twilio-Signature header from the request
+ @param {string} requestUrl - The full URL (with query string) you configured to handle this request
+ @param {string} body - The body of the request
+ */
+function validateRequestWithBody(authToken, twilioHeader, requestUrl, body) {
+  var urlObject = new url.URL(requestUrl);
+  return validateRequest(authToken, twilioHeader, requestUrl, {}) && validateBody(body, urlObject.searchParams.get('bodySHA256'));
+}
+
+function validateBody(body, expectedValue) {
+  var hash = crypto
+    .createHash('sha256')
+    .update(Buffer.from(body, 'utf-8'))
+    .digest('base64');
+
+  return scmp(expectedValue, hash);
 }
 
 /**
@@ -52,14 +80,24 @@ function validateExpressRequest(request, authToken, opts) {
     if (request.originalUrl.search(/\?/) >= 0) {
       webhookUrl = webhookUrl.replace("%3F","?");
     }
+
   }
 
-  return validateRequest(
-    authToken,
-    request.header('X-Twilio-Signature'),
-    webhookUrl,
-    request.body || {}
-  );
+  if (webhookUrl.indexOf('bodySHA256') > 0) {
+    return validateRequestWithBody(
+      authToken,
+      request.header('X-Twilio-Signature'),
+      webhookUrl,
+      request.body || {}
+    );
+  } else {
+    return validateRequest(
+      authToken,
+      request.header('X-Twilio-Signature'),
+      webhookUrl,
+      request.body || {}
+    );
+  }
 }
 
 /**
@@ -74,8 +112,6 @@ Options:
     Twilio, we will return a text body and a 403.  If there is no configured
     auth token and validate=true, this is an error condition, so we will return
     a 500.
-- includeHelpers: {Boolean} add helpers to the response object to improve support
-    for XML (TwiML) rendering.  Default true.
 - host: manually specify the host name used by Twilio in a number's webhook config
 - protocol: manually specify the protocol used by Twilio in a number's webhook config
 
@@ -95,7 +131,6 @@ var webhookMiddleware = twilio.webhook({
 function webhook() {
   var opts = {
     validate: true,
-    includeHelpers: true
   };
 
   // Process arguments
@@ -114,23 +149,6 @@ function webhook() {
 
   // Create middleware function
   return function hook(request, response, next) {
-    // Add helpers, unless disabled
-    if (opts.includeHelpers) {
-      var oldSend = response.send;
-      response.send = function() {
-        // This is a special TwiML-aware version of send.  If we detect
-        // A twiml response object, we'll set the content-type and
-        // automatically call .toString()
-        if (arguments.length === 1 && arguments[0].legalNodes) {
-          response.type('text/xml');
-          oldSend.call(response, arguments[0].toString());
-        } else {
-          // Continue with old version of send
-          oldSend.apply(response, arguments);
-        }
-      };
-    }
-
     // Do validation if requested
     if (opts.validate) {
       // Check for a valid auth token
@@ -163,7 +181,9 @@ function webhook() {
 }
 
 module.exports = {
-  validateRequest: validateRequest,
-  validateExpressRequest: validateExpressRequest,
-  webhook: webhook
+  validateRequest,
+  validateRequestWithBody,
+  validateExpressRequest,
+  validateBody,
+  webhook,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio",
-  "version": "3.17.2",
+  "version": "3.17.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1828,6 +1828,38 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
+    },
+    "net": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
+      "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g=",
+      "dev": true
+    },
+    "node-mocks-http": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.7.0.tgz",
+      "integrity": "sha512-AX1jGG87itK38N9UZif1CFYjJDibCOj07d0YGpUsxzglVWJjyJ3R7fxtuK7l6RVCKZteLiQyaTo9UR8rIEESgw==",
+      "dev": true,
+      "requires": {
+        "accepts": "^1.3.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "net": "^1.0.2",
+        "parseurl": "^1.3.1",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.14"
+      },
+      "dependencies": {
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+          "dev": true
+        }
+      }
     },
     "nodesecurity-npm-utils": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "jscs": "3.0.7",
     "jsdoc": "3.5.5",
     "jshint": "^2.8.0",
+    "node-mocks-http": "^1.7.0",
     "nsp": "^3.2.1",
     "proxyquire": "1.8.0"
   },

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -93,9 +93,7 @@ describe('Request validation middleware', () => {
     });
 
     it('should validate standard requests', done => {
-        const request = httpMocks.createRequest({
-            ...defaultRequest,
-        });
+        const request = httpMocks.createRequest(defaultRequest);
 
         middleware(request, response, error => {
             // This test will only pass if the middleware calls next().
@@ -107,10 +105,9 @@ describe('Request validation middleware', () => {
 
     it('should send 403 for invalid signatures', () => {
         const newUrl = fullUrl.pathname + fullUrl.search + '&somethingUnexpected=true';
-        const request = httpMocks.createRequest({
-            ...defaultRequest,
+        const request = httpMocks.createRequest(Object.assign({}, defaultRequest, {
             originalUrl: newUrl,
-        });
+        }));
 
         middleware(request, response, error => {
             expect(true).toBeFalsy();
@@ -134,15 +131,13 @@ describe('Request validation middleware', () => {
     });
 
     it('should accept manual host+proto', done => {
-        const request = httpMocks.createRequest({
-            ...defaultRequest,
+        const request = httpMocks.createRequest(Object.assign({}, defaultRequest, {
             host: 'someothercompany.com',
             protocol: 'http',
-            headers: {
-                ...defaultRequest.headers,
+            headers: Object.assign({}, defaultRequest.headers, {
                 host: 'someothercompany.com',
-            },
-        });
+            }),
+        }));
 
         const middleware = webhook(token, {
             host: 'mycompany.com',
@@ -157,15 +152,13 @@ describe('Request validation middleware', () => {
     });
 
     it('should accept manual url and override host+proto', done => {
-        const request = httpMocks.createRequest({
-            ...defaultRequest,
+        const request = httpMocks.createRequest(Object.assign({}, defaultRequest, {
             host: 'someothercompany.com',
             protocol: 'http',
-            headers: {
-                ...defaultRequest.headers,
+            headers: Object.assign({}, defaultRequest.headers, {
                 host: 'someothercompany.com',
-            },
-        });
+            }),
+        }));
 
         const middleware = webhook(token, {
             host: 'myothercompany.com',
@@ -185,15 +178,14 @@ describe('Request validation middleware', () => {
     });
 
     it('should validate post body if given a query param', done => {
-        const request = httpMocks.createRequest({
+        const request = httpMocks.createRequest(Object.assign({}, defaultRequest, {
             ...defaultRequest,
             originalUrl: requestUrlWithHash.substring(requestUrlWithHash.indexOf('.com/') + 4),
             body,
-            headers: {
-                ...defaultRequest.headers,
+            headers: Object.assign({}, defaultRequest.headers, {
                 'X-Twilio-Signature': requestUrlWithHashSignature,
-            },
-        });
+            }),
+        }));
 
         middleware(request, response, error => {
             done();
@@ -207,15 +199,14 @@ describe('Request validation middleware', () => {
     });
 
     it('should fail validation of post body with wrong hash', () => {
-        const request = httpMocks.createRequest({
-            ...defaultRequest,
+        const request = httpMocks.createRequest(Object.assign({}, defaultRequest, {
             originalUrl: requestUrlWithHash.substring(requestUrlWithHash.indexOf('.com/') + 4).replace('Ch', 'Zh'),
             body,
-            headers: {
+            headers: Object.assign({}, defaultRequest.headers, {
                 ...defaultRequest.headers,
                 'X-Twilio-Signature': requestUrlWithHashSignature,
-            },
-        });
+            }),
+        }));
 
         middleware(request, response, error => {
             expect(true).toBeFalsy();

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -179,7 +179,6 @@ describe('Request validation middleware', () => {
 
     it('should validate post body if given a query param', done => {
         const request = httpMocks.createRequest(Object.assign({}, defaultRequest, {
-            ...defaultRequest,
             originalUrl: requestUrlWithHash.substring(requestUrlWithHash.indexOf('.com/') + 4),
             body,
             headers: Object.assign({}, defaultRequest.headers, {
@@ -203,7 +202,6 @@ describe('Request validation middleware', () => {
             originalUrl: requestUrlWithHash.substring(requestUrlWithHash.indexOf('.com/') + 4).replace('Ch', 'Zh'),
             body,
             headers: Object.assign({}, defaultRequest.headers, {
-                ...defaultRequest.headers,
                 'X-Twilio-Signature': requestUrlWithHashSignature,
             }),
         }));

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -1,206 +1,226 @@
 'use strict';
 
-var twilio = require('../lib'),
-    express = require('express'),
-    request = require('request'),
-    http = require('http'),
-    crypto = require('crypto'),
-    f = require('util').format;
+const {
+    validateRequest,
+    validateRequestWithBody,
+    validateBody,
+    webhook,
+} = require('../lib/webhooks/webhooks');
+const httpMocks = require('node-mocks-http');
+const url = require('url');
 
-var twimlString = '<?xml version="1.0" encoding="UTF-8"?><Response><Message>hi</Message></Response>',
-    params = {
-        To:'+16515556677',
-        From:'+16515556699',
-        Body:'hello áçčëñtš 😃'
-    },
-    fakeToken = 'abcdefghijklmnopqrstuvwxyz1234567890';
+const cloneObject = require('lodash/clone')
 
-// Use this for testing the various manual configurations
-// Still use well-known sig to test the signature process its self
-function createTestSig(signUrl) {
-    Object.keys(params).sort().forEach(function(key, i) {
-        signUrl = signUrl + key + params[key];
+const defaultParams = {
+    CallSid: 'CA1234567890ABCDE',
+    Caller: '+14158675309',
+    Digits: '1234',
+    From: '+14158675309',
+    To: '+18005551212',
+};
+const token = '12345';
+const defaultSignature = 'RSOYDt4T1cUTdK1PDd93/VVr8B8=';
+const requestUrl = 'https://mycompany.com/myapp.php?foo=1&bar=2';
+const body = "{\"property\": \"value\", \"boolean\": true}";
+const bodySignature = "Ch/3Y02as7ldtcmi3+lBbkFQKyg6gMfPGWMmMvluZiA=";
+const requestUrlWithHash = requestUrl + '&bodySHA256=' + bodySignature.replace('+', '%2B').replace('=', '%3D');
+const requestUrlWithHashSignature = 'afcFvPLPYT8mg/JyIVkdnqQKa2s=';
+
+describe('Request validation', () => {
+    it('should succeed with the correct signature', () => {
+        const isValid = validateRequest(token, defaultSignature, requestUrl, defaultParams);
+
+        expect(isValid).toBeTruthy();
     });
-    return crypto.createHmac('sha1', fakeToken)
-                        .update(new Buffer(signUrl, 'utf-8'))
-                        .digest('Base64');
-}
 
-describe('Testing Express request validation', function() {
-    // create a local express app
-    var app = require('express')();
+    it('should fail when given the wrong signature', () => {
+        const isValid = validateRequest(token, 'WRONG_SIGNATURE', requestUrl, defaultParams);
 
-    // Use url-encoded body parser
-    app.use(express.urlencoded({ extended: false }));
+        expect(isValid).toBeFalsy();
+    });
 
-    // create a simple TwiML-serving web app that will validate a request
-    // was originated by Twilio
-    var requestValidated = false;
-    var twiml = new twilio.twiml.MessagingResponse();
-    twiml.message('hi');
+    it('should validate post body correctly', () => {
+        const isValid = validateBody(body, bodySignature);
 
-    app.post('/sms', function(request, response) {
-        // Use manually
-        if (twilio.validateExpressRequest(request, fakeToken)) {
-            requestValidated = true;
-            response.type('text/xml');
-            response.send(twiml.toString());
-        } else {
-            response
-                .type('text/plain')
-                .status(403)
-                .send('You are not Twilio >:/');
+        expect(isValid).toBeTruthy();
+    });
+
+    it('should fail to validate with wrong sha', () => {
+        const isValid = validateBody(body, 'WRONG_HASH');
+
+        expect(isValid).toBeFalsy();
+    });
+
+    it('should validate request body when given', () => {
+        const isValid = validateRequestWithBody(token, requestUrlWithHashSignature, requestUrlWithHash, body);
+
+        expect(isValid).toBeTruthy();
+    });
+
+    it('should validate request body with only sha param', () => {
+        const shortUrl = 'https://mycompany.com/myapp.php?bodySHA256=' + bodySignature.replace('+', '%2B').replace('=', '%3D');
+        const isValid = validateRequestWithBody(token, 'DXnNFCj8DJ/hZmiSg4UzaDHw5Og=', shortUrl, body);
+
+        expect(isValid).toBeTruthy();
+    });
+
+    it('should fail validation if given body but no bodySHA256 param', () => {
+        const isValid = validateRequestWithBody(token, defaultSignature, requestUrl, defaultParams, body);
+
+        expect(isValid).toBeFalsy();
+    });
+});
+
+describe('Request validation middleware', () => {
+    const fullUrl = new url.URL(requestUrl);
+    const defaultRequest = {
+        method: 'POST',
+        protocol: fullUrl.protocol,
+        host: fullUrl.host,
+        headers: {
+            'X-Twilio-Signature': defaultSignature,
+            'host': fullUrl.host,
+        },
+        url: fullUrl.pathname + fullUrl.search,
+        originalUrl: fullUrl.pathname + fullUrl.search,
+        body: defaultParams,
+    };
+    const middleware = webhook(token);
+    let response;
+
+    beforeEach(() => {
+        response = httpMocks.createResponse();
+    });
+
+    it('should validate standard requests', done => {
+        const request = httpMocks.createRequest({
+            ...defaultRequest,
+        });
+
+        middleware(request, response, error => {
+            // This test will only pass if the middleware calls next().
+            done();
+        });
+
+        expect(response.statusCode).toEqual(200);
+    });
+
+    it('should send 403 for invalid signatures', () => {
+        const newUrl = fullUrl.pathname + fullUrl.search + '&somethingUnexpected=true';
+        const request = httpMocks.createRequest({
+            ...defaultRequest,
+            originalUrl: newUrl,
+        });
+
+        middleware(request, response, error => {
+            expect(true).toBeFalsy();
+        });
+
+        expect(response.statusCode).toEqual(403);
+    });
+
+    it('should bypass validation if given {validate:false}', done => {
+        const request = httpMocks.createRequest(defaultRequest);
+
+        const middleware = webhook(token, {
+            validate: false,
+        });
+
+        middleware(request, response, error => {
+            done();
+        });
+
+        expect(response.statusCode).toEqual(200);
+    });
+
+    it('should accept manual host+proto', done => {
+        const request = httpMocks.createRequest({
+            ...defaultRequest,
+            host: 'someothercompany.com',
+            protocol: 'http',
+            headers: {
+                ...defaultRequest.headers,
+                host: 'someothercompany.com',
+            },
+        });
+
+        const middleware = webhook(token, {
+            host: 'mycompany.com',
+            protocol: 'https',
+        });
+
+        middleware(request, response, error => {
+            done();
+        });
+
+        expect(response.statusCode).toEqual(200);
+    });
+
+    it('should accept manual url and override host+proto', done => {
+        const request = httpMocks.createRequest({
+            ...defaultRequest,
+            host: 'someothercompany.com',
+            protocol: 'http',
+            headers: {
+                ...defaultRequest.headers,
+                host: 'someothercompany.com',
+            },
+        });
+
+        const middleware = webhook(token, {
+            host: 'myothercompany.com',
+            protocol: 'ftp',
+            url: requestUrl,
+        });
+
+        middleware(request, response, error => {
+            done();
+        });
+
+        expect(response.statusCode).toEqual(200);
+
+        if (response.statusCode !== 200) {
+            done();
         }
     });
 
-    // Create a second URL that will test the behavior of the validation
-    // middleware and TwiML-aware response monkey patch
-    app.post('/middleware', twilio.webhook(fakeToken), function(request, response) {
-        response.send(twiml.toString());
-    });
-
-    // Just decorate the request
-    app.post('/noauth', twilio.webhook(fakeToken, {
-        validate:false
-    }), function(request, response) {
-        response.send(twiml.toString());
-    });
-
-    // Manually configure the host and protocol
-    app.post('/manual/host', twilio.webhook(fakeToken, {
-        host:'foo.twilio.com',
-        protocol:'https'
-    }), function(request, response) {
-        response.send(twiml.toString());
-    });
-
-    // Manually configure the entire URL, ignore other input
-    app.post('/manual/url', twilio.webhook(fakeToken, {
-        url:'https://bar.twilio.com/sms',
-        host:'foo.twilio.com',
-        protocol:'http'
-    }), function(request, response) {
-        response.send(twiml.toString());
-    });
-
-    //start server
-    var server = http.createServer(app);
-    server.listen(3000);
-
-    // test ngrok-exposed URL
-    var testUrl = 'http://localhost:3000';
-    it('should give a 403 from a direct POST', function(done) {
-        request({
-            method:'POST',
-            url:testUrl+'/sms'
-        }, function(err, response, body) {
-            expect(response.statusCode).toBe(403);
-            done();
-        });
-    });
-
-    it('should act okay if the request is signed the Twilio way', function(done) {
-        // Manually create a Twilio signature
-        var signUrl = testUrl+'/sms';
-        var testSig = 'FUjfbzy5aqpVEYoCcThCAKmctVo=';
-
-        // Hit our webhook with a "Twilio signed" request
-        request({
-            method:'POST',
-            url:testUrl+'/sms',
+    it('should validate post body if given a query param', done => {
+        const request = httpMocks.createRequest({
+            ...defaultRequest,
+            originalUrl: requestUrlWithHash.substring(requestUrlWithHash.indexOf('.com/') + 4),
+            body,
             headers: {
-                'X-Twilio-Signature':testSig
+                ...defaultRequest.headers,
+                'X-Twilio-Signature': requestUrlWithHashSignature,
             },
-            form: params
-        }, function(err, response) {
-            expect(err).toBeFalsy();
-            expect(response.body).toBe(twimlString);
+        });
+
+        middleware(request, response, error => {
             done();
         });
 
-    });
+        expect(response.statusCode).toEqual(200);
 
-    it('should render twiml with no auth', function(done) {
-        request({
-            method:'POST',
-            url:testUrl+'/noauth'
-        }, function(err, response, body) {
-            expect(response.body).toBe(twimlString);
+        if (response.statusCode !== 200) {
             done();
-        });
+        }
     });
 
-    it('should give a 403 from a direct POST', function(done) {
-        request({
-            method:'POST',
-            url:testUrl+'/middleware'
-        }, function(err, response, body) {
-            expect(response.statusCode).toBe(403);
-            done();
-        });
-    });
-
-    it('should validate with middleware', function(done) {
-        // Manually create a Twilio signature
-        var signUrl = testUrl+'/middleware';
-        var testSig = 'Eh17e3p7Yu48aMIa+yHk++1+L5s=';
-
-        // Hit our webhook with a "Twilio signed" request
-        request({
-            method:'POST',
-            url:testUrl+'/middleware',
+    it('should fail validation of post body with wrong hash', () => {
+        const request = httpMocks.createRequest({
+            ...defaultRequest,
+            originalUrl: requestUrlWithHash.substring(requestUrlWithHash.indexOf('.com/') + 4).replace('Ch', 'Zh'),
+            body,
             headers: {
-                'X-Twilio-Signature':testSig
+                ...defaultRequest.headers,
+                'X-Twilio-Signature': requestUrlWithHashSignature,
             },
-            form: params
-        }, function(err, response) {
-            expect(err).toBeFalsy();
-            expect(response.body).toBe(twimlString);
-            done();
         });
 
-    });
-
-    it('should validate with a custom host and protocol', function(done) {
-        // Manually create a Twilio signature
-        var signUrl = testUrl+'/manual/host';
-        var testSig = createTestSig('https://foo.twilio.com/manual/host');
-
-        // Hit our webhook with a "Twilio signed" request
-        request({
-            method:'POST',
-            url:signUrl,
-            headers: {
-                'X-Twilio-Signature':testSig
-            },
-            form: params
-        }, function(err, response) {
-            expect(err).toBeFalsy();
-            expect(response.body).toBe(twimlString);
-            done();
+        middleware(request, response, error => {
+            expect(true).toBeFalsy();
         });
 
-    });
-
-    it('should validate with a fully custom URL', function(done) {
-        // Manually create a Twilio signature
-        var signUrl = testUrl+'/manual/url';
-        var testSig = createTestSig('https://bar.twilio.com/sms');
-
-        // Hit our webhook with a "Twilio signed" request
-        request({
-            method:'POST',
-            url:signUrl,
-            headers: {
-                'X-Twilio-Signature':testSig
-            },
-            form: params
-        }, function(err, response) {
-            expect(err).toBeFalsy();
-            expect(response.body).toBe(twimlString);
-            server.close();
-            done();
-        });
-
+        expect(response.statusCode).toEqual(403);
     });
 });


### PR DESCRIPTION
This PR:

- Adds a request body validator that accepts a string, for validating POST body that's not form data
- Gracefully (backwards-compatibly) removes unsupported, useless code from the Express Middleware
- Refactors tests to not stand up an express server, mocking requests instead