### PR TITLE
Fix return type for remove()

### DIFF
--- a/lib/rest/api/v2010/account/incomingPhoneNumber.d.ts
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber.d.ts
@@ -343,7 +343,7 @@ declare class IncomingPhoneNumberContext {
    *
    * @param callback - Callback to handle processed record
    */
-  remove(callback?: (error: Error | null, items: IncomingPhoneNumberInstance) => any): void;
+  remove(callback?: (error: Error | null, items: IncomingPhoneNumberInstance) => any): Promise<void>;
   /**
    * update a IncomingPhoneNumberInstance
    *


### PR DESCRIPTION
getting tslint error:

```
- Expression has type `void`. Put it on its own line as a statement.
```
when writing this code:

```ts
await twilioClient.incomingPhoneNumbers(sid).remove()
```