### PR TITLE
Fix client.tokens.iceServers type

### DIFF
--- a/lib/rest/api/v2010/account/token.d.ts
+++ b/lib/rest/api/v2010/account/token.d.ts
@@ -50,11 +50,18 @@ interface TokenListInstanceCreateOptions {
 interface TokenPayload extends TokenResource, Page.TwilioResponsePayload {
 }
 
+interface IceServer {
+  url?: string,
+  urls?: string,
+  username?: string,
+  credential?: string,
+}
+
 interface TokenResource {
   account_sid: string;
   date_created: Date;
   date_updated: Date;
-  ice_servers: string[];
+  iceServers: IceServer[];
   password: string;
   ttl: string;
   username: string;
@@ -78,7 +85,7 @@ declare class TokenInstance extends SerializableClass {
   accountSid: string;
   dateCreated: Date;
   dateUpdated: Date;
-  iceServers: string[];
+  iceServers: IceServer[];
   password: string;
   /**
    * Provide a user-friendly representation


### PR DESCRIPTION
# Fixes #730

The type of the value by client.tokens.iceServers is incorrectly defined as `string[]`.
The actual value is an array of objects, each consisting of an ice server url, username and password.

I understand that this code is generated but making an example change was trivial so here you go.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
