### PR TITLE
[SECURITY] fix: integrate jest to avoid `growl` critical vulnerabirities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-    - "0.10"
-    - "0.8"
+    - "6.15.1"
+    - "8.14.0"
+    - "10.14.2"
 before_install:
 - npm install npm@2 -g
 - npm install npm -g

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-test-install:
-	npm install jasmine-node -g
-
-install:
-	npm install ./
-
-test:
-	jasmine-node spec

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   },
   "devDependencies": {
     "express": "3.x",
-    "jasmine-node": "2.0.0"
+    "jest": "^23.6.0"
   },
   "scripts": {
-    "test": "jasmine-node --captureExceptions spec"
+    "test": "jest spec"
   },
   "main": "./lib",
   "engines": {


### PR DESCRIPTION
The latest `jasmine-node` has CRITICAL vulnerabirity in depending `growl`.
These days this library is not updated frequently, so I suggest to use jest.

(to Pass CI with current supported Node, rebased #404 , so please merge it before.)