### PR TITLE
fix: remove @type/express 

### DIFF
--- a/examples/typescript/example.ts
+++ b/examples/typescript/example.ts
@@ -1,9 +1,7 @@
 import twilio = require('../../');
 import {MessageListInstanceCreateOptions} from '../../lib/rest/api/v2010/account/message';
 
-
 const accountSid: string = process.env.TWILIO_ACCOUNT_SID || '';
-
 const token: string = process.env.TWILIO_AUTH_TOKEN || '';
 
 const client = twilio(accountSid, token);
@@ -28,9 +26,7 @@ client.calls.each({}, call => {
   console.log(call.sid);
 });
 
-
 const from = process.env.FROM_NUMBER || '';
-
 const to = process.env.TO_NUMBER || '';
 
 const msgData: MessageListInstanceCreateOptions = {

--- a/examples/typescript/example.ts
+++ b/examples/typescript/example.ts
@@ -1,9 +1,9 @@
 import twilio = require('../../');
 import {MessageListInstanceCreateOptions} from '../../lib/rest/api/v2010/account/message';
 
-// @ts-ignore
+
 const accountSid: string = process.env.TWILIO_ACCOUNT_SID || '';
-// @ts-ignore
+
 const token: string = process.env.TWILIO_AUTH_TOKEN || '';
 
 const client = twilio(accountSid, token);
@@ -28,9 +28,9 @@ client.calls.each({}, call => {
   console.log(call.sid);
 });
 
-// @ts-ignore
+
 const from = process.env.FROM_NUMBER || '';
-// @ts-ignore
+
 const to = process.env.TO_NUMBER || '';
 
 const msgData: MessageListInstanceCreateOptions = {

--- a/examples/typescript/example.ts
+++ b/examples/typescript/example.ts
@@ -1,7 +1,9 @@
 import twilio = require('../../');
 import {MessageListInstanceCreateOptions} from '../../lib/rest/api/v2010/account/message';
 
+// @ts-ignore
 const accountSid: string = process.env.TWILIO_ACCOUNT_SID || '';
+// @ts-ignore
 const token: string = process.env.TWILIO_AUTH_TOKEN || '';
 
 const client = twilio(accountSid, token);
@@ -26,7 +28,9 @@ client.calls.each({}, call => {
   console.log(call.sid);
 });
 
+// @ts-ignore
 const from = process.env.FROM_NUMBER || '';
+// @ts-ignore
 const to = process.env.TO_NUMBER || '';
 
 const msgData: MessageListInstanceCreateOptions = {
@@ -115,7 +119,7 @@ client.messages.list({}, (err, messages) => {
   console.log('Listing messages using callbacks');
   messages.forEach(function(message){
     console.log(message.sid);
-  });  
+  });
 });
 
 // List messages using promises
@@ -124,7 +128,7 @@ promiseMessage.then(messages => {
   console.log('Listing messages using promises');
   messages.forEach(function(message){
     console.log(message.sid);
-  });  
+  });
 });
 
 const twiml = new twilio.twiml.VoiceResponse();

