### PR TITLE
fix: refactor 'RestException' to properly extend 'Error'

### DIFF
--- a/lib/base/RestException.js
+++ b/lib/base/RestException.js
@@ -1,17 +1,16 @@
 'use strict';
-var util = require('util');
 
-function RestException(response) {
-  Error.call('[HTTP ' + response.statusCode + '] Failed to execute request');
+class RestException extends Error {
+  constructor(response) {
+    super('[HTTP ' + response.statusCode + '] Failed to execute request');
 
-  var body = response.body;
-  this.status = response.statusCode;
-  this.message = body.message;
-  this.code = body.code;
-  this.moreInfo = body.more_info; /* jshint ignore:line */
-  this.detail = body.detail;
+    const body = response.body;
+    this.status = response.statusCode;
+    this.message = body.message;
+    this.code = body.code;
+    this.moreInfo = body.more_info; /* jshint ignore:line */
+    this.detail = body.detail;
+  }
 }
-
-util.inherits(RestException, Error);
 
 module.exports = RestException;


### PR DESCRIPTION
Enables stack traces (.stack) that come with 'Error'.

Fixes #548 