### PR TITLE
Request middleware fails on validate set to false

### DIFF
--- a/lib/webhooks/webhooks.js
+++ b/lib/webhooks/webhooks.js
@@ -172,12 +172,6 @@ function webhook() {
 
   // Create middleware function
   return function hook(request, response, next) {
-    // Check if the 'X-Twilio-Signature' header exists or not
-    if (!request.header('X-Twilio-Signature')) {
-      return response.type('text/plain')
-      .status(400)
-      .send('No signature header error - X-Twilio-Signature header does not exist, maybe this request is not coming from Twilio.');
-    }
     // Do validation if requested
     if (opts.validate) {
       // Check for a valid auth token

--- a/lib/webhooks/webhooks.js
+++ b/lib/webhooks/webhooks.js
@@ -174,6 +174,12 @@ function webhook() {
   return function hook(request, response, next) {
     // Do validation if requested
     if (opts.validate) {
+      // Check if the 'X-Twilio-Signature' header exists or not
+      if (!request.header('X-Twilio-Signature')) {
+        return response.type('text/plain')
+        .status(400)
+        .send('No signature header error - X-Twilio-Signature header does not exist, maybe this request is not coming from Twilio.');
+      }
       // Check for a valid auth token
       if (!opts.authToken) {
         console.error('[Twilio]: Error - Twilio auth token is required for webhook request validation.');

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -91,6 +91,17 @@ describe('Request validation middleware', () => {
         originalUrl: fullUrl.pathname + fullUrl.search,
         body: defaultParams,
     };
+    const defaultRequestWithoutTwilioSignature = {
+        method: 'POST',
+        protocol: fullUrl.protocol,
+        host: fullUrl.host,
+        headers: {
+            'host': fullUrl.host,
+        },
+        url: fullUrl.pathname + fullUrl.search,
+        originalUrl: fullUrl.pathname + fullUrl.search,
+        body: defaultParams,
+    };
     const middleware = webhook(token);
     let response;
 
@@ -219,4 +230,17 @@ describe('Request validation middleware', () => {
         expect(response.statusCode).toEqual(403);
     });
 
+    it('should fail if no twilio signature is provided in the request headers', () => {
+        const newUrl = fullUrl.pathname + fullUrl.search + '&somethingUnexpected=true';
+        const request = httpMocks.createRequest(Object.assign({},
+            defaultRequestWithoutTwilioSignature, {
+            originalUrl: newUrl,
+        }));
+
+        middleware(request, response, error => {
+            expect(true).toBeFalsy();
+        });
+
+        expect(response.statusCode).toEqual(400);å
+    });
 });

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -91,17 +91,6 @@ describe('Request validation middleware', () => {
         originalUrl: fullUrl.pathname + fullUrl.search,
         body: defaultParams,
     };
-    const defaultRequestWithoutTwilioSignature = {
-        method: 'POST',
-        protocol: fullUrl.protocol,
-        host: fullUrl.host,
-        headers: {
-            'host': fullUrl.host,
-        },
-        url: fullUrl.pathname + fullUrl.search,
-        originalUrl: fullUrl.pathname + fullUrl.search,
-        body: defaultParams,
-    };
     const middleware = webhook(token);
     let response;
 
@@ -230,17 +219,4 @@ describe('Request validation middleware', () => {
         expect(response.statusCode).toEqual(403);
     });
 
-    it('should fail if no twilio signature is provided in the request headers', () => {
-        const newUrl = fullUrl.pathname + fullUrl.search + '&somethingUnexpected=true';
-        const request = httpMocks.createRequest(Object.assign({},
-            defaultRequestWithoutTwilioSignature, {
-            originalUrl: newUrl,
-        }));
-
-        middleware(request, response, error => {
-            expect(true).toBeFalsy();
-        });
-
-        expect(response.statusCode).toEqual(400);
-    });
 });

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -241,6 +241,6 @@ describe('Request validation middleware', () => {
             expect(true).toBeFalsy();
         });
 
-        expect(response.statusCode).toEqual(400);å
+        expect(response.statusCode).toEqual(400);
     });
 });


### PR DESCRIPTION
<!-- Describe your Pull Request -->
[X-Twilio-Signature check](https://github.com/twilio/twilio-node/blob/6585f327e4f681971dc3eddf40ca5840adf685dc/lib/webhooks/webhooks.js#L176) is added before [checking](https://github.com/twilio/twilio-node/blob/6585f327e4f681971dc3eddf40ca5840adf685dc/lib/webhooks/webhooks.js#L182) the validate option. The request will fail even if [validate option](https://github.com/twilio/twilio-node/blob/6585f327e4f681971dc3eddf40ca5840adf685dc/lib/webhooks/webhooks.d.ts#L32) is set to false. If a request is sent from POSTMAN on dev/test environment, which means the validate option is false, so there is no need to check if the header is present or not. Similarly, if a test is written for Express route in my code, the middleware will fail despite the fact that validate option is false.

It also checks for X-Twilio-Signature [here](https://github.com/twilio/twilio-node/blob/6585f327e4f681971dc3eddf40ca5840adf685dc/lib/webhooks/webhooks.js#L50) which will not fail with validate option set to false. If validate option is true and X-Twilio-Signature is undefined, empty string is set as a [default value](https://github.com/twilio/twilio-node/pull/446) which will then obviously differ from [expected twilio signature](https://github.com/twilio/twilio-node/blob/6585f327e4f681971dc3eddf40ca5840adf685dc/lib/webhooks/webhooks.js#L51) and fail.
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.