### PR TITLE
fix: done callback execution when each method limit reached

### DIFF
--- a/lib/rest/accounts/v1/credential/aws.js
+++ b/lib/rest/accounts/v1/credential/aws.js
@@ -134,6 +134,8 @@ AwsList = function AwsList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/accounts/v1/credential/publicKey.js
+++ b/lib/rest/accounts/v1/credential/publicKey.js
@@ -134,6 +134,8 @@ PublicKeyList = function PublicKeyList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account.js
+++ b/lib/rest/api/v2010/account.js
@@ -207,6 +207,8 @@ AccountList = function AccountList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/address.js
+++ b/lib/rest/api/v2010/account/address.js
@@ -227,6 +227,8 @@ AddressList = function AddressList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/address/dependentPhoneNumber.js
+++ b/lib/rest/api/v2010/account/address/dependentPhoneNumber.js
@@ -136,6 +136,8 @@ DependentPhoneNumberList = function DependentPhoneNumberList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/application.js
+++ b/lib/rest/api/v2010/account/application.js
@@ -226,6 +226,8 @@ ApplicationList = function ApplicationList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/authorizedConnectApp.js
+++ b/lib/rest/api/v2010/account/authorizedConnectApp.js
@@ -136,6 +136,8 @@ AuthorizedConnectAppList = function AuthorizedConnectAppList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/availablePhoneNumber.js
+++ b/lib/rest/api/v2010/account/availablePhoneNumber.js
@@ -144,6 +144,8 @@ AvailablePhoneNumberCountryList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/availablePhoneNumber/local.js
+++ b/lib/rest/api/v2010/account/availablePhoneNumber/local.js
@@ -169,6 +169,8 @@ LocalList = function LocalList(version, accountSid, countryCode) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/availablePhoneNumber/machineToMachine.js
+++ b/lib/rest/api/v2010/account/availablePhoneNumber/machineToMachine.js
@@ -170,6 +170,8 @@ MachineToMachineList = function MachineToMachineList(version, accountSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/availablePhoneNumber/mobile.js
+++ b/lib/rest/api/v2010/account/availablePhoneNumber/mobile.js
@@ -169,6 +169,8 @@ MobileList = function MobileList(version, accountSid, countryCode) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/availablePhoneNumber/national.js
+++ b/lib/rest/api/v2010/account/availablePhoneNumber/national.js
@@ -169,6 +169,8 @@ NationalList = function NationalList(version, accountSid, countryCode) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/availablePhoneNumber/sharedCost.js
+++ b/lib/rest/api/v2010/account/availablePhoneNumber/sharedCost.js
@@ -169,6 +169,8 @@ SharedCostList = function SharedCostList(version, accountSid, countryCode) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/availablePhoneNumber/tollFree.js
+++ b/lib/rest/api/v2010/account/availablePhoneNumber/tollFree.js
@@ -169,6 +169,8 @@ TollFreeList = function TollFreeList(version, accountSid, countryCode) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/availablePhoneNumber/voip.js
+++ b/lib/rest/api/v2010/account/availablePhoneNumber/voip.js
@@ -169,6 +169,8 @@ VoipList = function VoipList(version, accountSid, countryCode) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/call.js
+++ b/lib/rest/api/v2010/account/call.js
@@ -303,6 +303,8 @@ CallList = function CallList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/call/event.js
+++ b/lib/rest/api/v2010/account/call/event.js
@@ -133,6 +133,8 @@ EventList = function EventList(version, accountSid, callSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/call/notification.js
+++ b/lib/rest/api/v2010/account/call/notification.js
@@ -142,6 +142,8 @@ NotificationList = function NotificationList(version, accountSid, callSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/call/recording.js
+++ b/lib/rest/api/v2010/account/call/recording.js
@@ -207,6 +207,8 @@ RecordingList = function RecordingList(version, accountSid, callSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/conference.js
+++ b/lib/rest/api/v2010/account/conference.js
@@ -153,6 +153,8 @@ ConferenceList = function ConferenceList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/conference/participant.js
+++ b/lib/rest/api/v2010/account/conference/participant.js
@@ -303,6 +303,8 @@ ParticipantList = function ParticipantList(version, accountSid, conferenceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/conference/recording.js
+++ b/lib/rest/api/v2010/account/conference/recording.js
@@ -145,6 +145,8 @@ RecordingList = function RecordingList(version, accountSid, conferenceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/connectApp.js
+++ b/lib/rest/api/v2010/account/connectApp.js
@@ -134,6 +134,8 @@ ConnectAppList = function ConnectAppList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/incomingPhoneNumber.js
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber.js
@@ -155,6 +155,8 @@ IncomingPhoneNumberList = function IncomingPhoneNumberList(version, accountSid)
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/assignedAddOn.js
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/assignedAddOn.js
@@ -143,6 +143,8 @@ AssignedAddOnList = function AssignedAddOnList(version, accountSid, resourceSid)
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/assignedAddOn/assignedAddOnExtension.js
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/assignedAddOn/assignedAddOnExtension.js
@@ -145,6 +145,8 @@ AssignedAddOnExtensionList = function AssignedAddOnExtensionList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/local.js
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/local.js
@@ -142,6 +142,8 @@ LocalList = function LocalList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/mobile.js
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/mobile.js
@@ -142,6 +142,8 @@ MobileList = function MobileList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/tollFree.js
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/tollFree.js
@@ -142,6 +142,8 @@ TollFreeList = function TollFreeList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/key.js
+++ b/lib/rest/api/v2010/account/key.js
@@ -136,6 +136,8 @@ KeyList = function KeyList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/message.js
+++ b/lib/rest/api/v2010/account/message.js
@@ -237,6 +237,8 @@ MessageList = function MessageList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/message/media.js
+++ b/lib/rest/api/v2010/account/message/media.js
@@ -144,6 +144,8 @@ MediaList = function MediaList(version, accountSid, messageSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/notification.js
+++ b/lib/rest/api/v2010/account/notification.js
@@ -140,6 +140,8 @@ NotificationList = function NotificationList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/outgoingCallerId.js
+++ b/lib/rest/api/v2010/account/outgoingCallerId.js
@@ -139,6 +139,8 @@ OutgoingCallerIdList = function OutgoingCallerIdList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/queue.js
+++ b/lib/rest/api/v2010/account/queue.js
@@ -136,6 +136,8 @@ QueueList = function QueueList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/queue/member.js
+++ b/lib/rest/api/v2010/account/queue/member.js
@@ -136,6 +136,8 @@ MemberList = function MemberList(version, accountSid, queueSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/recording.js
+++ b/lib/rest/api/v2010/account/recording.js
@@ -147,6 +147,8 @@ RecordingList = function RecordingList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/recording/addOnResult.js
+++ b/lib/rest/api/v2010/account/recording/addOnResult.js
@@ -138,6 +138,8 @@ AddOnResultList = function AddOnResultList(version, accountSid, referenceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/recording/addOnResult/payload.js
+++ b/lib/rest/api/v2010/account/recording/addOnResult/payload.js
@@ -144,6 +144,8 @@ PayloadList = function PayloadList(version, accountSid, referenceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/recording/transcription.js
+++ b/lib/rest/api/v2010/account/recording/transcription.js
@@ -138,6 +138,8 @@ TranscriptionList = function TranscriptionList(version, accountSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/shortCode.js
+++ b/lib/rest/api/v2010/account/shortCode.js
@@ -138,6 +138,8 @@ ShortCodeList = function ShortCodeList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/signingKey.js
+++ b/lib/rest/api/v2010/account/signingKey.js
@@ -136,6 +136,8 @@ SigningKeyList = function SigningKeyList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/sip/credentialList.js
+++ b/lib/rest/api/v2010/account/sip/credentialList.js
@@ -137,6 +137,8 @@ CredentialListList = function CredentialListList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/sip/credentialList/credential.js
+++ b/lib/rest/api/v2010/account/sip/credentialList/credential.js
@@ -139,6 +139,8 @@ CredentialList = function CredentialList(version, accountSid, credentialListSid)
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/sip/domain.js
+++ b/lib/rest/api/v2010/account/sip/domain.js
@@ -143,6 +143,8 @@ DomainList = function DomainList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsCredentialListMapping.js
+++ b/lib/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsCredentialListMapping.js
@@ -193,6 +193,8 @@ AuthCallsCredentialListMappingList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsIpAccessControlListMapping.js
+++ b/lib/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsIpAccessControlListMapping.js
@@ -193,6 +193,8 @@ AuthCallsIpAccessControlListMappingList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/sip/domain/authTypes/authRegistrationsMapping/authRegistrationsCredentialListMapping.js
+++ b/lib/rest/api/v2010/account/sip/domain/authTypes/authRegistrationsMapping/authRegistrationsCredentialListMapping.js
@@ -193,6 +193,8 @@ AuthRegistrationsCredentialListMappingList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/sip/domain/credentialListMapping.js
+++ b/lib/rest/api/v2010/account/sip/domain/credentialListMapping.js
@@ -188,6 +188,8 @@ CredentialListMappingList = function CredentialListMappingList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/sip/domain/ipAccessControlListMapping.js
+++ b/lib/rest/api/v2010/account/sip/domain/ipAccessControlListMapping.js
@@ -189,6 +189,8 @@ IpAccessControlListMappingList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/sip/ipAccessControlList.js
+++ b/lib/rest/api/v2010/account/sip/ipAccessControlList.js
@@ -138,6 +138,8 @@ IpAccessControlListList = function IpAccessControlListList(version, accountSid)
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/sip/ipAccessControlList/ipAddress.js
+++ b/lib/rest/api/v2010/account/sip/ipAccessControlList/ipAddress.js
@@ -142,6 +142,8 @@ IpAddressList = function IpAddressList(version, accountSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/transcription.js
+++ b/lib/rest/api/v2010/account/transcription.js
@@ -135,6 +135,8 @@ TranscriptionList = function TranscriptionList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/usage/record.js
+++ b/lib/rest/api/v2010/account/usage/record.js
@@ -164,6 +164,8 @@ RecordList = function RecordList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/usage/record/allTime.js
+++ b/lib/rest/api/v2010/account/usage/record/allTime.js
@@ -145,6 +145,8 @@ AllTimeList = function AllTimeList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/usage/record/daily.js
+++ b/lib/rest/api/v2010/account/usage/record/daily.js
@@ -145,6 +145,8 @@ DailyList = function DailyList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/usage/record/lastMonth.js
+++ b/lib/rest/api/v2010/account/usage/record/lastMonth.js
@@ -145,6 +145,8 @@ LastMonthList = function LastMonthList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/usage/record/monthly.js
+++ b/lib/rest/api/v2010/account/usage/record/monthly.js
@@ -145,6 +145,8 @@ MonthlyList = function MonthlyList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/usage/record/thisMonth.js
+++ b/lib/rest/api/v2010/account/usage/record/thisMonth.js
@@ -145,6 +145,8 @@ ThisMonthList = function ThisMonthList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/usage/record/today.js
+++ b/lib/rest/api/v2010/account/usage/record/today.js
@@ -145,6 +145,8 @@ TodayList = function TodayList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/usage/record/yearly.js
+++ b/lib/rest/api/v2010/account/usage/record/yearly.js
@@ -145,6 +145,8 @@ YearlyList = function YearlyList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/usage/record/yesterday.js
+++ b/lib/rest/api/v2010/account/usage/record/yesterday.js
@@ -145,6 +145,8 @@ YesterdayList = function YesterdayList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/api/v2010/account/usage/trigger.js
+++ b/lib/rest/api/v2010/account/usage/trigger.js
@@ -214,6 +214,8 @@ TriggerList = function TriggerList(version, accountSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/autopilot/v1/assistant.js
+++ b/lib/rest/autopilot/v1/assistant.js
@@ -147,6 +147,8 @@ AssistantList = function AssistantList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/autopilot/v1/assistant/fieldType.js
+++ b/lib/rest/autopilot/v1/assistant/fieldType.js
@@ -141,6 +141,8 @@ FieldTypeList = function FieldTypeList(version, assistantSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/autopilot/v1/assistant/fieldType/fieldValue.js
+++ b/lib/rest/autopilot/v1/assistant/fieldType/fieldValue.js
@@ -144,6 +144,8 @@ FieldValueList = function FieldValueList(version, assistantSid, fieldTypeSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/autopilot/v1/assistant/modelBuild.js
+++ b/lib/rest/autopilot/v1/assistant/modelBuild.js
@@ -140,6 +140,8 @@ ModelBuildList = function ModelBuildList(version, assistantSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/autopilot/v1/assistant/query.js
+++ b/lib/rest/autopilot/v1/assistant/query.js
@@ -147,6 +147,8 @@ QueryList = function QueryList(version, assistantSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/autopilot/v1/assistant/task.js
+++ b/lib/rest/autopilot/v1/assistant/task.js
@@ -145,6 +145,8 @@ TaskList = function TaskList(version, assistantSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/autopilot/v1/assistant/task/field.js
+++ b/lib/rest/autopilot/v1/assistant/task/field.js
@@ -142,6 +142,8 @@ FieldList = function FieldList(version, assistantSid, taskSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/autopilot/v1/assistant/task/sample.js
+++ b/lib/rest/autopilot/v1/assistant/task/sample.js
@@ -143,6 +143,8 @@ SampleList = function SampleList(version, assistantSid, taskSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/autopilot/v1/assistant/webhook.js
+++ b/lib/rest/autopilot/v1/assistant/webhook.js
@@ -140,6 +140,8 @@ WebhookList = function WebhookList(version, assistantSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/bulkexports/v1/export/day.js
+++ b/lib/rest/bulkexports/v1/export/day.js
@@ -136,6 +136,8 @@ DayList = function DayList(version, resourceType) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/bulkexports/v1/export/exportCustomJob.js
+++ b/lib/rest/bulkexports/v1/export/exportCustomJob.js
@@ -133,6 +133,8 @@ ExportCustomJobList = function ExportCustomJobList(version, resourceType) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v1/credential.js
+++ b/lib/rest/chat/v1/credential.js
@@ -135,6 +135,8 @@ CredentialList = function CredentialList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v1/service.js
+++ b/lib/rest/chat/v1/service.js
@@ -180,6 +180,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v1/service/channel.js
+++ b/lib/rest/chat/v1/service/channel.js
@@ -198,6 +198,8 @@ ChannelList = function ChannelList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v1/service/channel/invite.js
+++ b/lib/rest/chat/v1/service/channel/invite.js
@@ -191,6 +191,8 @@ InviteList = function InviteList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v1/service/channel/member.js
+++ b/lib/rest/chat/v1/service/channel/member.js
@@ -191,6 +191,8 @@ MemberList = function MemberList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v1/service/channel/message.js
+++ b/lib/rest/chat/v1/service/channel/message.js
@@ -195,6 +195,8 @@ MessageList = function MessageList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v1/service/role.js
+++ b/lib/rest/chat/v1/service/role.js
@@ -196,6 +196,8 @@ RoleList = function RoleList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v1/service/user.js
+++ b/lib/rest/chat/v1/service/user.js
@@ -194,6 +194,8 @@ UserList = function UserList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v1/service/user/userChannel.js
+++ b/lib/rest/chat/v1/service/user/userChannel.js
@@ -136,6 +136,8 @@ UserChannelList = function UserChannelList(version, serviceSid, userSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/credential.js
+++ b/lib/rest/chat/v2/credential.js
@@ -135,6 +135,8 @@ CredentialList = function CredentialList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service.js
+++ b/lib/rest/chat/v2/service.js
@@ -181,6 +181,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service/binding.js
+++ b/lib/rest/chat/v2/service/binding.js
@@ -141,6 +141,8 @@ BindingList = function BindingList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service/channel.js
+++ b/lib/rest/chat/v2/service/channel.js
@@ -211,6 +211,8 @@ ChannelList = function ChannelList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service/channel/invite.js
+++ b/lib/rest/chat/v2/service/channel/invite.js
@@ -191,6 +191,8 @@ InviteList = function InviteList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service/channel/member.js
+++ b/lib/rest/chat/v2/service/channel/member.js
@@ -212,6 +212,8 @@ MemberList = function MemberList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service/channel/message.js
+++ b/lib/rest/chat/v2/service/channel/message.js
@@ -211,6 +211,8 @@ MessageList = function MessageList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service/channel/webhook.js
+++ b/lib/rest/chat/v2/service/channel/webhook.js
@@ -140,6 +140,8 @@ WebhookList = function WebhookList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service/role.js
+++ b/lib/rest/chat/v2/service/role.js
@@ -196,6 +196,8 @@ RoleList = function RoleList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service/user.js
+++ b/lib/rest/chat/v2/service/user.js
@@ -198,6 +198,8 @@ UserList = function UserList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service/user/userBinding.js
+++ b/lib/rest/chat/v2/service/user/userBinding.js
@@ -141,6 +141,8 @@ UserBindingList = function UserBindingList(version, serviceSid, userSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/chat/v2/service/user/userChannel.js
+++ b/lib/rest/chat/v2/service/user/userChannel.js
@@ -139,6 +139,8 @@ UserChannelList = function UserChannelList(version, serviceSid, userSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/conversation.js
+++ b/lib/rest/conversations/v1/conversation.js
@@ -206,6 +206,8 @@ ConversationList = function ConversationList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/conversation/message.js
+++ b/lib/rest/conversations/v1/conversation/message.js
@@ -205,6 +205,8 @@ MessageList = function MessageList(version, conversationSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/conversation/message/deliveryReceipt.js
+++ b/lib/rest/conversations/v1/conversation/message/deliveryReceipt.js
@@ -139,6 +139,8 @@ DeliveryReceiptList = function DeliveryReceiptList(version, conversationSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/conversation/participant.js
+++ b/lib/rest/conversations/v1/conversation/participant.js
@@ -208,6 +208,8 @@ ParticipantList = function ParticipantList(version, conversationSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/conversation/webhook.js
+++ b/lib/rest/conversations/v1/conversation/webhook.js
@@ -137,6 +137,8 @@ WebhookList = function WebhookList(version, conversationSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/credential.js
+++ b/lib/rest/conversations/v1/credential.js
@@ -197,6 +197,8 @@ CredentialList = function CredentialList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/participantConversation.js
+++ b/lib/rest/conversations/v1/participantConversation.js
@@ -137,6 +137,8 @@ ParticipantConversationList = function ParticipantConversationList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/role.js
+++ b/lib/rest/conversations/v1/role.js
@@ -189,6 +189,8 @@ RoleList = function RoleList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service.js
+++ b/lib/rest/conversations/v1/service.js
@@ -183,6 +183,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service/binding.js
+++ b/lib/rest/conversations/v1/service/binding.js
@@ -141,6 +141,8 @@ BindingList = function BindingList(version, chatServiceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service/conversation.js
+++ b/lib/rest/conversations/v1/service/conversation.js
@@ -213,6 +213,8 @@ ConversationList = function ConversationList(version, chatServiceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service/conversation/message.js
+++ b/lib/rest/conversations/v1/service/conversation/message.js
@@ -209,6 +209,8 @@ MessageList = function MessageList(version, chatServiceSid, conversationSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service/conversation/message/deliveryReceipt.js
+++ b/lib/rest/conversations/v1/service/conversation/message/deliveryReceipt.js
@@ -146,6 +146,8 @@ DeliveryReceiptList = function DeliveryReceiptList(version, chatServiceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service/conversation/participant.js
+++ b/lib/rest/conversations/v1/service/conversation/participant.js
@@ -216,6 +216,8 @@ ParticipantList = function ParticipantList(version, chatServiceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service/conversation/webhook.js
+++ b/lib/rest/conversations/v1/service/conversation/webhook.js
@@ -208,6 +208,8 @@ WebhookList = function WebhookList(version, chatServiceSid, conversationSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service/participantConversation.js
+++ b/lib/rest/conversations/v1/service/participantConversation.js
@@ -140,6 +140,8 @@ ParticipantConversationList = function ParticipantConversationList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service/role.js
+++ b/lib/rest/conversations/v1/service/role.js
@@ -196,6 +196,8 @@ RoleList = function RoleList(version, chatServiceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service/user.js
+++ b/lib/rest/conversations/v1/service/user.js
@@ -199,6 +199,8 @@ UserList = function UserList(version, chatServiceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/service/user/userConversation.js
+++ b/lib/rest/conversations/v1/service/user/userConversation.js
@@ -140,6 +140,8 @@ UserConversationList = function UserConversationList(version, chatServiceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/user.js
+++ b/lib/rest/conversations/v1/user.js
@@ -192,6 +192,8 @@ UserList = function UserList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/conversations/v1/user/userConversation.js
+++ b/lib/rest/conversations/v1/user/userConversation.js
@@ -136,6 +136,8 @@ UserConversationList = function UserConversationList(version, userSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/events/v1/eventType.js
+++ b/lib/rest/events/v1/eventType.js
@@ -138,6 +138,8 @@ EventTypeList = function EventTypeList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/events/v1/schema/version.js
+++ b/lib/rest/events/v1/schema/version.js
@@ -138,6 +138,8 @@ SchemaVersionList = function SchemaVersionList(version, id) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/events/v1/sink.js
+++ b/lib/rest/events/v1/sink.js
@@ -197,6 +197,8 @@ SinkList = function SinkList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/events/v1/subscription.js
+++ b/lib/rest/events/v1/subscription.js
@@ -141,6 +141,8 @@ SubscriptionList = function SubscriptionList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/events/v1/subscription/subscribedEvent.js
+++ b/lib/rest/events/v1/subscription/subscribedEvent.js
@@ -138,6 +138,8 @@ SubscribedEventList = function SubscribedEventList(version, subscriptionSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/fax/v1/fax.js
+++ b/lib/rest/fax/v1/fax.js
@@ -146,6 +146,8 @@ FaxList = function FaxList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/fax/v1/fax/faxMedia.js
+++ b/lib/rest/fax/v1/fax/faxMedia.js
@@ -139,6 +139,8 @@ FaxMediaList = function FaxMediaList(version, faxSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/flexApi/v1/channel.js
+++ b/lib/rest/flexApi/v1/channel.js
@@ -135,6 +135,8 @@ ChannelList = function ChannelList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/flexApi/v1/flexFlow.js
+++ b/lib/rest/flexApi/v1/flexFlow.js
@@ -137,6 +137,8 @@ FlexFlowList = function FlexFlowList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/flexApi/v1/webChannel.js
+++ b/lib/rest/flexApi/v1/webChannel.js
@@ -134,6 +134,8 @@ WebChannelList = function WebChannelList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/insights/v1/call/event.js
+++ b/lib/rest/insights/v1/call/event.js
@@ -137,6 +137,8 @@ EventList = function EventList(version, callSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/insights/v1/call/metric.js
+++ b/lib/rest/insights/v1/call/metric.js
@@ -138,6 +138,8 @@ MetricList = function MetricList(version, callSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/insights/v1/callSummaries.js
+++ b/lib/rest/insights/v1/callSummaries.js
@@ -153,6 +153,8 @@ CallSummariesList = function CallSummariesList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/insights/v1/room.js
+++ b/lib/rest/insights/v1/room.js
@@ -146,6 +146,8 @@ RoomList = function RoomList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/insights/v1/room/participant.js
+++ b/lib/rest/insights/v1/room/participant.js
@@ -138,6 +138,8 @@ ParticipantList = function ParticipantList(version, roomSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v1/credential.js
+++ b/lib/rest/ipMessaging/v1/credential.js
@@ -135,6 +135,8 @@ CredentialList = function CredentialList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v1/service.js
+++ b/lib/rest/ipMessaging/v1/service.js
@@ -180,6 +180,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v1/service/channel.js
+++ b/lib/rest/ipMessaging/v1/service/channel.js
@@ -194,6 +194,8 @@ ChannelList = function ChannelList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v1/service/channel/invite.js
+++ b/lib/rest/ipMessaging/v1/service/channel/invite.js
@@ -188,6 +188,8 @@ InviteList = function InviteList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v1/service/channel/member.js
+++ b/lib/rest/ipMessaging/v1/service/channel/member.js
@@ -188,6 +188,8 @@ MemberList = function MemberList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v1/service/channel/message.js
+++ b/lib/rest/ipMessaging/v1/service/channel/message.js
@@ -191,6 +191,8 @@ MessageList = function MessageList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v1/service/role.js
+++ b/lib/rest/ipMessaging/v1/service/role.js
@@ -195,6 +195,8 @@ RoleList = function RoleList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v1/service/user.js
+++ b/lib/rest/ipMessaging/v1/service/user.js
@@ -191,6 +191,8 @@ UserList = function UserList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v1/service/user/userChannel.js
+++ b/lib/rest/ipMessaging/v1/service/user/userChannel.js
@@ -135,6 +135,8 @@ UserChannelList = function UserChannelList(version, serviceSid, userSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/credential.js
+++ b/lib/rest/ipMessaging/v2/credential.js
@@ -135,6 +135,8 @@ CredentialList = function CredentialList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service.js
+++ b/lib/rest/ipMessaging/v2/service.js
@@ -181,6 +181,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service/binding.js
+++ b/lib/rest/ipMessaging/v2/service/binding.js
@@ -138,6 +138,8 @@ BindingList = function BindingList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service/channel.js
+++ b/lib/rest/ipMessaging/v2/service/channel.js
@@ -204,6 +204,8 @@ ChannelList = function ChannelList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service/channel/invite.js
+++ b/lib/rest/ipMessaging/v2/service/channel/invite.js
@@ -188,6 +188,8 @@ InviteList = function InviteList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service/channel/member.js
+++ b/lib/rest/ipMessaging/v2/service/channel/member.js
@@ -205,6 +205,8 @@ MemberList = function MemberList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service/channel/message.js
+++ b/lib/rest/ipMessaging/v2/service/channel/message.js
@@ -203,6 +203,8 @@ MessageList = function MessageList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service/channel/webhook.js
+++ b/lib/rest/ipMessaging/v2/service/channel/webhook.js
@@ -138,6 +138,8 @@ WebhookList = function WebhookList(version, serviceSid, channelSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service/role.js
+++ b/lib/rest/ipMessaging/v2/service/role.js
@@ -195,6 +195,8 @@ RoleList = function RoleList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service/user.js
+++ b/lib/rest/ipMessaging/v2/service/user.js
@@ -195,6 +195,8 @@ UserList = function UserList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service/user/userBinding.js
+++ b/lib/rest/ipMessaging/v2/service/user/userBinding.js
@@ -139,6 +139,8 @@ UserBindingList = function UserBindingList(version, serviceSid, userSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/ipMessaging/v2/service/user/userChannel.js
+++ b/lib/rest/ipMessaging/v2/service/user/userChannel.js
@@ -138,6 +138,8 @@ UserChannelList = function UserChannelList(version, serviceSid, userSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/media/v1/mediaProcessor.js
+++ b/lib/rest/media/v1/mediaProcessor.js
@@ -196,6 +196,8 @@ MediaProcessorList = function MediaProcessorList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/media/v1/playerStreamer.js
+++ b/lib/rest/media/v1/playerStreamer.js
@@ -189,6 +189,8 @@ PlayerStreamerList = function PlayerStreamerList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/messaging/v1/brandRegistration.js
+++ b/lib/rest/messaging/v1/brandRegistration.js
@@ -140,6 +140,8 @@ BrandRegistrationList = function BrandRegistrationList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/messaging/v1/brandRegistration/brandVetting.js
+++ b/lib/rest/messaging/v1/brandRegistration/brandVetting.js
@@ -192,6 +192,8 @@ BrandVettingList = function BrandVettingList(version, brandSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/messaging/v1/service.js
+++ b/lib/rest/messaging/v1/service.js
@@ -231,6 +231,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/messaging/v1/service/alphaSender.js
+++ b/lib/rest/messaging/v1/service/alphaSender.js
@@ -186,6 +186,8 @@ AlphaSenderList = function AlphaSenderList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/messaging/v1/service/phoneNumber.js
+++ b/lib/rest/messaging/v1/service/phoneNumber.js
@@ -187,6 +187,8 @@ PhoneNumberList = function PhoneNumberList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/messaging/v1/service/shortCode.js
+++ b/lib/rest/messaging/v1/service/shortCode.js
@@ -187,6 +187,8 @@ ShortCodeList = function ShortCodeList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/messaging/v1/service/usAppToPerson.js
+++ b/lib/rest/messaging/v1/service/usAppToPerson.js
@@ -217,6 +217,8 @@ UsAppToPersonList = function UsAppToPersonList(version, messagingServiceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/monitor/v1/alert.js
+++ b/lib/rest/monitor/v1/alert.js
@@ -140,6 +140,8 @@ AlertList = function AlertList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/monitor/v1/event.js
+++ b/lib/rest/monitor/v1/event.js
@@ -145,6 +145,8 @@ EventList = function EventList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/notify/v1/credential.js
+++ b/lib/rest/notify/v1/credential.js
@@ -138,6 +138,8 @@ CredentialList = function CredentialList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/notify/v1/service.js
+++ b/lib/rest/notify/v1/service.js
@@ -218,6 +218,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/notify/v1/service/binding.js
+++ b/lib/rest/notify/v1/service/binding.js
@@ -219,6 +219,8 @@ BindingList = function BindingList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/numbers/v2/regulatoryCompliance/bundle.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/bundle.js
@@ -207,6 +207,8 @@ BundleList = function BundleList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/numbers/v2/regulatoryCompliance/bundle/evaluation.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/bundle/evaluation.js
@@ -171,6 +171,8 @@ EvaluationList = function EvaluationList(version, bundleSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/numbers/v2/regulatoryCompliance/bundle/itemAssignment.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/bundle/itemAssignment.js
@@ -183,6 +183,8 @@ ItemAssignmentList = function ItemAssignmentList(version, bundleSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/numbers/v2/regulatoryCompliance/endUser.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/endUser.js
@@ -188,6 +188,8 @@ EndUserList = function EndUserList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/numbers/v2/regulatoryCompliance/endUserType.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/endUserType.js
@@ -132,6 +132,8 @@ EndUserTypeList = function EndUserTypeList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/numbers/v2/regulatoryCompliance/regulation.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/regulation.js
@@ -137,6 +137,8 @@ RegulationList = function RegulationList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/numbers/v2/regulatoryCompliance/supportingDocument.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/supportingDocument.js
@@ -188,6 +188,8 @@ SupportingDocumentList = function SupportingDocumentList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/numbers/v2/regulatoryCompliance/supportingDocumentType.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/supportingDocumentType.js
@@ -132,6 +132,8 @@ SupportingDocumentTypeList = function SupportingDocumentTypeList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/bulk_exports/export/day.js
+++ b/lib/rest/preview/bulk_exports/export/day.js
@@ -140,6 +140,8 @@ DayList = function DayList(version, resourceType) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/bulk_exports/export/exportCustomJob.js
+++ b/lib/rest/preview/bulk_exports/export/exportCustomJob.js
@@ -137,6 +137,8 @@ ExportCustomJobList = function ExportCustomJobList(version, resourceType) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/deployed_devices/fleet.js
+++ b/lib/rest/preview/deployed_devices/fleet.js
@@ -184,6 +184,8 @@ FleetList = function FleetList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/deployed_devices/fleet/certificate.js
+++ b/lib/rest/preview/deployed_devices/fleet/certificate.js
@@ -196,6 +196,8 @@ CertificateList = function CertificateList(version, fleetSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/deployed_devices/fleet/deployment.js
+++ b/lib/rest/preview/deployed_devices/fleet/deployment.js
@@ -191,6 +191,8 @@ DeploymentList = function DeploymentList(version, fleetSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/deployed_devices/fleet/device.js
+++ b/lib/rest/preview/deployed_devices/fleet/device.js
@@ -199,6 +199,8 @@ DeviceList = function DeviceList(version, fleetSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/deployed_devices/fleet/key.js
+++ b/lib/rest/preview/deployed_devices/fleet/key.js
@@ -193,6 +193,8 @@ KeyList = function KeyList(version, fleetSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/hosted_numbers/authorizationDocument.js
+++ b/lib/rest/preview/hosted_numbers/authorizationDocument.js
@@ -144,6 +144,8 @@ AuthorizationDocumentList = function AuthorizationDocumentList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/hosted_numbers/authorizationDocument/dependentHostedNumberOrder.js
+++ b/lib/rest/preview/hosted_numbers/authorizationDocument/dependentHostedNumberOrder.js
@@ -147,6 +147,8 @@ DependentHostedNumberOrderList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/hosted_numbers/hostedNumberOrder.js
+++ b/lib/rest/preview/hosted_numbers/hostedNumberOrder.js
@@ -147,6 +147,8 @@ HostedNumberOrderList = function HostedNumberOrderList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/marketplace/availableAddOn.js
+++ b/lib/rest/preview/marketplace/availableAddOn.js
@@ -138,6 +138,8 @@ AvailableAddOnList = function AvailableAddOnList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/marketplace/availableAddOn/availableAddOnExtension.js
+++ b/lib/rest/preview/marketplace/availableAddOn/availableAddOnExtension.js
@@ -139,6 +139,8 @@ AvailableAddOnExtensionList = function AvailableAddOnExtensionList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/marketplace/installedAddOn.js
+++ b/lib/rest/preview/marketplace/installedAddOn.js
@@ -198,6 +198,8 @@ InstalledAddOnList = function InstalledAddOnList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/marketplace/installedAddOn/installedAddOnExtension.js
+++ b/lib/rest/preview/marketplace/installedAddOn/installedAddOnExtension.js
@@ -140,6 +140,8 @@ InstalledAddOnExtensionList = function InstalledAddOnExtensionList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/sync/service.js
+++ b/lib/rest/preview/sync/service.js
@@ -192,6 +192,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/sync/service/document.js
+++ b/lib/rest/preview/sync/service/document.js
@@ -192,6 +192,8 @@ DocumentList = function DocumentList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/sync/service/document/documentPermission.js
+++ b/lib/rest/preview/sync/service/document/documentPermission.js
@@ -141,6 +141,8 @@ DocumentPermissionList = function DocumentPermissionList(version, serviceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/sync/service/syncList.js
+++ b/lib/rest/preview/sync/service/syncList.js
@@ -188,6 +188,8 @@ SyncListList = function SyncListList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/sync/service/syncList/syncListItem.js
+++ b/lib/rest/preview/sync/service/syncList/syncListItem.js
@@ -193,6 +193,8 @@ SyncListItemList = function SyncListItemList(version, serviceSid, listSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/sync/service/syncList/syncListPermission.js
+++ b/lib/rest/preview/sync/service/syncList/syncListPermission.js
@@ -141,6 +141,8 @@ SyncListPermissionList = function SyncListPermissionList(version, serviceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/sync/service/syncMap.js
+++ b/lib/rest/preview/sync/service/syncMap.js
@@ -188,6 +188,8 @@ SyncMapList = function SyncMapList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/sync/service/syncMap/syncMapItem.js
+++ b/lib/rest/preview/sync/service/syncMap/syncMapItem.js
@@ -197,6 +197,8 @@ SyncMapItemList = function SyncMapItemList(version, serviceSid, mapSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/sync/service/syncMap/syncMapPermission.js
+++ b/lib/rest/preview/sync/service/syncMap/syncMapPermission.js
@@ -141,6 +141,8 @@ SyncMapPermissionList = function SyncMapPermissionList(version, serviceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/understand/assistant.js
+++ b/lib/rest/preview/understand/assistant.js
@@ -149,6 +149,8 @@ AssistantList = function AssistantList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/understand/assistant/fieldType.js
+++ b/lib/rest/preview/understand/assistant/fieldType.js
@@ -140,6 +140,8 @@ FieldTypeList = function FieldTypeList(version, assistantSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/understand/assistant/fieldType/fieldValue.js
+++ b/lib/rest/preview/understand/assistant/fieldType/fieldValue.js
@@ -143,6 +143,8 @@ FieldValueList = function FieldValueList(version, assistantSid, fieldTypeSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/understand/assistant/modelBuild.js
+++ b/lib/rest/preview/understand/assistant/modelBuild.js
@@ -139,6 +139,8 @@ ModelBuildList = function ModelBuildList(version, assistantSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/understand/assistant/query.js
+++ b/lib/rest/preview/understand/assistant/query.js
@@ -144,6 +144,8 @@ QueryList = function QueryList(version, assistantSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/understand/assistant/task.js
+++ b/lib/rest/preview/understand/assistant/task.js
@@ -144,6 +144,8 @@ TaskList = function TaskList(version, assistantSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/understand/assistant/task/field.js
+++ b/lib/rest/preview/understand/assistant/task/field.js
@@ -140,6 +140,8 @@ FieldList = function FieldList(version, assistantSid, taskSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/understand/assistant/task/sample.js
+++ b/lib/rest/preview/understand/assistant/task/sample.js
@@ -141,6 +141,8 @@ SampleList = function SampleList(version, assistantSid, taskSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/wireless/command.js
+++ b/lib/rest/preview/wireless/command.js
@@ -142,6 +142,8 @@ CommandList = function CommandList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/wireless/ratePlan.js
+++ b/lib/rest/preview/wireless/ratePlan.js
@@ -139,6 +139,8 @@ RatePlanList = function RatePlanList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/preview/wireless/sim.js
+++ b/lib/rest/preview/wireless/sim.js
@@ -144,6 +144,8 @@ SimList = function SimList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/pricing/v1/messaging/country.js
+++ b/lib/rest/pricing/v1/messaging/country.js
@@ -132,6 +132,8 @@ CountryList = function CountryList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/pricing/v1/phoneNumber/country.js
+++ b/lib/rest/pricing/v1/phoneNumber/country.js
@@ -132,6 +132,8 @@ CountryList = function CountryList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/pricing/v1/voice/country.js
+++ b/lib/rest/pricing/v1/voice/country.js
@@ -132,6 +132,8 @@ CountryList = function CountryList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/pricing/v2/country.js
+++ b/lib/rest/pricing/v2/country.js
@@ -132,6 +132,8 @@ CountryList = function CountryList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/pricing/v2/voice/country.js
+++ b/lib/rest/pricing/v2/voice/country.js
@@ -132,6 +132,8 @@ CountryList = function CountryList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/proxy/v1/service.js
+++ b/lib/rest/proxy/v1/service.js
@@ -140,6 +140,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/proxy/v1/service/phoneNumber.js
+++ b/lib/rest/proxy/v1/service/phoneNumber.js
@@ -193,6 +193,8 @@ PhoneNumberList = function PhoneNumberList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/proxy/v1/service/session.js
+++ b/lib/rest/proxy/v1/service/session.js
@@ -141,6 +141,8 @@ SessionList = function SessionList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/proxy/v1/service/session/interaction.js
+++ b/lib/rest/proxy/v1/service/session/interaction.js
@@ -139,6 +139,8 @@ InteractionList = function InteractionList(version, serviceSid, sessionSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/proxy/v1/service/session/participant.js
+++ b/lib/rest/proxy/v1/service/session/participant.js
@@ -143,6 +143,8 @@ ParticipantList = function ParticipantList(version, serviceSid, sessionSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/proxy/v1/service/session/participant/messageInteraction.js
+++ b/lib/rest/proxy/v1/service/session/participant/messageInteraction.js
@@ -200,6 +200,8 @@ MessageInteractionList = function MessageInteractionList(version, serviceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/proxy/v1/service/shortCode.js
+++ b/lib/rest/proxy/v1/service/shortCode.js
@@ -186,6 +186,8 @@ ShortCodeList = function ShortCodeList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/serverless/v1/service.js
+++ b/lib/rest/serverless/v1/service.js
@@ -142,6 +142,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/serverless/v1/service/asset.js
+++ b/lib/rest/serverless/v1/service/asset.js
@@ -140,6 +140,8 @@ AssetList = function AssetList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/serverless/v1/service/asset/assetVersion.js
+++ b/lib/rest/serverless/v1/service/asset/assetVersion.js
@@ -141,6 +141,8 @@ AssetVersionList = function AssetVersionList(version, serviceSid, assetSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/serverless/v1/service/build.js
+++ b/lib/rest/serverless/v1/service/build.js
@@ -141,6 +141,8 @@ BuildList = function BuildList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/serverless/v1/service/environment.js
+++ b/lib/rest/serverless/v1/service/environment.js
@@ -142,6 +142,8 @@ EnvironmentList = function EnvironmentList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/serverless/v1/service/environment/deployment.js
+++ b/lib/rest/serverless/v1/service/environment/deployment.js
@@ -140,6 +140,8 @@ DeploymentList = function DeploymentList(version, serviceSid, environmentSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/serverless/v1/service/environment/log.js
+++ b/lib/rest/serverless/v1/service/environment/log.js
@@ -149,6 +149,8 @@ LogList = function LogList(version, serviceSid, environmentSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/serverless/v1/service/environment/variable.js
+++ b/lib/rest/serverless/v1/service/environment/variable.js
@@ -141,6 +141,8 @@ VariableList = function VariableList(version, serviceSid, environmentSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/serverless/v1/service/function.js
+++ b/lib/rest/serverless/v1/service/function.js
@@ -141,6 +141,8 @@ FunctionList = function FunctionList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/serverless/v1/service/function/functionVersion.js
+++ b/lib/rest/serverless/v1/service/function/functionVersion.js
@@ -144,6 +144,8 @@ FunctionVersionList = function FunctionVersionList(version, serviceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/studio/v1/flow.js
+++ b/lib/rest/studio/v1/flow.js
@@ -136,6 +136,8 @@ FlowList = function FlowList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/studio/v1/flow/engagement.js
+++ b/lib/rest/studio/v1/flow/engagement.js
@@ -139,6 +139,8 @@ EngagementList = function EngagementList(version, flowSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/studio/v1/flow/engagement/step.js
+++ b/lib/rest/studio/v1/flow/engagement/step.js
@@ -137,6 +137,8 @@ StepList = function StepList(version, flowSid, engagementSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/studio/v1/flow/execution.js
+++ b/lib/rest/studio/v1/flow/execution.js
@@ -143,6 +143,8 @@ ExecutionList = function ExecutionList(version, flowSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/studio/v1/flow/execution/executionStep.js
+++ b/lib/rest/studio/v1/flow/execution/executionStep.js
@@ -138,6 +138,8 @@ ExecutionStepList = function ExecutionStepList(version, flowSid, executionSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/studio/v2/flow.js
+++ b/lib/rest/studio/v2/flow.js
@@ -196,6 +196,8 @@ FlowList = function FlowList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/studio/v2/flow/execution.js
+++ b/lib/rest/studio/v2/flow/execution.js
@@ -143,6 +143,8 @@ ExecutionList = function ExecutionList(version, flowSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/studio/v2/flow/execution/executionStep.js
+++ b/lib/rest/studio/v2/flow/execution/executionStep.js
@@ -138,6 +138,8 @@ ExecutionStepList = function ExecutionStepList(version, flowSid, executionSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/studio/v2/flow/flowRevision.js
+++ b/lib/rest/studio/v2/flow/flowRevision.js
@@ -135,6 +135,8 @@ FlowRevisionList = function FlowRevisionList(version, sid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/supersim/v1/command.js
+++ b/lib/rest/supersim/v1/command.js
@@ -197,6 +197,8 @@ CommandList = function CommandList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/supersim/v1/fleet.js
+++ b/lib/rest/supersim/v1/fleet.js
@@ -212,6 +212,8 @@ FleetList = function FleetList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/supersim/v1/ipCommand.js
+++ b/lib/rest/supersim/v1/ipCommand.js
@@ -208,6 +208,8 @@ IpCommandList = function IpCommandList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/supersim/v1/network.js
+++ b/lib/rest/supersim/v1/network.js
@@ -139,6 +139,8 @@ NetworkList = function NetworkList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/supersim/v1/networkAccessProfile.js
+++ b/lib/rest/supersim/v1/networkAccessProfile.js
@@ -187,6 +187,8 @@ NetworkAccessProfileList = function NetworkAccessProfileList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/supersim/v1/networkAccessProfile/networkAccessProfileNetwork.js
+++ b/lib/rest/supersim/v1/networkAccessProfile/networkAccessProfileNetwork.js
@@ -140,6 +140,8 @@ NetworkAccessProfileNetworkList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/supersim/v1/sim.js
+++ b/lib/rest/supersim/v1/sim.js
@@ -194,6 +194,8 @@ SimList = function SimList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/supersim/v1/sim/billingPeriod.js
+++ b/lib/rest/supersim/v1/sim/billingPeriod.js
@@ -134,6 +134,8 @@ BillingPeriodList = function BillingPeriodList(version, simSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/supersim/v1/smsCommand.js
+++ b/lib/rest/supersim/v1/smsCommand.js
@@ -198,6 +198,8 @@ SmsCommandList = function SmsCommandList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/supersim/v1/usageRecord.js
+++ b/lib/rest/supersim/v1/usageRecord.js
@@ -153,6 +153,8 @@ UsageRecordList = function UsageRecordList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/sync/v1/service.js
+++ b/lib/rest/sync/v1/service.js
@@ -201,6 +201,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/sync/v1/service/document.js
+++ b/lib/rest/sync/v1/service/document.js
@@ -194,6 +194,8 @@ DocumentList = function DocumentList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/sync/v1/service/document/documentPermission.js
+++ b/lib/rest/sync/v1/service/document/documentPermission.js
@@ -138,6 +138,8 @@ DocumentPermissionList = function DocumentPermissionList(version, serviceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/sync/v1/service/syncList.js
+++ b/lib/rest/sync/v1/service/syncList.js
@@ -193,6 +193,8 @@ SyncListList = function SyncListList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/sync/v1/service/syncList/syncListItem.js
+++ b/lib/rest/sync/v1/service/syncList/syncListItem.js
@@ -204,6 +204,8 @@ SyncListItemList = function SyncListItemList(version, serviceSid, listSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/sync/v1/service/syncList/syncListPermission.js
+++ b/lib/rest/sync/v1/service/syncList/syncListPermission.js
@@ -139,6 +139,8 @@ SyncListPermissionList = function SyncListPermissionList(version, serviceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/sync/v1/service/syncMap.js
+++ b/lib/rest/sync/v1/service/syncMap.js
@@ -193,6 +193,8 @@ SyncMapList = function SyncMapList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/sync/v1/service/syncMap/syncMapItem.js
+++ b/lib/rest/sync/v1/service/syncMap/syncMapItem.js
@@ -209,6 +209,8 @@ SyncMapItemList = function SyncMapItemList(version, serviceSid, mapSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/sync/v1/service/syncMap/syncMapPermission.js
+++ b/lib/rest/sync/v1/service/syncMap/syncMapPermission.js
@@ -138,6 +138,8 @@ SyncMapPermissionList = function SyncMapPermissionList(version, serviceSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/sync/v1/service/syncStream.js
+++ b/lib/rest/sync/v1/service/syncStream.js
@@ -186,6 +186,8 @@ SyncStreamList = function SyncStreamList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace.js
+++ b/lib/rest/taskrouter/v1/workspace.js
@@ -150,6 +150,8 @@ WorkspaceList = function WorkspaceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/activity.js
+++ b/lib/rest/taskrouter/v1/workspace/activity.js
@@ -141,6 +141,8 @@ ActivityList = function ActivityList(version, workspaceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/event.js
+++ b/lib/rest/taskrouter/v1/workspace/event.js
@@ -151,6 +151,8 @@ EventList = function EventList(version, workspaceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/task.js
+++ b/lib/rest/taskrouter/v1/workspace/task.js
@@ -152,6 +152,8 @@ TaskList = function TaskList(version, workspaceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/task/reservation.js
+++ b/lib/rest/taskrouter/v1/workspace/task/reservation.js
@@ -141,6 +141,8 @@ ReservationList = function ReservationList(version, workspaceSid, taskSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/taskChannel.js
+++ b/lib/rest/taskrouter/v1/workspace/taskChannel.js
@@ -137,6 +137,8 @@ TaskChannelList = function TaskChannelList(version, workspaceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/taskQueue.js
+++ b/lib/rest/taskrouter/v1/workspace/taskQueue.js
@@ -154,6 +154,8 @@ TaskQueueList = function TaskQueueList(version, workspaceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueuesStatistics.js
+++ b/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueuesStatistics.js
@@ -148,6 +148,8 @@ TaskQueuesStatisticsList = function TaskQueuesStatisticsList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/worker.js
+++ b/lib/rest/taskrouter/v1/workspace/worker.js
@@ -164,6 +164,8 @@ WorkerList = function WorkerList(version, workspaceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/worker/reservation.js
+++ b/lib/rest/taskrouter/v1/workspace/worker/reservation.js
@@ -141,6 +141,8 @@ ReservationList = function ReservationList(version, workspaceSid, workerSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/worker/workerChannel.js
+++ b/lib/rest/taskrouter/v1/workspace/worker/workerChannel.js
@@ -141,6 +141,8 @@ WorkerChannelList = function WorkerChannelList(version, workspaceSid, workerSid)
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/taskrouter/v1/workspace/workflow.js
+++ b/lib/rest/taskrouter/v1/workspace/workflow.js
@@ -144,6 +144,8 @@ WorkflowList = function WorkflowList(version, workspaceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trunking/v1/trunk.js
+++ b/lib/rest/trunking/v1/trunk.js
@@ -205,6 +205,8 @@ TrunkList = function TrunkList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trunking/v1/trunk/credentialList.js
+++ b/lib/rest/trunking/v1/trunk/credentialList.js
@@ -184,6 +184,8 @@ CredentialListList = function CredentialListList(version, trunkSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trunking/v1/trunk/ipAccessControlList.js
+++ b/lib/rest/trunking/v1/trunk/ipAccessControlList.js
@@ -183,6 +183,8 @@ IpAccessControlListList = function IpAccessControlListList(version, trunkSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trunking/v1/trunk/originationUrl.js
+++ b/lib/rest/trunking/v1/trunk/originationUrl.js
@@ -207,6 +207,8 @@ OriginationUrlList = function OriginationUrlList(version, trunkSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trunking/v1/trunk/phoneNumber.js
+++ b/lib/rest/trunking/v1/trunk/phoneNumber.js
@@ -184,6 +184,8 @@ PhoneNumberList = function PhoneNumberList(version, trunkSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/customerProfiles.js
+++ b/lib/rest/trusthub/v1/customerProfiles.js
@@ -203,6 +203,8 @@ CustomerProfilesList = function CustomerProfilesList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/customerProfiles/customerProfilesChannelEndpointAssignment.js
+++ b/lib/rest/trusthub/v1/customerProfiles/customerProfilesChannelEndpointAssignment.js
@@ -198,6 +198,8 @@ CustomerProfilesChannelEndpointAssignmentList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/customerProfiles/customerProfilesEntityAssignments.js
+++ b/lib/rest/trusthub/v1/customerProfiles/customerProfilesEntityAssignments.js
@@ -186,6 +186,8 @@ CustomerProfilesEntityAssignmentsList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/customerProfiles/customerProfilesEvaluations.js
+++ b/lib/rest/trusthub/v1/customerProfiles/customerProfilesEvaluations.js
@@ -185,6 +185,8 @@ CustomerProfilesEvaluationsList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/endUser.js
+++ b/lib/rest/trusthub/v1/endUser.js
@@ -188,6 +188,8 @@ EndUserList = function EndUserList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/endUserType.js
+++ b/lib/rest/trusthub/v1/endUserType.js
@@ -132,6 +132,8 @@ EndUserTypeList = function EndUserTypeList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/policies.js
+++ b/lib/rest/trusthub/v1/policies.js
@@ -132,6 +132,8 @@ PoliciesList = function PoliciesList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/supportingDocument.js
+++ b/lib/rest/trusthub/v1/supportingDocument.js
@@ -188,6 +188,8 @@ SupportingDocumentList = function SupportingDocumentList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/supportingDocumentType.js
+++ b/lib/rest/trusthub/v1/supportingDocumentType.js
@@ -132,6 +132,8 @@ SupportingDocumentTypeList = function SupportingDocumentTypeList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/trustProducts.js
+++ b/lib/rest/trusthub/v1/trustProducts.js
@@ -203,6 +203,8 @@ TrustProductsList = function TrustProductsList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/trustProducts/trustProductsChannelEndpointAssignment.js
+++ b/lib/rest/trusthub/v1/trustProducts/trustProductsChannelEndpointAssignment.js
@@ -196,6 +196,8 @@ TrustProductsChannelEndpointAssignmentList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/trustProducts/trustProductsEntityAssignments.js
+++ b/lib/rest/trusthub/v1/trustProducts/trustProductsEntityAssignments.js
@@ -186,6 +186,8 @@ TrustProductsEntityAssignmentsList = function
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/trusthub/v1/trustProducts/trustProductsEvaluations.js
+++ b/lib/rest/trusthub/v1/trustProducts/trustProductsEvaluations.js
@@ -183,6 +183,8 @@ TrustProductsEvaluationsList = function TrustProductsEvaluationsList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/verify/v2/service.js
+++ b/lib/rest/verify/v2/service.js
@@ -236,6 +236,8 @@ ServiceList = function ServiceList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/verify/v2/service/entity.js
+++ b/lib/rest/verify/v2/service/entity.js
@@ -188,6 +188,8 @@ EntityList = function EntityList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/verify/v2/service/entity/challenge.js
+++ b/lib/rest/verify/v2/service/entity/challenge.js
@@ -210,6 +210,8 @@ ChallengeList = function ChallengeList(version, serviceSid, identity) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/verify/v2/service/entity/factor.js
+++ b/lib/rest/verify/v2/service/entity/factor.js
@@ -139,6 +139,8 @@ FactorList = function FactorList(version, serviceSid, identity) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/verify/v2/service/messagingConfiguration.js
+++ b/lib/rest/verify/v2/service/messagingConfiguration.js
@@ -193,6 +193,8 @@ MessagingConfigurationList = function MessagingConfigurationList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/verify/v2/service/rateLimit.js
+++ b/lib/rest/verify/v2/service/rateLimit.js
@@ -189,6 +189,8 @@ RateLimitList = function RateLimitList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/verify/v2/service/rateLimit/bucket.js
+++ b/lib/rest/verify/v2/service/rateLimit/bucket.js
@@ -190,6 +190,8 @@ BucketList = function BucketList(version, serviceSid, rateLimitSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/verify/v2/service/webhook.js
+++ b/lib/rest/verify/v2/service/webhook.js
@@ -204,6 +204,8 @@ WebhookList = function WebhookList(version, serviceSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/verify/v2/template.js
+++ b/lib/rest/verify/v2/template.js
@@ -132,6 +132,8 @@ TemplateList = function TemplateList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/verify/v2/verificationAttempt.js
+++ b/lib/rest/verify/v2/verificationAttempt.js
@@ -140,6 +140,8 @@ VerificationAttemptList = function VerificationAttemptList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/video/v1/composition.js
+++ b/lib/rest/video/v1/composition.js
@@ -143,6 +143,8 @@ CompositionList = function CompositionList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/video/v1/compositionHook.js
+++ b/lib/rest/video/v1/compositionHook.js
@@ -143,6 +143,8 @@ CompositionHookList = function CompositionHookList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/video/v1/recording.js
+++ b/lib/rest/video/v1/recording.js
@@ -147,6 +147,8 @@ RecordingList = function RecordingList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/video/v1/room.js
+++ b/lib/rest/video/v1/room.js
@@ -225,6 +225,8 @@ RoomList = function RoomList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/video/v1/room/recording.js
+++ b/lib/rest/video/v1/room/recording.js
@@ -145,6 +145,8 @@ RoomRecordingList = function RoomRecordingList(version, roomSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/video/v1/room/roomParticipant.js
+++ b/lib/rest/video/v1/room/roomParticipant.js
@@ -150,6 +150,8 @@ ParticipantList = function ParticipantList(version, roomSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/video/v1/room/roomParticipant/roomParticipantPublishedTrack.js
+++ b/lib/rest/video/v1/room/roomParticipant/roomParticipantPublishedTrack.js
@@ -139,6 +139,8 @@ PublishedTrackList = function PublishedTrackList(version, roomSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/video/v1/room/roomParticipant/roomParticipantSubscribedTrack.js
+++ b/lib/rest/video/v1/room/roomParticipant/roomParticipantSubscribedTrack.js
@@ -138,6 +138,8 @@ SubscribedTrackList = function SubscribedTrackList(version, roomSid,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/voice/v1/byocTrunk.js
+++ b/lib/rest/voice/v1/byocTrunk.js
@@ -203,6 +203,8 @@ ByocTrunkList = function ByocTrunkList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/voice/v1/connectionPolicy.js
+++ b/lib/rest/voice/v1/connectionPolicy.js
@@ -177,6 +177,8 @@ ConnectionPolicyList = function ConnectionPolicyList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/voice/v1/connectionPolicy/connectionPolicyTarget.js
+++ b/lib/rest/voice/v1/connectionPolicy/connectionPolicyTarget.js
@@ -197,6 +197,8 @@ ConnectionPolicyTargetList = function ConnectionPolicyTargetList(version,
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/voice/v1/dialingPermissions/country.js
+++ b/lib/rest/voice/v1/dialingPermissions/country.js
@@ -150,6 +150,8 @@ CountryList = function CountryList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/voice/v1/dialingPermissions/country/highriskSpecialPrefix.js
+++ b/lib/rest/voice/v1/dialingPermissions/country/highriskSpecialPrefix.js
@@ -137,6 +137,8 @@ HighriskSpecialPrefixList = function HighriskSpecialPrefixList(version, isoCode)
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/voice/v1/ipRecord.js
+++ b/lib/rest/voice/v1/ipRecord.js
@@ -184,6 +184,8 @@ IpRecordList = function IpRecordList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/voice/v1/sourceIpMapping.js
+++ b/lib/rest/voice/v1/sourceIpMapping.js
@@ -185,6 +185,8 @@ SourceIpMappingList = function SourceIpMappingList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/wireless/v1/command.js
+++ b/lib/rest/wireless/v1/command.js
@@ -141,6 +141,8 @@ CommandList = function CommandList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/wireless/v1/ratePlan.js
+++ b/lib/rest/wireless/v1/ratePlan.js
@@ -135,6 +135,8 @@ RatePlanList = function RatePlanList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/wireless/v1/sim.js
+++ b/lib/rest/wireless/v1/sim.js
@@ -143,6 +143,8 @@ SimList = function SimList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/wireless/v1/sim/dataSession.js
+++ b/lib/rest/wireless/v1/sim/dataSession.js
@@ -135,6 +135,8 @@ DataSessionList = function DataSessionList(version, simSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/wireless/v1/sim/usageRecord.js
+++ b/lib/rest/wireless/v1/sim/usageRecord.js
@@ -140,6 +140,8 @@ UsageRecordList = function UsageRecordList(version, simSid) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/lib/rest/wireless/v1/usageRecord.js
+++ b/lib/rest/wireless/v1/usageRecord.js
@@ -138,6 +138,8 @@ UsageRecordList = function UsageRecordList(version) {
         if (!done) {
           currentPage++;
           fetchNextPage(_.bind(page.nextPage, page));
+        } else {
+          onComplete();
         }
       });
 

--- a/spec/unit/rest/incomingPhoneNumber.spec.js
+++ b/spec/unit/rest/incomingPhoneNumber.spec.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var Holodeck = require('../../integration/holodeck');
+var Response = require('../../../lib/http/response');
+var Twilio = require('../../../lib');
+
+var client;
+var holodeck;
+
+describe('IncomingPhoneNumber', function () {
+  /* Before Hooks */
+  beforeEach(function() {
+    holodeck = new Holodeck();
+    client = new Twilio('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'AUTHTOKEN', {
+      httpClient: holodeck
+    });
+  });
+
+  /* Tests */
+  it('should call done in the opts object when done',
+    function (done) {
+      var body = {
+        'end': 0,
+        'first_page_uri': '/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers.json?FriendlyName=friendly_name&Beta=true&PhoneNumber=%2B19876543210&PageSize=50&Page=0',
+        'incoming_phone_numbers': [{}],
+        'next_page_uri': null,
+        'page': 0,
+        'page_size': 50,
+        'previous_page_uri': null,
+        'start': 0,
+        'uri': '/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers.json?FriendlyName=friendly_name&Beta=true&PhoneNumber=%2B19876543210&PageSize=50&Page=0'
+      };
+      holodeck.mock(new Response(200, body));
+      client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+        .incomingPhoneNumbers.each({ done }, () => null);
+    }
+  );
+  it('should call done when limit in the opts object is reached',
+    function (done) {
+      var body = {
+        'end': 0,
+        'first_page_uri': '/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers.json?FriendlyName=friendly_name&Beta=true&PhoneNumber=%2B19876543210&PageSize=1&Page=0',
+        'incoming_phone_numbers': [{}],
+        'next_page_uri': '/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers.json?FriendlyName=friendly_name&Beta=true&PhoneNumber=%2B19876543210&PageSize=1&Page=1',
+        'page': 0,
+        'page_size': 1,
+        'previous_page_uri': null,
+        'start': 0,
+        'uri': '/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/IncomingPhoneNumbers.json?FriendlyName=friendly_name&Beta=true&PhoneNumber=%2B19876543210&PageSize=1&Page=0'
+      };
+      holodeck.mock(new Response(200, body));
+      client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+        .incomingPhoneNumbers.each({ limit: 1, done }, () => null);
+    }
+  );
+});


### PR DESCRIPTION
 Fixes https://github.com/twilio/twilio-node/issues/678

For resources that contain an `each` method to stream records from the API until a limit is reached, its `opts.done` callback fails to execute when the user defines a limit in the `opts` object and it is reached.

Changes include new tests for testing that:

- The `opts.done` callback is executed when incomingPhoneNumber records processed
- The `opts.done` callback is executed when a user defined limit is reached for incomingPhoneNumber records

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
