### PR TITLE
Tag and push Docker latest image when deploying with TravisCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,10 @@ docker-build:
 	docker build -t twilio/twilio-node .
 	docker tag twilio/twilio-node twilio/twilio-node:${TRAVIS_TAG}
 	docker tag twilio/twilio-node twilio/twilio-node:apidefs-${API_DEFINITIONS_SHA}
+	docker tag twilio/twilio-node twilio/twilio-node:latest
 
 docker-push:
 	echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 	docker push twilio/twilio-node:${TRAVIS_TAG}
 	docker push twilio/twilio-node:apidefs-${API_DEFINITIONS_SHA}
+	docker push twilio/twilio-node:latest


### PR DESCRIPTION
Necessary image tag to be used with Tricorder.