### PR TITLE
feat: add API response headers to the returned response

### DIFF
--- a/lib/base/RequestClient.js
+++ b/lib/base/RequestClient.js
@@ -108,6 +108,7 @@ RequestClient.prototype.request = function (opts) {
     deferred.resolve({
       statusCode: response.status,
       body: response.data,
+      headers: response.headers,
     });
   }).catch((error) => {
     _this.lastResponse = undefined;


### PR DESCRIPTION
This makes it easier to wrap the client and get access to the response headers.