### PR TITLE
fix: allow lower versions of typescript (2.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "xmlbuilder": "^13.0.2"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.157",
-    "@types/node": "^9.6.55",
+    "@types/lodash": "^4.14.112",
+    "@types/node": "^9.6.57",
     "eslint": "^7.3.1",
     "express": "^4.17.1",
     "jasmine": "^3.5.0",


### PR DESCRIPTION
Fix for internal CI build.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
