### PR TITLE
Add getExpectedTwilioSignature to the index exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,7 @@ declare namespace twilio {
   export const jwt: JwtInterface;
   export const twiml: TwimlInterface;
   export const validateRequest: typeof webhookTools.validateRequest;
+  export const getExpectedTwilioSignature: typeof webhookTools.getExpectedTwilioSignature;
   export const validateRequestWithBody: typeof webhookTools.validateRequestWithBody;
   export const validateExpressRequest: typeof webhookTools.validateExpressRequest;
   export const webhook: typeof webhookTools.webhook;

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,7 @@ initializer.TrunkingClient = obsolete.TrunkingClient;
 
 // Setup webhook helper functionality
 initializer.validateRequest = webhooks.validateRequest;
+initializer.getExpectedTwilioSignature = webhooks.validateExpressRequest
 initializer.validateRequestWithBody = webhooks.validateRequestWithBody;
 initializer.validateExpressRequest = webhooks.validateExpressRequest;
 initializer.webhook = webhooks.webhook;


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Export the `getExpectedTwilioSignature` function to the main twilio object.

We've added this because in our org we've deployed a service to a FaaS platform so express is not able to pass our application the correct URL in its request object. This will allow us to match the URL manually that Twilio is expecting in its signature.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
