### PR TITLE
fix: webhook validation with an array parameter

### DIFF
--- a/lib/webhooks/webhooks.js
+++ b/lib/webhooks/webhooks.js
@@ -51,6 +51,22 @@ function removePort(parsedUrl) {
 }
 
 /**
+ Utility function to convert request parameter to a string format
+
+ @param {string} paramName - The request parameter name
+ @param {string|array<string>} paramValue - The request parameter value
+ @returns {string} - Formatted parameter string
+ */
+function toFormUrlEncodedParam(paramName, paramValue) {
+  if (paramValue instanceof Array) {
+    return paramValue
+      .map(val => toFormUrlEncodedParam(paramName, val))
+      .reduce((acc, val) => acc + val, '');
+  }
+  return paramName + paramValue;
+}
+
+/**
  Utility function to get the expected signature for a given request
 
  @param {string} authToken - The auth token, as seen in the Twilio portal
@@ -65,7 +81,7 @@ function getExpectedTwilioSignature(authToken, url, params) {
 
   var data = Object.keys(params)
     .sort()
-    .reduce((acc, key) => acc + key + params[key], url);
+    .reduce((acc, key) => acc + toFormUrlEncodedParam(key, params[key]), url);
 
   return crypto
     .createHmac('sha1', authToken)

--- a/spec/validation.spec.js
+++ b/spec/validation.spec.js
@@ -147,6 +147,14 @@ describe('Request validation', () => {
 
     expect(isValid).toBeTruthy();
   });
+
+  it('should validate request body with an array parameter', () => {
+    const paramsWithArray = { 'MessagingBinding.Address': ['+1325xxxxxxx', '+1415xxxxxxx'] };
+    const signature = '83O6e2vORAoJHUNzJjDWN1jz+BA=';
+    const isValid = validateRequest(token, signature, requestUrl, paramsWithArray);
+
+    expect(isValid).toBeTruthy();
+  });
 });
 
 describe('Request validation middleware', () => {


### PR DESCRIPTION
# Fixes

[Conversations API `onConversationAdd` webhook](https://www.twilio.com/docs/conversations/conversations-webhooks#onconversationadd) `MessagingBinding.Address` parameter can be either `string` or `array<string>` (you can see it underneath the parameters table in the **Note** section). twilio-node library will always fail to validate such webhooks because array parameters are not supported. In this pull-request I added a support for such parameters, but nothing more than that — deeply nested arrays, or object parameters are still not supported and I am not sure If they should be.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
