### PR TITLE
Added the ability for users to specify a CA bundle for HTTPS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ TypeScript is supported for TypeScript version 2.9 and above.
 
 Check out these [code examples](examples) in JavaScript and TypeScript to get up and running quickly.
 
+### Environment Variables
+
+`twilio-node` supports credential storage in environment variables. If no credentials are provided when instantiating the Twilio client (e.g., `const client = require('twilio')();`), the values in following env vars will be used: `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN`.
+
+If your environment requires SSL decryption, you can set the path to CA bundle in the env var `TWILIO_CA_BUNDLE`.
+
 ## Docker Image
 
 The `Dockerfile` present in this repository and its respective `twilio/twilio-node` Docker image are currently used by Twilio for testing purposes only.
@@ -67,13 +73,6 @@ To run just one specific test file instead of the whole suite, provide a JavaScr
 ```bash
 npm run test -- -m .\*client.\*
 ```
-
-####Environment Variables
- 
-* `TWILIO_ACCOUNT_SID` - TODO
-* `TWILIO_AUTH_TOKEN` - TODO
-* `TWILIO_CA_BUNDLE` - Optional, if set will use the specified path to a CA bundle. Useful for environments using SSL decryption
-
 
 [apidocs]: https://www.twilio.com/docs/api
 [libdocs]: https://twilio.github.io/twilio-node

