### PR TITLE
Add link to code examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ as through in-line code documentation here in the library.
 
 ## End User Docs
 
-Check out these [code examples](https://github.com/twilio/twilio-node/tree/master/examples) in JavaScript and TypeScript to get up and running quickly.
+Check out these [code examples](examples) in JavaScript and TypeScript to get up and running quickly.
 
 For detailed usage information and API docs, head out here:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ as through in-line code documentation here in the library.
 
 ## End User Docs
 
+Check out these [code examples](https://github.com/twilio/twilio-node/tree/master/examples) in JavaScript and TypeScript to get up and running quickly.
+
 For detailed usage information and API docs, head out here:
 
 [https://www.twilio.com/docs/libraries/node](https://www.twilio.com/docs/libraries/node)
@@ -52,7 +54,7 @@ After cloning the repository, install the dependencies by running the following 
 npm install
 ```
 
-You can run the existing tests to see if everything is okay by executing: 
+You can run the existing tests to see if everything is okay by executing:
 
 ```bash
 npm test


### PR DESCRIPTION
Hello! 

First off, thanks for maintaining such a useful library. :heart: I truly appreciate it.

There is a bunch of really helpful code in the examples folder, that I didn't discover until late in the game. Linking to the examples in the README seems like an easy fix to help other people avoid my mistake.  Thanks and have a great day.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
