### PR TITLE
feat: Improve error message if an API Key is passed in place of an Auth Token

### DIFF
--- a/lib/rest/Twilio.js
+++ b/lib/rest/Twilio.js
@@ -137,6 +137,11 @@ function Twilio(username, password, opts) {
   }
 
   if (!this.accountSid.startsWith('AC')) {
+
+    if (this.accountSid.startsWith('SK')) {
+      throw new Error('accountSid must start with AC. The SID provided indicates an API Key, which requires the accountSid to be passed as one of the options in the third parameter: {accountSid: "ACXXX}');
+    }
+
     throw new Error('accountSid must start with AC');
   }
 

--- a/lib/rest/Twilio.js
+++ b/lib/rest/Twilio.js
@@ -139,7 +139,7 @@ function Twilio(username, password, opts) {
   if (!this.accountSid.startsWith('AC')) {
 
     if (this.accountSid.startsWith('SK')) {
-      throw new Error('accountSid must start with AC. The SID provided indicates an API Key, which requires the accountSid to be passed as one of the options in the third parameter: {accountSid: "ACXXX}');
+      throw new Error('accountSid must start with AC. The SID provided indicates an API Key, which requires the accountSid to be passed as one of the options in the third parameter: {accountSid: "ACXXX"}');
     }
 
     throw new Error('accountSid must start with AC');


### PR DESCRIPTION
# Fixes #

Fixes #600 

At present, if an auth token is provided instead of an API key the error 'accountSid must start with AC' is issued. This suggests that it is not possible to use API keys in place of auth tokens with twilio-node, when in fact API keys can be used but require an additional optional paramater to be used.

The present error messages encourages poor practice as it indiciates that API keys cannot be used in place of auth tokens.

This change implements a new error message that explains to developer the requirements in order to use API keys in the event that a API key SID is provided (whcih starts with "SK").

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
