### PR TITLE
fix: Prevent throwing an exception on 3xx response status code

### DIFF
--- a/lib/base/Version.d.ts
+++ b/lib/base/Version.d.ts
@@ -26,7 +26,7 @@ declare class Version {
   request(opts: TwilioClient.RequestOptions): Promise<any>;
   /**
    * Fetch a instance of a record
-   * @throws {Error} If response returns non 2xx status code
+   * @throws {Error} If response returns non 2xx or 3xx status code
    *
    * @param  opts request options
    * @return promise that resolves to fetched result

--- a/lib/base/Version.js
+++ b/lib/base/Version.js
@@ -49,7 +49,7 @@ Version.prototype.request = function(opts) {
 
 /**
  * Fetch a instance of a record
- * @throws {Error} If response returns non 2xx status code
+ * @throws {Error} If response returns non 2xx or 3xx status code
  *
  * @param  {object} opts request options
  * @return {Promise} promise that resolves to fetched result
@@ -59,7 +59,7 @@ Version.prototype.fetch = function(opts) {
 
   qResponse = qResponse.then(
     function success(response) {
-      if (response.statusCode < 200 || response.statusCode >= 300) {
+      if (response.statusCode < 200 || response.statusCode >= 400) {
         throw new RestException(response);
       }
 

--- a/spec/unit/base/Version.spec.js
+++ b/spec/unit/base/Version.spec.js
@@ -1,0 +1,31 @@
+const Version = require('../../../lib/base/Version');
+
+describe('fetch method', function() {
+  it('should not throw an exception on 3xx status code', function(done) {
+    const body = {test: true};
+    const version = new Version({
+      request: () => Promise.resolve({statusCode: 307, body}),
+    }, {});
+
+    version.fetch({}).then(response => {
+      expect(response).toBeDefined();
+      expect(response).toEqual(body);
+      done();
+    });
+  });
+
+  it('should throw an exception if status code >= 400', function(done) {
+    const body = {message: 'invalid body'};
+    const version = new Version({
+      request: () => Promise.resolve({statusCode: 400, body}),
+    }, null);
+
+    version.fetch({}).catch(error => {
+      expect(error).toBeDefined();
+      expect(error.status).toEqual(400);
+      expect(error.message).toEqual(body.message);
+      done();
+    });
+  });
+});
+


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

Prevent throwing a `RestExpection` on `3XX` response status code. https://github.com/twilio/twilio-node/issues/613

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified


Questions/Notes:
- There is similar logic in other http request wrappers (`update`, `remove`, `create`). Do I need to change it as well?
- I'll add tests if/when the general approach is approved