### PR TITLE
Fix TypeScript related issues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
-import * as VoiceResponse from './lib/twiml/VoiceResponse';
-import * as MessagingResponse from './lib/twiml/MessagingResponse';
-import * as FaxResponse from './lib/twiml/FaxResponse';
-import * as webhookTools from './lib/webhooks/webhooks';
 import * as util from './lib/jwt/taskrouter/util';
+import * as FaxResponse from './lib/twiml/FaxResponse';
+import * as MessagingResponse from './lib/twiml/MessagingResponse';
+import * as VoiceResponse from './lib/twiml/VoiceResponse';
+import * as webhookTools from './lib/webhooks/webhooks';
 
 import TwilioClient = require('./lib/rest/Twilio');
 import AccessToken = require('./lib/jwt/AccessToken');
@@ -21,9 +21,9 @@ declare function twilio(
 
 declare namespace twilio {
   export interface TwimlInterface {
-    VoiceResponse: typeof VoiceResponse;
-    FaxResponse: typeof FaxResponse;
-    MessagingResponse: typeof MessagingResponse;
+    VoiceResponse: TwimlConstructor<VoiceResponse>;
+    FaxResponse: TwimlConstructor<FaxResponse>;
+    MessagingResponse: TwimlConstructor<MessagingResponse>;
   }
   export interface JwtInterface {
     AccessToken: typeof AccessToken;

--- a/lib/jwt/AccessToken.d.ts
+++ b/lib/jwt/AccessToken.d.ts
@@ -148,13 +148,15 @@ declare namespace AccessToken {
     /**
      * Time to live in seconds
      */
-    ttl: number /**
+    ttl?: number;
+    /**
      * The identity of the first person
-     */;
-    identity: string /**
+     */
+    identity?: string;
+    /**
      * Time from epoch in seconds for not before value
-     */;
-    nbf: number;
+     */
+    nbf?: number;
   }
 }
 

--- a/lib/jwt/AccessToken.d.ts
+++ b/lib/jwt/AccessToken.d.ts
@@ -27,7 +27,7 @@ declare class AccessToken {
    * Turns the access token instance into a JWT that can be used in the front-end
    * @param algorithm The algorithm to sign the JWT
    */
-  toJwt(algorithm: 'HS256' | 'HS384' | 'HS512'): string;
+  toJwt(algorithm?: 'HS256' | 'HS384' | 'HS512'): string;
 }
 
 declare namespace AccessToken {

--- a/lib/jwt/AccessToken.d.ts
+++ b/lib/jwt/AccessToken.d.ts
@@ -126,6 +126,7 @@ declare namespace AccessToken {
   > {}
 
   export interface VoiceGrantOptions {
+    incomingAllow?: boolean;
     outgoingApplicationSid?: string;
     outgoingApplicationParams?: object;
     pushCredentialSid?: string;

--- a/lib/webhooks/webhooks.d.ts
+++ b/lib/webhooks/webhooks.d.ts
@@ -10,15 +10,15 @@ export interface RequestValidatorOptions {
   /**
    * The full URL (with query string) you used to configure the webhook with Twilio - overrides host/protocol options
    */
-  url: string;
+  url?: string;
   /**
    * Manually specify the host name used by Twilio in a number's webhook config
    */
-  host: string;
+  host?: string;
   /**
    * Manually specify the protocol used by Twilio in a number's webhook config
    */
-  protocol: string;
+  protocol?: string;
 }
 
 export interface WebhookOptions {


### PR DESCRIPTION
This PR fixes different TypeScript related binding issues found in #374, #376 and by @nash-md. Specifically this fixes:

- Exporting TwiML constructors correctly as `twilio.twiml.VoiceResponse` etc.
- Making all options in `AccessTokenOptions` optional to not force the user to provide all if one is present
- Setting the algorithm argument in `toJwt` for AccessTokens to optional since a default value is present
- Add `allowIncoming` as new option for `VoiceGrantOptions`
- Marking the `RequestValidatorOptions` values as optional

<details>
<summary>Script used to verify changes</summary>

```ts
import twilio = require('twilio');

// creating a client
const client = twilio(
  process.env.TWILIO_ACCOUNT_SID,
  process.env.TWILIO_AUTH_TOKEN
);

// create TwiML
const myTwiml = new twilio.twiml.VoiceResponse();
myTwiml.say({}, 'foo');
myTwiml.toString();

console.log(myTwiml.toString());

// create AccessToken
const accessToken = new twilio.jwt.AccessToken(
  process.env.TWILIO_ACCOUNT_SID!,
  process.env.TWILIO_API_KEY!,
  process.env.TWILIO_API_SECRET!,
  {
    ttl: 360,
  }
);

// create Grant
const grant = new twilio.jwt.AccessToken.VideoGrant();
grant.toPayload();

const AccessToken = twilio.jwt.AccessToken;
const voiceGrant = new AccessToken.VoiceGrant({
  incomingAllow: true,
  outgoingApplicationSid: 'someSid',
});
voiceGrant.toPayload();

accessToken.addGrant(voiceGrant);
accessToken.addGrant(grant);

const token = accessToken.toJwt();
console.log(token);

// verify requests

import express = require('express');
const app = express();

app.get('/', (req: express.Request, res: express.Response) => {
  const isRequestValid = twilio.validateExpressRequest(
    req,
    process.env.TWILIO_AUTH_TOKEN!,
    { url: process.env.TWILIO_WEBHOOK_URL! }
  );

  if (isRequestValid) {
    res.send('Yay');
    return;
  }

  res.send('Nay');
});
```
</details>