### PR TITLE
Fixes missing identity value in token when it's not a string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ config.js
 
 ### jsdoc dir ###
 docs
+
+### ide / editors ###
+.vscode

--- a/lib/jwt/AccessToken.js
+++ b/lib/jwt/AccessToken.js
@@ -249,7 +249,7 @@ _.extend(AccessToken.prototype, {
     }
 
     var grants = {};
-    if (_.isInteger(this.identity) || _.isString(this.identity)) { grants.identity = String(this.identity); };
+    if (_.isInteger(this.identity) || _.isString(this.identity)) { grants.identity = String(this.identity); }
 
     _.each(this.grants, function(grant) {
       grants[grant.key] = grant.toPayload();

--- a/lib/jwt/AccessToken.js
+++ b/lib/jwt/AccessToken.js
@@ -212,6 +212,7 @@ function AccessToken(accountSid, keySid, secret, options) {
   if (!keySid) { throw new Error('keySid is required'); }
   if (!secret) { throw new Error('secret is required'); }
   options = options || {};
+  if (_.isInteger(options.identity)) { options.identity = new String(options.identity); };
 
   this.accountSid = accountSid;
   this.keySid = keySid;

--- a/lib/jwt/AccessToken.js
+++ b/lib/jwt/AccessToken.js
@@ -212,7 +212,6 @@ function AccessToken(accountSid, keySid, secret, options) {
   if (!keySid) { throw new Error('keySid is required'); }
   if (!secret) { throw new Error('secret is required'); }
   options = options || {};
-  if (_.isInteger(options.identity)) { options.identity = new String(options.identity); };
 
   this.accountSid = accountSid;
   this.keySid = keySid;
@@ -250,7 +249,7 @@ _.extend(AccessToken.prototype, {
     }
 
     var grants = {};
-    if (_.isString(this.identity)) { grants.identity = this.identity; }
+    if (_.isInteger(this.identity) || _.isString(this.identity)) { grants.identity = String(this.identity); };
 
     _.each(this.grants, function(grant) {
       grants[grant.key] = grant.toPayload();

--- a/spec/unit/jwt/AccessToken.spec.js
+++ b/spec/unit/jwt/AccessToken.spec.js
@@ -28,6 +28,11 @@ describe('AccessToken', function() {
     it('should require secret', function() {
       expect(initWithoutIndex(2)).toThrow(new Error('secret is required'));
     });
+    it('should convert identity from integer to string', function () {
+      var token = new twilio.jwt.AccessToken(accountSid, keySid, 'secret', { identity: 4444 });
+      var decoded = jwt.decode(token.toJwt());
+      expect(decoded.grants.identity).toEqual('4444');
+    });
   });
 
   describe('generate', function() {


### PR DESCRIPTION
Fixes #438

Resolves missing identity value in token when it's not a string begin passed in the `AccessToken` constructor.

The specs of the issue ticket suggest throwing an error when identity is passed as an integer. Originally, I took this approach but I quickly realized this would cause breaking changes for anyone passing numeric values in identity option. I do not believe this is error worthy because simple converting the value to a string solves the down stream implication in the jwt.

```javascript
 if (_.isInteger(options.identity)) { options.identity = new String(options.identity); };
```

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
