### PR TITLE
fix: upgrade dependencies and ignore low severity vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jsdoc": "^3.6.4",
     "jshint": "^2.11.0",
     "mock-fs": "^4.12.0",
-    "nock": "^13.0.2",
+    "nock": "^10.0.6",
     "node-mocks-http": "^1.8.1",
     "proxyquire": "^2.1.3",
     "typescript": "^2.8.3"

--- a/package.json
+++ b/package.json
@@ -20,28 +20,28 @@
     "url": "https://github.com/twilio/twilio-node.git"
   },
   "dependencies": {
-    "@types/express": "^4.17.3",
+    "@types/express": "^4.17.6",
     "axios": "^0.19.2",
-    "dayjs": "^1.8.21",
+    "dayjs": "^1.8.29",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",
     "q": "2.0.x",
-    "qs": "^6.9.1",
+    "qs": "^6.9.4",
     "rootpath": "^0.1.2",
     "scmp": "^2.1.0",
     "url-parse": "^1.4.7",
     "xmlbuilder": "^13.0.2"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.149",
+    "@types/lodash": "^4.14.157",
     "@types/node": "^9.6.55",
-    "eslint": "^6.8.0",
+    "eslint": "^7.3.1",
     "express": "^4.17.1",
     "jasmine": "^3.5.0",
-    "jsdoc": "^3.6.3",
+    "jsdoc": "^3.6.4",
     "jshint": "^2.11.0",
-    "mock-fs": "^4.11.0",
-    "nock": "^10.0.6",
+    "mock-fs": "^4.12.0",
+    "nock": "^13.0.2",
     "node-mocks-http": "^1.8.1",
     "proxyquire": "^2.1.3",
     "typescript": "^2.8.3"
@@ -55,7 +55,7 @@
     "check": "npm run jshint && npm run jscs",
     "ci": "npm test && npm run nsp",
     "jsdoc": "jsdoc -r lib -d docs",
-    "nsp": "if [ `npm --version | cut -d'.' -f1` -ge \"6\" ]; then npm audit; else echo \"npm audit is not available for npm < 6.0\"; fi"
+    "nsp": "if [ `npm --version | cut -d'.' -f1` -ge \"6\" ]; then npm audit --audit-level=moderate; else echo \"npm audit is not available for npm < 6.0\"; fi"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Ignoring low severity vulnerabilities until lodash issue is resolved: https://www.npmjs.com/advisories/1523
