### PR TITLE
Check X-Twilio-Signature in webhook middleware

### DIFF
--- a/lib/webhooks/webhooks.js
+++ b/lib/webhooks/webhooks.js
@@ -171,6 +171,12 @@ function webhook() {
 
   // Create middleware function
   return function hook(request, response, next) {
+    // Check if the 'X-Twilio-Signature' header exists or not
+    if (!request.header('X-Twilio-Signature')) {
+      return response.type('text/plain')
+      .status(400)
+      .send('No signature header error - X-Twilio-Signature header does not exist, maybe this request is not coming from Twilio.');
+    }
     // Do validation if requested
     if (opts.validate) {
       // Check for a valid auth token

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio",
-  "version": "3.30.1",
+  "version": "3.30.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -85,6 +85,17 @@ describe('Request validation middleware', () => {
         originalUrl: fullUrl.pathname + fullUrl.search,
         body: defaultParams,
     };
+    const defaultRequestWithoutTwilioSignature = {
+        method: 'POST',
+        protocol: fullUrl.protocol,
+        host: fullUrl.host,
+        headers: {
+            'host': fullUrl.host,
+        },
+        url: fullUrl.pathname + fullUrl.search,
+        originalUrl: fullUrl.pathname + fullUrl.search,
+        body: defaultParams,
+    };
     const middleware = webhook(token);
     let response;
 
@@ -211,5 +222,19 @@ describe('Request validation middleware', () => {
         });
 
         expect(response.statusCode).toEqual(403);
+    });
+
+    it('should fail if no twilio signature is provided in the request headers', () => {
+        const newUrl = fullUrl.pathname + fullUrl.search + '&somethingUnexpected=true';
+        const request = httpMocks.createRequest(Object.assign({},
+            defaultRequestWithoutTwilioSignature, {
+            originalUrl: newUrl,
+        }));
+
+        middleware(request, response, error => {
+            expect(true).toBeFalsy();
+        });
+
+        expect(response.statusCode).toEqual(400);
     });
 });


### PR DESCRIPTION
Implemented a check in lib/webhooks/webhooks.js's webhook() middleware to check if the X-Twilio-Signature header exists or not.

If the request is not made from Twilio servers then we won't have *X-Twilio-Signature* header in the request and the middleware will throw cryptic error from *validateRequest()* function.
