### PR TITLE
Typing fix for PolicyOptions

### DIFF
--- a/lib/jwt/taskrouter/TaskRouterCapability.d.ts
+++ b/lib/jwt/taskrouter/TaskRouterCapability.d.ts
@@ -39,7 +39,7 @@ declare namespace TaskRouterCapability {
     /** Request post filter allowances */
     postFilter?: object;
     /** Allow the policy */
-    allowed?: boolean;
+    allow?: boolean;
   }
 
   export interface PolicyPayload {


### PR DESCRIPTION
As per this:
https://github.com/twilio/twilio-node/blob/master/lib/jwt/taskrouter/TaskRouterCapability.js#L23
PolicyOption has a property `allow`

In types file here:
https://github.com/twilio/twilio-node/blob/master/lib/jwt/taskrouter/TaskRouterCapability.d.ts#L42
it is `allowed`

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
