### PR TITLE
DeprecationWarning: Buffer()

### DIFF
--- a/lib/base/RequestClient.js
+++ b/lib/base/RequestClient.js
@@ -40,7 +40,7 @@ RequestClient.prototype.request = function(opts) {
   }
 
   if (opts.username && opts.password) {
-    var b64Auth = new Buffer(opts.username + ':' + opts.password).toString('base64');
+    var b64Auth = Buffer.from(opts.username + ':' + opts.password).toString('base64');
     headers.Authorization = 'Basic ' + b64Auth;
   }
 


### PR DESCRIPTION
After running `npm test` the log mentions a deprecation warning:

(node:12636) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsause the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

This fix should be in line with supporting Node 6/8 and other areas of the code are already using Buffer.from(...).