--- a/lib/webhooks/webhooks.d.ts
+++ b/lib/webhooks/webhooks.d.ts
@@ -1,3 +1,11 @@
+type Request = (
+  protocol: string,
+  host: string,
+  originalUrl: string,
+  rawBody: Body,
+  body: Body,
+) => any;
+
 export interface RequestValidatorOptions {
   /**
    * The full URL (with query string) you used to configure the webhook with Twilio - overrides host/protocol options
@@ -101,7 +109,7 @@ export function validateRequestWithBody(
  * @param opts - options for request validation
  */
 export function validateExpressRequest(
-  request: any,
+  request: Request,
   authToken: string,
   opts?: RequestValidatorOptions
 ): boolean;

--- a/lib/webhooks/webhooks.d.ts
+++ b/lib/webhooks/webhooks.d.ts
@@ -1,11 +1,3 @@
-import { Request, Response } from 'express';
-
-type Middleware = (
-  request: Request,
-  response: Response,
-  next: () => void
-) => any;
-
 export interface RequestValidatorOptions {
   /**
    * The full URL (with query string) you used to configure the webhook with Twilio - overrides host/protocol options
@@ -109,7 +101,7 @@ export function validateRequestWithBody(
  * @param opts - options for request validation
  */
 export function validateExpressRequest(
-  request: Request,
+  request: any,
   authToken: string,
   opts?: RequestValidatorOptions
 ): boolean;
@@ -144,7 +136,7 @@ export function validateExpressRequest(
  *     protocol: 'https'
  * });
  */
-export function webhook(): Middleware;
-export function webhook(opts: WebhookOptions): Middleware;
-export function webhook(authToken: string, opts: WebhookOptions): Middleware;
-export function webhook(opts: WebhookOptions, authToken: string): Middleware;
+export function webhook(): any;
+export function webhook(opts: WebhookOptions): any;
+export function webhook(authToken: string, opts: WebhookOptions): any;
+export function webhook(opts: WebhookOptions, authToken: string): any;

--- a/lib/webhooks/webhooks.d.ts
+++ b/lib/webhooks/webhooks.d.ts
@@ -1,10 +1,13 @@
-type Request = (
-  protocol: string,
-  host: string,
-  originalUrl: string,
-  rawBody: Body,
-  body: Body,
-) => any;
+interface Request {
+  protocol: string;
+  host: header;
+  originalUrl: string;
+  rawBody: Body;
+  body: Body;
+}
+export interface header{
+  [header: string]: string;
+}
 
 export interface RequestValidatorOptions {
   /**

--- a/lib/webhooks/webhooks.d.ts
+++ b/lib/webhooks/webhooks.d.ts
@@ -1,12 +1,12 @@
+import {IncomingHttpHeaders} from "http2";
+
 interface Request {
   protocol: string;
-  host: header;
+  header(name: string): string | undefined;
+  headers: IncomingHttpHeaders;
   originalUrl: string;
-  rawBody: Body;
-  body: Body;
-}
-export interface header{
-  [header: string]: string;
+  rawBody: any;
+  body: any;
 }
 
 export interface RequestValidatorOptions {

--- a/lib/webhooks/webhooks.d.ts
+++ b/lib/webhooks/webhooks.d.ts
@@ -5,7 +5,7 @@ interface Request {
   header(name: string): string | undefined;
   headers: IncomingHttpHeaders;
   originalUrl: string;
-  rawBody: any;
+  rawBody?: any;
   body: any;
 }
 

--- a/package.json
+++ b/package.json
@@ -33,10 +33,6 @@
     "xmlbuilder": "^13.0.2"
   },
   "devDependencies": {
-    "@types/express": "^4.17.7",
-    "@types/lodash": "4.14.112",
-    "@types/node": "9.6.57",
-    "@types/qs": "6.9.4",
     "eslint": "^7.3.1",
     "express": "^4.17.1",
     "jasmine": "~3.5.0",
@@ -47,7 +43,7 @@
     "node-mocks-http": "^1.8.1",
     "nyc": "^15.1.0",
     "proxyquire": "^2.1.3",
-    "typescript": "^2.8.3"
+    "typescript": "^2.9.2"
   },
   "scripts": {
     "test": "npm run test:javascript && npm run test:typescript",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "xmlbuilder": "^13.0.2"
   },
   "devDependencies": {
+    "@types/node": "9.6.57",
     "eslint": "^7.3.1",
     "express": "^4.17.1",
     "jasmine": "~3.5.0",


### PR DESCRIPTION
# Fixes #
@types/express only supports TypeScript 3.5+ versions while we support TypeScript 2.9+. This PR removes all of the @types dependencies as dev dependencies except for @types/node for environment variables.