### PR TITLE
feat: include API response headers in 'Last Response'

### DIFF
--- a/lib/base/RequestClient.js
+++ b/lib/base/RequestClient.js
@@ -49,7 +49,7 @@ RequestClient.prototype.request = function(opts) {
     var b64Auth = Buffer.from(opts.username + ':' + opts.password).toString('base64');
     headers.Authorization = 'Basic ' + b64Auth;
   }
-  
+
   var options = {
     timeout: opts.timeout || 30000,
     maxRedirects: opts.allowRedirects ? 10 : 0, // Same number of allowed redirects as request module default
@@ -94,7 +94,7 @@ RequestClient.prototype.request = function(opts) {
   this.lastRequest = new Request(optionsRequest);
 
   axios(options).then((response) => {
-    _this.lastResponse = new Response(response.status, response.data);
+    _this.lastResponse = new Response(response.status, response.data, response.headers);
     deferred.resolve({
       statusCode: response.status,
       body: response.data,

--- a/lib/http/response.d.ts
+++ b/lib/http/response.d.ts
@@ -1,5 +1,5 @@
 declare class Response<TPayload> {
-  constructor(statusCode: number, body: TPayload);
+  constructor(statusCode: number, body: TPayload, headers: any);
   toString(): string;
 }
 

--- a/lib/http/response.js
+++ b/lib/http/response.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var Response = function(statusCode, body) {
+var Response = function(statusCode, body, headers) {
   this.statusCode = statusCode;
   this.body = body;
+  this.headers = headers;
 };
 
 Response.prototype.toString = function() {


### PR DESCRIPTION
The default HTTP client stores 'Last Request' and 'Last Response' information for access to more data about the raw API request/response. The response object did not contain the headers until now.