--- a/README.md
+++ b/README.md
@@ -68,5 +68,12 @@ To run just one specific test file instead of the whole suite, provide a JavaScr
 npm run test -- -m .\*client.\*
 ```
 
+####Environment Variables
+ 
+* `TWILIO_ACCOUNT_SID` - TODO
+* `TWILIO_AUTH_TOKEN` - TODO
+* `TWILIO_CA_BUNDLE` - Optional, if set will use the specified path to a CA bundle. Useful for environments using SSL decryption
+
+
 [apidocs]: https://www.twilio.com/docs/api
 [libdocs]: https://twilio.github.io/twilio-node

--- a/examples/example.js
+++ b/examples/example.js
@@ -5,6 +5,10 @@ var Twilio = require('../lib');
 var accountSid = process.env.TWILIO_ACCOUNT_SID;
 var token = process.env.TWILIO_AUTH_TOKEN;
 
+// Uncomment the following line to specify a custom CA bundle for HTTPS requests:
+// process.env.TWILIO_CA_BUNDLE = '/path/to/cert.pem';
+// You can also set this as a regular environment variable outside of the code
+
 var twilio = new Twilio(accountSid, token);
 
 var i = 0;

--- a/lib/base/RequestClient.js
+++ b/lib/base/RequestClient.js
@@ -55,7 +55,10 @@ RequestClient.prototype.request = function(opts) {
   };
 
   if (process.env.TWILIO_CA_BUNDLE !== undefined) {
-    options.ca = fs.readFileSync(process.env.TWILIO_CA_BUNDLE);
+    if (this.ca === undefined) {
+      this.ca = fs.readFileSync(process.env.TWILIO_CA_BUNDLE);
+    }
+    options.ca = this.ca;
   }
 
   if (!_.isNull(opts.data)) {

--- a/lib/base/RequestClient.js
+++ b/lib/base/RequestClient.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var http = require('request');
+var fs = require('fs');
 var Q = require('q');
 var Response = require('../http/response');
 var Request = require('../http/request');
@@ -53,6 +54,10 @@ RequestClient.prototype.request = function(opts) {
     forever: opts.forever === false ? false : true,
   };
 
+  if (process.env.TWILIO_CA_BUNDLE !== undefined) {
+    options.ca = fs.readFileSync(process.env.TWILIO_CA_BUNDLE);
+  }
+
   if (!_.isNull(opts.data)) {
     options.formData = opts.data;
   }
@@ -69,6 +74,7 @@ RequestClient.prototype.request = function(opts) {
     params: options.qs,
     data: options.formData,
     headers: options.headers,
+    ca: options.ca
   };
 
   var _this = this;

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -11,6 +11,7 @@ var Request = function(opts) {
   this.params = opts.params || this.ANY;
   this.data = opts.data || this.ANY;
   this.headers = opts.headers || this.ANY;
+  this.ca = opts.ca;
 };
 
 Request.prototype.ANY = '*';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1535,6 +1535,12 @@
         "minimist": "0.0.8"
       }
     },
+    "mock-fs": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.1.tgz",
+      "integrity": "sha512-w22rOL5ZYu6HbUehB5deurghGM0hS/xBVyHMGKOuQctkk93J9z9VEOhDsiWrXOprVNQpP9uzGKdl8v9mFspKuw==",
+      "dev": true
+    },
     "module-not-found-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "jasmine": "^3.4.0",
     "jsdoc": "^3.6.3",
     "jshint": "^2.10.2",
+    "mock-fs": "^4.10.1",
     "node-mocks-http": "^1.8.0",
     "proxyquire": "1.8.0",
     "typescript": "^2.8.3"

--- a/spec/unit/base/RequestClient.spec.js
+++ b/spec/unit/base/RequestClient.spec.js
@@ -130,4 +130,18 @@ describe('User specified CA bundle', function() {
     expect(client.lastRequest.ca.toString()).toEqual('test ca data');
     delete process.env.TWILIO_CA_BUNDLE;
   });
+
+  it('should cache the CA after loading it for the first time', function () {
+    process.env.TWILIO_CA_BUNDLE = '/path/to/ca/test-ca.pem';
+    client.request(options);
+    mockfs({
+      '/path/to/ca': {
+        'test-ca.pem': null
+      }
+    });
+    client.request(options);
+    expect(client.lastRequest.ca.toString()).toEqual('test ca data');
+    delete process.env.TWILIO_CA_BUNDLE;
+  })
+
 });

--- a/spec/unit/base/RequestClient.spec.js
+++ b/spec/unit/base/RequestClient.spec.js
@@ -1,3 +1,4 @@
+var mockfs = require('mock-fs');
 var proxyquire = require('proxyquire');
 
 describe('lastResponse and lastRequest defined', function() {
@@ -84,4 +85,49 @@ describe('lastRequest defined, lastResponse undefined', function() {
     expect(client.lastResponse).toBeUndefined();
   });
 
+});
+
+describe('User specified CA bundle', function() {
+  var client;
+  beforeEach(function() {
+    RequestClientMock = proxyquire('../../../lib/base/RequestClient', {
+      request: function (options, callback) {
+        callback('failed', null);
+      },
+    });
+
+    client = new RequestClientMock();
+
+    options = {
+      method: 'GET',
+      uri: 'test-uri',
+      username: 'test-username',
+      password: 'test-password',
+      headers: {'test-header-key': 'test-header-value'},
+      params: {'test-param-key': 'test-param-value'},
+      data: {'test-data-key': 'test-data-value'}
+    };
+
+    mockfs({
+      '/path/to/ca': {
+        'test-ca.pem': 'test ca data'
+      }
+    });
+  });
+
+  afterEach(function () {
+    mockfs.restore();
+  });
+
+  it('should not modify CA if not specified', function() {
+    client.request(options);
+    expect(client.lastRequest.ca).toBeUndefined();
+  });
+
+  it('should use CA if it is specified', function() {
+    process.env.TWILIO_CA_BUNDLE = '/path/to/ca/test-ca.pem';
+    client.request(options);
+    expect(client.lastRequest.ca.toString()).toEqual('test ca data');
+    delete process.env.TWILIO_CA_BUNDLE;
+  });
 });


### PR DESCRIPTION
Proposal to Issue #481

Right now there is no way for a user to specify a CA bundle to replace the default one that `request` ships with.

According to [the request docs](https://github.com/request/request#tlsssl-protocol) you can specify it in the `options` object passed to `request`.

This change offers a simple solution by setting a path to your CA bundle as an environment variable: 
`TWILIO_CA_BUNDLE=/path/to/cert.pem`

Test cases have been included to ensure that the specified CA bundle is used, and that the original behavior of not including it in `options` remains unchanged if it is not specified.


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
