### PR TITLE
Better error message when username doesn't start with AC

### DIFF
--- a/lib/rest/Twilio.js
+++ b/lib/rest/Twilio.js
@@ -146,7 +146,7 @@ function Twilio(username, password, opts) {
   }
 
   if (!_.startsWith(this.accountSid, 'AC')) {
-    throw new Error('accountSid is required');
+    throw new Error('accountSid must start with AC');
   }
 
   // Domains


### PR DESCRIPTION
This error message is a little less confusing when a user is passing an accountSid but it doesn't start with AC.