### PR TITLE
fix: make ttl optional in ClientCapabilityOptions

### DIFF
--- a/lib/jwt/ClientCapability.d.ts
+++ b/lib/jwt/ClientCapability.d.ts
@@ -47,7 +47,7 @@ declare namespace ClientCapability {
   export interface ClientCapabilityOptions {
     accountSid: string;
     authToken: string;
-    ttl: number;
+    ttl?: number;
   }
 }
 


### PR DESCRIPTION
# Fixes #
Resolves #699

Makes ttl optional in ClientCapabilityOptions since the constructor doesn't require a value and provides a default.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
