### PR TITLE
Include TTL option in ClientCapability

### DIFF
--- a/lib/jwt/ClientCapability.d.ts
+++ b/lib/jwt/ClientCapability.d.ts
@@ -47,6 +47,7 @@ declare namespace ClientCapability {
   export interface ClientCapabilityOptions {
     accountSid: string;
     authToken: string;
+    ttl: number;
   }
 }
 

--- a/spec/unit/jwt/ClientCapability.spec.js
+++ b/spec/unit/jwt/ClientCapability.spec.js
@@ -29,6 +29,18 @@ describe('The TwiML Capability Token Object', function () {
           authToken: 'bar'
       }) instanceof ClientCapability).toBe(true);
     });
+
+    it('should accept ttl option', function() {
+      var c = new ClientCapability({
+        accountSid: 'foo',
+        authToken: 'bar',
+        ttl: 7200
+      });
+      
+      expect(c.accountSid).toBe('foo');
+      expect(c.authToken).toBe('bar');
+      expect(c.ttl).toBe(7200);
+    })
   });
 
   describe('IncomingClientScope', function() {


### PR DESCRIPTION
Included TTL option in `ClientCapability` and test code to cover this.

I was not sure about write another condition in unit test where a token is generated so I wrote a new unit test to cover TTL option. Let me know If I should change it and move the condition to another test.