### PR TITLE
fix: fix validateExpressRequest issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ const client = require('twilio')(accountSid, authToken);
 client.logLevel = 'debug';
 ```
 
+## Using webhook validation
+See [example](examples/express.js) for a code sample for incoming Twilio request validation
+
 ## Handling Exceptions
 
 For an example on how to handle exceptions in this helper library, please see the [Twilio documentation](https://www.twilio.com/docs/libraries/node/usage-guide#exceptions).

--- a/examples/express.js
+++ b/examples/express.js
@@ -1,0 +1,32 @@
+const twilio = require('twilio');
+const bodyParser = require('body-parser');
+const MessagingResponse = require('twilio').twiml.MessagingResponse;
+
+const express = require('express')
+const app = express()
+const port = 3000
+
+app.use(bodyParser.json({
+    verify: (req, res, buf) => {
+        req.rawBody = buf
+    }
+}))
+
+app.get('/', (req, res) => {
+    res.send('Hello World!')
+})
+
+app.post('/message', twilio.webhook(), (req, res) => {
+    // Twilio Messaging URL - receives incoming messages from Twilio
+    const response = new MessagingResponse();
+
+    response.message(`Your text to me was ${req.body.Body}.
+                    Webhooks are neat :)`);
+
+    res.set('Content-Type', 'text/xml');
+    res.send(response.toString());
+});
+
+app.listen(port, () => {
+    console.log(`Example app listening at http://localhost:${port}`)
+})

--- a/lib/webhooks/webhooks.js
+++ b/lib/webhooks/webhooks.js
@@ -172,7 +172,7 @@ function validateExpressRequest(request, authToken, opts) {
       authToken,
       request.header('X-Twilio-Signature'),
       webhookUrl,
-      request.body || {}
+      request.rawBody || '{}'
     );
   } else {
     return validateRequest(

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "qs": "^6.9.4",
     "rootpath": "^0.1.2",
     "scmp": "^2.1.0",
-    "url-parse": "^1.4.7",
+    "url-parse": "^1.5.0",
     "xmlbuilder": "^13.0.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.7",
-    "@types/qs": "6.9.4",
     "@types/lodash": "4.14.112",
     "@types/node": "9.6.57",
+    "@types/qs": "6.9.4",
     "eslint": "^7.3.1",
     "express": "^4.17.1",
     "jasmine": "~3.5.0",

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -24,6 +24,10 @@ const bodySignature = '0a1ff7634d9ab3b95db5c9a2dfe9416e41502b283a80c7cf19632632f
 const requestUrlWithHash = requestUrl + '&bodySHA256=' + bodySignature;
 const requestUrlWithHashSignature = 'a9nBmqA0ju/hNViExpshrM61xv4=';
 
+const requestUrlWithHashSignatureEmptyBody = 'Ldidvp12m26NI7eqEvxnEpkd9Hc=';
+const bodySignatureEmpty = '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a';
+const requestUrlWithHashEmpty = requestUrl + '&bodySHA256=' + bodySignatureEmpty;
+
 describe('Request validation', () => {
   it('should succeed with the correct signature', () => {
     const isValid = validateRequest(token, defaultSignature, requestUrl, defaultParams);
@@ -51,6 +55,12 @@ describe('Request validation', () => {
 
   it('should validate request body when given', () => {
     const isValid = validateRequestWithBody(token, requestUrlWithHashSignature, requestUrlWithHash, body);
+
+    expect(isValid).toBeTruthy();
+  });
+
+  it('should validate request body when empty', () => {
+    const isValid = validateRequestWithBody(token, requestUrlWithHashSignatureEmptyBody, requestUrlWithHashEmpty, '{}');
 
     expect(isValid).toBeTruthy();
   });
@@ -265,6 +275,7 @@ describe('Request validation middleware', () => {
       }),
     }));
 
+    request.rawBody = body;
     middleware(request, response, () => {
       done();
     });
@@ -296,8 +307,8 @@ describe('Request validation middleware', () => {
     const newUrl = fullUrl.pathname + fullUrl.search + '&somethingUnexpected=true';
     const request = httpMocks.createRequest(Object.assign({},
       defaultRequestWithoutTwilioSignature, {
-        originalUrl: newUrl,
-      }));
+      originalUrl: newUrl,
+    }));
 
     middleware(request, response, () => {
       expect(true).toBeFalsy();


### PR DESCRIPTION
# Fixes #

This PR fixes issue when the `validateExpressRequest` is used for webhook validation when the content-type is application/json. 

Note: We expect the `request.rawBody` populated for the validation in this case. 

Fixes #657 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
