### PR TITLE
Close connections unless the header says otherwise

### DIFF
--- a/lib/base/RequestClient.js
+++ b/lib/base/RequestClient.js
@@ -34,6 +34,11 @@ RequestClient.prototype.request = function(opts) {
 
   var deferred = Q.defer();
   var headers = opts.headers || {};
+
+  if (!headers.Connection && !headers.connection) {
+    headers.Connection = 'close';
+  }
+
   if (opts.username && opts.password) {
     var b64Auth = new Buffer(opts.username + ':' + opts.password).toString('base64');
     headers.Authorization = 'Basic ' + b64Auth;

--- a/spec/unit/base/RequestClient.spec.js
+++ b/spec/unit/base/RequestClient.spec.js
@@ -31,8 +31,11 @@ describe('lastResponse and lastRequest defined', function() {
     expect(client.lastRequest.url).toEqual('test-uri');
     expect(client.lastRequest.auth).toEqual('dGVzdC11c2VybmFtZTp0ZXN0LXBhc3N3b3Jk');
     expect(client.lastRequest.params).toEqual({'test-param-key': 'test-param-value'});
-    expect(client.lastRequest.headers).toEqual({'test-header-key': 'test-header-value',
-      'Authorization': 'Basic dGVzdC11c2VybmFtZTp0ZXN0LXBhc3N3b3Jk'});
+    expect(client.lastRequest.headers).toEqual({
+      'test-header-key': 'test-header-value',
+      'Authorization': 'Basic dGVzdC11c2VybmFtZTp0ZXN0LXBhc3N3b3Jk',
+      'Connection': 'close',
+    });
     expect(client.lastRequest.data).toEqual({'test-data-key': 'test-data-value'});
     expect(client.lastResponse).toBeDefined();
     expect(client.lastResponse.statusCode).toEqual(200);
@@ -72,8 +75,11 @@ describe('lastRequest defined, lastResponse undefined', function() {
     expect(client.lastRequest.url).toEqual('test-uri');
     expect(client.lastRequest.auth).toEqual('dGVzdC11c2VybmFtZTp0ZXN0LXBhc3N3b3Jk');
     expect(client.lastRequest.params).toEqual({'test-param-key': 'test-param-value'});
-    expect(client.lastRequest.headers).toEqual({'test-header-key': 'test-header-value',
-      'Authorization': 'Basic dGVzdC11c2VybmFtZTp0ZXN0LXBhc3N3b3Jk'});
+    expect(client.lastRequest.headers).toEqual({
+      'test-header-key': 'test-header-value',
+      'Authorization': 'Basic dGVzdC11c2VybmFtZTp0ZXN0LXBhc3N3b3Jk',
+      'Connection': 'close',
+    });
     expect(client.lastRequest.data).toEqual({'test-data-key': 'test-data-value'});
     expect(client.lastResponse).toBeUndefined();
   });


### PR DESCRIPTION
Close HTTP connections when done with a request.

This resolves an issue of running Twilio in AWS Lambda, where clients get a socket hang up.

For folks that don't want this additional header and would prefer to recycle connections, a custom implementation of RequestClient can be passed to Twilio via the `httpClient` option.

```js
const t = new Twilio(sid, token, {
  httpClient: new MyOwnRestClientImpl(),
});
```