### PR TITLE
[BUG] Fix/use lts node versions and remove eol versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-    - "0.10"
-    - "0.8"
+    - "6.15.1"
+    - "8.14.0"
+    - "10.14.2"
 before_install:
 - npm install npm@2 -g
 - npm install npm -g


### PR DESCRIPTION
Node versions used in travis `0.10` and `0.8` is already EOL.
Remove then and set LTS versions.