### PR TITLE
Allow using newer moment versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deprecate": "1.0.0",
     "jsonwebtoken": "^8.1.0",
     "lodash": "^4.17.11",
-    "moment": "2.19.3",
+    "moment": "^2.19.3",
     "q": "2.0.x",
     "request": "^2.88.0",
     "rootpath": "0.1.2",


### PR DESCRIPTION
Pinning down moment to an exact version can lead to unsolvable requirements in bigger projects. Never but compatible versions of moments should be allowed.

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
