### PR TITLE
feat: support required resource properties with names containing periods

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -61,5 +61,8 @@
    */
 
   // Suppress warnings about == null comparisons.
-  "eqnull": true
+  "eqnull": true,
+
+  // Supress errors regarding the use of bracket notation over dot notation
+  "sub": true
 }

--- a/lib/rest/accounts/v1/credential/aws.js
+++ b/lib/rest/accounts/v1/credential/aws.js
@@ -316,8 +316,8 @@ AwsList = function AwsList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.credentials)) {
-      throw new Error('Required parameter "opts.credentials" missing.');
+    if (_.isUndefined(opts['credentials'])) {
+      throw new Error('Required parameter "opts[\'credentials\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/accounts/v1/credential/publicKey.js
+++ b/lib/rest/accounts/v1/credential/publicKey.js
@@ -315,8 +315,8 @@ PublicKeyList = function PublicKeyList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.publicKey)) {
-      throw new Error('Required parameter "opts.publicKey" missing.');
+    if (_.isUndefined(opts['publicKey'])) {
+      throw new Error('Required parameter "opts[\'publicKey\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/address.js
+++ b/lib/rest/api/v2010/account/address.js
@@ -83,23 +83,23 @@ AddressList = function AddressList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.customerName)) {
-      throw new Error('Required parameter "opts.customerName" missing.');
+    if (_.isUndefined(opts['customerName'])) {
+      throw new Error('Required parameter "opts[\'customerName\']" missing.');
     }
-    if (_.isUndefined(opts.street)) {
-      throw new Error('Required parameter "opts.street" missing.');
+    if (_.isUndefined(opts['street'])) {
+      throw new Error('Required parameter "opts[\'street\']" missing.');
     }
-    if (_.isUndefined(opts.city)) {
-      throw new Error('Required parameter "opts.city" missing.');
+    if (_.isUndefined(opts['city'])) {
+      throw new Error('Required parameter "opts[\'city\']" missing.');
     }
-    if (_.isUndefined(opts.region)) {
-      throw new Error('Required parameter "opts.region" missing.');
+    if (_.isUndefined(opts['region'])) {
+      throw new Error('Required parameter "opts[\'region\']" missing.');
     }
-    if (_.isUndefined(opts.postalCode)) {
-      throw new Error('Required parameter "opts.postalCode" missing.');
+    if (_.isUndefined(opts['postalCode'])) {
+      throw new Error('Required parameter "opts[\'postalCode\']" missing.');
     }
-    if (_.isUndefined(opts.isoCountry)) {
-      throw new Error('Required parameter "opts.isoCountry" missing.');
+    if (_.isUndefined(opts['isoCountry'])) {
+      throw new Error('Required parameter "opts[\'isoCountry\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/call.js
+++ b/lib/rest/api/v2010/account/call.js
@@ -137,11 +137,11 @@ CallList = function CallList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.to)) {
-      throw new Error('Required parameter "opts.to" missing.');
+    if (_.isUndefined(opts['to'])) {
+      throw new Error('Required parameter "opts[\'to\']" missing.');
     }
-    if (_.isUndefined(opts.from)) {
-      throw new Error('Required parameter "opts.from" missing.');
+    if (_.isUndefined(opts['from'])) {
+      throw new Error('Required parameter "opts[\'from\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/call/feedback.js
+++ b/lib/rest/api/v2010/account/call/feedback.js
@@ -367,8 +367,8 @@ FeedbackContext.prototype.create = function create(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.qualityScore)) {
-    throw new Error('Required parameter "opts.qualityScore" missing.');
+  if (_.isUndefined(opts['qualityScore'])) {
+    throw new Error('Required parameter "opts[\'qualityScore\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/call/feedbackSummary.js
+++ b/lib/rest/api/v2010/account/call/feedbackSummary.js
@@ -78,11 +78,11 @@ FeedbackSummaryList = function FeedbackSummaryList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.startDate)) {
-      throw new Error('Required parameter "opts.startDate" missing.');
+    if (_.isUndefined(opts['startDate'])) {
+      throw new Error('Required parameter "opts[\'startDate\']" missing.');
     }
-    if (_.isUndefined(opts.endDate)) {
-      throw new Error('Required parameter "opts.endDate" missing.');
+    if (_.isUndefined(opts['endDate'])) {
+      throw new Error('Required parameter "opts[\'endDate\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/call/payment.js
+++ b/lib/rest/api/v2010/account/call/payment.js
@@ -107,11 +107,11 @@ PaymentList = function PaymentList(version, accountSid, callSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.idempotencyKey)) {
-      throw new Error('Required parameter "opts.idempotencyKey" missing.');
+    if (_.isUndefined(opts['idempotencyKey'])) {
+      throw new Error('Required parameter "opts[\'idempotencyKey\']" missing.');
     }
-    if (_.isUndefined(opts.statusCallback)) {
-      throw new Error('Required parameter "opts.statusCallback" missing.');
+    if (_.isUndefined(opts['statusCallback'])) {
+      throw new Error('Required parameter "opts[\'statusCallback\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -431,11 +431,11 @@ PaymentContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.idempotencyKey)) {
-    throw new Error('Required parameter "opts.idempotencyKey" missing.');
+  if (_.isUndefined(opts['idempotencyKey'])) {
+    throw new Error('Required parameter "opts[\'idempotencyKey\']" missing.');
   }
-  if (_.isUndefined(opts.statusCallback)) {
-    throw new Error('Required parameter "opts.statusCallback" missing.');
+  if (_.isUndefined(opts['statusCallback'])) {
+    throw new Error('Required parameter "opts[\'statusCallback\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/call/recording.js
+++ b/lib/rest/api/v2010/account/call/recording.js
@@ -694,8 +694,8 @@ RecordingContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.status)) {
-    throw new Error('Required parameter "opts.status" missing.');
+  if (_.isUndefined(opts['status'])) {
+    throw new Error('Required parameter "opts[\'status\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/call/siprec.js
+++ b/lib/rest/api/v2010/account/call/siprec.js
@@ -754,8 +754,8 @@ SiprecContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.status)) {
-    throw new Error('Required parameter "opts.status" missing.');
+  if (_.isUndefined(opts['status'])) {
+    throw new Error('Required parameter "opts[\'status\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/conference/participant.js
+++ b/lib/rest/api/v2010/account/conference/participant.js
@@ -140,11 +140,11 @@ ParticipantList = function ParticipantList(version, accountSid, conferenceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.from)) {
-      throw new Error('Required parameter "opts.from" missing.');
+    if (_.isUndefined(opts['from'])) {
+      throw new Error('Required parameter "opts[\'from\']" missing.');
     }
-    if (_.isUndefined(opts.to)) {
-      throw new Error('Required parameter "opts.to" missing.');
+    if (_.isUndefined(opts['to'])) {
+      throw new Error('Required parameter "opts[\'to\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/conference/recording.js
+++ b/lib/rest/api/v2010/account/conference/recording.js
@@ -634,8 +634,8 @@ RecordingContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.status)) {
-    throw new Error('Required parameter "opts.status" missing.');
+  if (_.isUndefined(opts['status'])) {
+    throw new Error('Required parameter "opts[\'status\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/assignedAddOn.js
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/assignedAddOn.js
@@ -322,8 +322,8 @@ AssignedAddOnList = function AssignedAddOnList(version, accountSid, resourceSid)
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.installedAddOnSid)) {
-      throw new Error('Required parameter "opts.installedAddOnSid" missing.');
+    if (_.isUndefined(opts['installedAddOnSid'])) {
+      throw new Error('Required parameter "opts[\'installedAddOnSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/local.js
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/local.js
@@ -377,8 +377,8 @@ LocalList = function LocalList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.phoneNumber)) {
-      throw new Error('Required parameter "opts.phoneNumber" missing.');
+    if (_.isUndefined(opts['phoneNumber'])) {
+      throw new Error('Required parameter "opts[\'phoneNumber\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/mobile.js
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/mobile.js
@@ -377,8 +377,8 @@ MobileList = function MobileList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.phoneNumber)) {
-      throw new Error('Required parameter "opts.phoneNumber" missing.');
+    if (_.isUndefined(opts['phoneNumber'])) {
+      throw new Error('Required parameter "opts[\'phoneNumber\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/tollFree.js
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/tollFree.js
@@ -377,8 +377,8 @@ TollFreeList = function TollFreeList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.phoneNumber)) {
-      throw new Error('Required parameter "opts.phoneNumber" missing.');
+    if (_.isUndefined(opts['phoneNumber'])) {
+      throw new Error('Required parameter "opts[\'phoneNumber\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/message.js
+++ b/lib/rest/api/v2010/account/message.js
@@ -105,8 +105,8 @@ MessageList = function MessageList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.to)) {
-      throw new Error('Required parameter "opts.to" missing.');
+    if (_.isUndefined(opts['to'])) {
+      throw new Error('Required parameter "opts[\'to\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/queue.js
+++ b/lib/rest/api/v2010/account/queue.js
@@ -315,8 +315,8 @@ QueueList = function QueueList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/queue/member.js
+++ b/lib/rest/api/v2010/account/queue/member.js
@@ -601,8 +601,8 @@ MemberContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.url)) {
-    throw new Error('Required parameter "opts.url" missing.');
+  if (_.isUndefined(opts['url'])) {
+    throw new Error('Required parameter "opts[\'url\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/sip/credentialList.js
+++ b/lib/rest/api/v2010/account/sip/credentialList.js
@@ -315,8 +315,8 @@ CredentialListList = function CredentialListList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -674,8 +674,8 @@ CredentialListContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.friendlyName)) {
-    throw new Error('Required parameter "opts.friendlyName" missing.');
+  if (_.isUndefined(opts['friendlyName'])) {
+    throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/sip/credentialList/credential.js
+++ b/lib/rest/api/v2010/account/sip/credentialList/credential.js
@@ -319,11 +319,11 @@ CredentialList = function CredentialList(version, accountSid, credentialListSid)
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.username)) {
-      throw new Error('Required parameter "opts.username" missing.');
+    if (_.isUndefined(opts['username'])) {
+      throw new Error('Required parameter "opts[\'username\']" missing.');
     }
-    if (_.isUndefined(opts.password)) {
-      throw new Error('Required parameter "opts.password" missing.');
+    if (_.isUndefined(opts['password'])) {
+      throw new Error('Required parameter "opts[\'password\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/sip/domain.js
+++ b/lib/rest/api/v2010/account/sip/domain.js
@@ -340,8 +340,8 @@ DomainList = function DomainList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.domainName)) {
-      throw new Error('Required parameter "opts.domainName" missing.');
+    if (_.isUndefined(opts['domainName'])) {
+      throw new Error('Required parameter "opts[\'domainName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsCredentialListMapping.js
+++ b/lib/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsCredentialListMapping.js
@@ -78,8 +78,8 @@ AuthCallsCredentialListMappingList = function
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.credentialListSid)) {
-      throw new Error('Required parameter "opts.credentialListSid" missing.');
+    if (_.isUndefined(opts['credentialListSid'])) {
+      throw new Error('Required parameter "opts[\'credentialListSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsIpAccessControlListMapping.js
+++ b/lib/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsIpAccessControlListMapping.js
@@ -78,8 +78,8 @@ AuthCallsIpAccessControlListMappingList = function
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.ipAccessControlListSid)) {
-      throw new Error('Required parameter "opts.ipAccessControlListSid" missing.');
+    if (_.isUndefined(opts['ipAccessControlListSid'])) {
+      throw new Error('Required parameter "opts[\'ipAccessControlListSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/sip/domain/authTypes/authRegistrationsMapping/authRegistrationsCredentialListMapping.js
+++ b/lib/rest/api/v2010/account/sip/domain/authTypes/authRegistrationsMapping/authRegistrationsCredentialListMapping.js
@@ -78,8 +78,8 @@ AuthRegistrationsCredentialListMappingList = function
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.credentialListSid)) {
-      throw new Error('Required parameter "opts.credentialListSid" missing.');
+    if (_.isUndefined(opts['credentialListSid'])) {
+      throw new Error('Required parameter "opts[\'credentialListSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/sip/domain/credentialListMapping.js
+++ b/lib/rest/api/v2010/account/sip/domain/credentialListMapping.js
@@ -74,8 +74,8 @@ CredentialListMappingList = function CredentialListMappingList(version,
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.credentialListSid)) {
-      throw new Error('Required parameter "opts.credentialListSid" missing.');
+    if (_.isUndefined(opts['credentialListSid'])) {
+      throw new Error('Required parameter "opts[\'credentialListSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/sip/domain/ipAccessControlListMapping.js
+++ b/lib/rest/api/v2010/account/sip/domain/ipAccessControlListMapping.js
@@ -75,8 +75,8 @@ IpAccessControlListMappingList = function
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.ipAccessControlListSid)) {
-      throw new Error('Required parameter "opts.ipAccessControlListSid" missing.');
+    if (_.isUndefined(opts['ipAccessControlListSid'])) {
+      throw new Error('Required parameter "opts[\'ipAccessControlListSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/sip/ipAccessControlList.js
+++ b/lib/rest/api/v2010/account/sip/ipAccessControlList.js
@@ -319,8 +319,8 @@ IpAccessControlListList = function IpAccessControlListList(version, accountSid)
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -680,8 +680,8 @@ IpAccessControlListContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.friendlyName)) {
-    throw new Error('Required parameter "opts.friendlyName" missing.');
+  if (_.isUndefined(opts['friendlyName'])) {
+    throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/sip/ipAccessControlList/ipAddress.js
+++ b/lib/rest/api/v2010/account/sip/ipAccessControlList/ipAddress.js
@@ -325,11 +325,11 @@ IpAddressList = function IpAddressList(version, accountSid,
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.ipAddress)) {
-      throw new Error('Required parameter "opts.ipAddress" missing.');
+    if (_.isUndefined(opts['ipAddress'])) {
+      throw new Error('Required parameter "opts[\'ipAddress\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/usage/trigger.js
+++ b/lib/rest/api/v2010/account/usage/trigger.js
@@ -81,14 +81,14 @@ TriggerList = function TriggerList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.callbackUrl)) {
-      throw new Error('Required parameter "opts.callbackUrl" missing.');
+    if (_.isUndefined(opts['callbackUrl'])) {
+      throw new Error('Required parameter "opts[\'callbackUrl\']" missing.');
     }
-    if (_.isUndefined(opts.triggerValue)) {
-      throw new Error('Required parameter "opts.triggerValue" missing.');
+    if (_.isUndefined(opts['triggerValue'])) {
+      throw new Error('Required parameter "opts[\'triggerValue\']" missing.');
     }
-    if (_.isUndefined(opts.usageCategory)) {
-      throw new Error('Required parameter "opts.usageCategory" missing.');
+    if (_.isUndefined(opts['usageCategory'])) {
+      throw new Error('Required parameter "opts[\'usageCategory\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/api/v2010/account/validationRequest.js
+++ b/lib/rest/api/v2010/account/validationRequest.js
@@ -75,8 +75,8 @@ ValidationRequestList = function ValidationRequestList(version, accountSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.phoneNumber)) {
-      throw new Error('Required parameter "opts.phoneNumber" missing.');
+    if (_.isUndefined(opts['phoneNumber'])) {
+      throw new Error('Required parameter "opts[\'phoneNumber\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/autopilot/v1/assistant/fieldType.js
+++ b/lib/rest/autopilot/v1/assistant/fieldType.js
@@ -321,8 +321,8 @@ FieldTypeList = function FieldTypeList(version, assistantSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/autopilot/v1/assistant/fieldType/fieldValue.js
+++ b/lib/rest/autopilot/v1/assistant/fieldType/fieldValue.js
@@ -331,11 +331,11 @@ FieldValueList = function FieldValueList(version, assistantSid, fieldTypeSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.language)) {
-      throw new Error('Required parameter "opts.language" missing.');
+    if (_.isUndefined(opts['language'])) {
+      throw new Error('Required parameter "opts[\'language\']" missing.');
     }
-    if (_.isUndefined(opts.value)) {
-      throw new Error('Required parameter "opts.value" missing.');
+    if (_.isUndefined(opts['value'])) {
+      throw new Error('Required parameter "opts[\'value\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/autopilot/v1/assistant/query.js
+++ b/lib/rest/autopilot/v1/assistant/query.js
@@ -348,11 +348,11 @@ QueryList = function QueryList(version, assistantSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.language)) {
-      throw new Error('Required parameter "opts.language" missing.');
+    if (_.isUndefined(opts['language'])) {
+      throw new Error('Required parameter "opts[\'language\']" missing.');
     }
-    if (_.isUndefined(opts.query)) {
-      throw new Error('Required parameter "opts.query" missing.');
+    if (_.isUndefined(opts['query'])) {
+      throw new Error('Required parameter "opts[\'query\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/autopilot/v1/assistant/task.js
+++ b/lib/rest/autopilot/v1/assistant/task.js
@@ -330,8 +330,8 @@ TaskList = function TaskList(version, assistantSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/autopilot/v1/assistant/task/field.js
+++ b/lib/rest/autopilot/v1/assistant/task/field.js
@@ -322,11 +322,11 @@ FieldList = function FieldList(version, assistantSid, taskSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.fieldType)) {
-      throw new Error('Required parameter "opts.fieldType" missing.');
+    if (_.isUndefined(opts['fieldType'])) {
+      throw new Error('Required parameter "opts[\'fieldType\']" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/autopilot/v1/assistant/task/sample.js
+++ b/lib/rest/autopilot/v1/assistant/task/sample.js
@@ -331,11 +331,11 @@ SampleList = function SampleList(version, assistantSid, taskSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.language)) {
-      throw new Error('Required parameter "opts.language" missing.');
+    if (_.isUndefined(opts['language'])) {
+      throw new Error('Required parameter "opts[\'language\']" missing.');
     }
-    if (_.isUndefined(opts.taggedText)) {
-      throw new Error('Required parameter "opts.taggedText" missing.');
+    if (_.isUndefined(opts['taggedText'])) {
+      throw new Error('Required parameter "opts[\'taggedText\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/autopilot/v1/assistant/webhook.js
+++ b/lib/rest/autopilot/v1/assistant/webhook.js
@@ -324,14 +324,14 @@ WebhookList = function WebhookList(version, assistantSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
-    if (_.isUndefined(opts.events)) {
-      throw new Error('Required parameter "opts.events" missing.');
+    if (_.isUndefined(opts['events'])) {
+      throw new Error('Required parameter "opts[\'events\']" missing.');
     }
-    if (_.isUndefined(opts.webhookUrl)) {
-      throw new Error('Required parameter "opts.webhookUrl" missing.');
+    if (_.isUndefined(opts['webhookUrl'])) {
+      throw new Error('Required parameter "opts[\'webhookUrl\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/autopilot/v1/restoreAssistant.js
+++ b/lib/rest/autopilot/v1/restoreAssistant.js
@@ -71,8 +71,8 @@ RestoreAssistantList = function RestoreAssistantList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.assistant)) {
-      throw new Error('Required parameter "opts.assistant" missing.');
+    if (_.isUndefined(opts['assistant'])) {
+      throw new Error('Required parameter "opts[\'assistant\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/bulkexports/v1/export/exportCustomJob.js
+++ b/lib/rest/bulkexports/v1/export/exportCustomJob.js
@@ -322,14 +322,14 @@ ExportCustomJobList = function ExportCustomJobList(version, resourceType) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.startDay)) {
-      throw new Error('Required parameter "opts.startDay" missing.');
+    if (_.isUndefined(opts['startDay'])) {
+      throw new Error('Required parameter "opts[\'startDay\']" missing.');
     }
-    if (_.isUndefined(opts.endDay)) {
-      throw new Error('Required parameter "opts.endDay" missing.');
+    if (_.isUndefined(opts['endDay'])) {
+      throw new Error('Required parameter "opts[\'endDay\']" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v1/credential.js
+++ b/lib/rest/chat/v1/credential.js
@@ -325,8 +325,8 @@ CredentialList = function CredentialList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v1/service.js
+++ b/lib/rest/chat/v1/service.js
@@ -72,8 +72,8 @@ ServiceList = function ServiceList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v1/service/channel/invite.js
+++ b/lib/rest/chat/v1/service/channel/invite.js
@@ -75,8 +75,8 @@ InviteList = function InviteList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v1/service/channel/member.js
+++ b/lib/rest/chat/v1/service/channel/member.js
@@ -75,8 +75,8 @@ MemberList = function MemberList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v1/service/channel/message.js
+++ b/lib/rest/chat/v1/service/channel/message.js
@@ -75,8 +75,8 @@ MessageList = function MessageList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.body)) {
-      throw new Error('Required parameter "opts.body" missing.');
+    if (_.isUndefined(opts['body'])) {
+      throw new Error('Required parameter "opts[\'body\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v1/service/role.js
+++ b/lib/rest/chat/v1/service/role.js
@@ -73,14 +73,14 @@ RoleList = function RoleList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
-    if (_.isUndefined(opts.permission)) {
-      throw new Error('Required parameter "opts.permission" missing.');
+    if (_.isUndefined(opts['permission'])) {
+      throw new Error('Required parameter "opts[\'permission\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -695,8 +695,8 @@ RoleContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.permission)) {
-    throw new Error('Required parameter "opts.permission" missing.');
+  if (_.isUndefined(opts['permission'])) {
+    throw new Error('Required parameter "opts[\'permission\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/chat/v1/service/user.js
+++ b/lib/rest/chat/v1/service/user.js
@@ -76,8 +76,8 @@ UserList = function UserList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v2/credential.js
+++ b/lib/rest/chat/v2/credential.js
@@ -325,8 +325,8 @@ CredentialList = function CredentialList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v2/service.js
+++ b/lib/rest/chat/v2/service.js
@@ -73,8 +73,8 @@ ServiceList = function ServiceList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v2/service/channel/invite.js
+++ b/lib/rest/chat/v2/service/channel/invite.js
@@ -75,8 +75,8 @@ InviteList = function InviteList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v2/service/channel/member.js
+++ b/lib/rest/chat/v2/service/channel/member.js
@@ -87,8 +87,8 @@ MemberList = function MemberList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v2/service/channel/webhook.js
+++ b/lib/rest/chat/v2/service/channel/webhook.js
@@ -329,8 +329,8 @@ WebhookList = function WebhookList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/chat/v2/service/role.js
+++ b/lib/rest/chat/v2/service/role.js
@@ -73,14 +73,14 @@ RoleList = function RoleList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
-    if (_.isUndefined(opts.permission)) {
-      throw new Error('Required parameter "opts.permission" missing.');
+    if (_.isUndefined(opts['permission'])) {
+      throw new Error('Required parameter "opts[\'permission\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -695,8 +695,8 @@ RoleContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.permission)) {
-    throw new Error('Required parameter "opts.permission" missing.');
+  if (_.isUndefined(opts['permission'])) {
+    throw new Error('Required parameter "opts[\'permission\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/chat/v2/service/user.js
+++ b/lib/rest/chat/v2/service/user.js
@@ -79,8 +79,8 @@ UserList = function UserList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/conversations/v1/conversation/webhook.js
+++ b/lib/rest/conversations/v1/conversation/webhook.js
@@ -327,8 +327,8 @@ WebhookList = function WebhookList(version, conversationSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.target)) {
-      throw new Error('Required parameter "opts.target" missing.');
+    if (_.isUndefined(opts['target'])) {
+      throw new Error('Required parameter "opts[\'target\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/conversations/v1/credential.js
+++ b/lib/rest/conversations/v1/credential.js
@@ -81,8 +81,8 @@ CredentialList = function CredentialList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/conversations/v1/role.js
+++ b/lib/rest/conversations/v1/role.js
@@ -71,14 +71,14 @@ RoleList = function RoleList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
-    if (_.isUndefined(opts.permission)) {
-      throw new Error('Required parameter "opts.permission" missing.');
+    if (_.isUndefined(opts['permission'])) {
+      throw new Error('Required parameter "opts[\'permission\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -618,8 +618,8 @@ RoleContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.permission)) {
-    throw new Error('Required parameter "opts.permission" missing.');
+  if (_.isUndefined(opts['permission'])) {
+    throw new Error('Required parameter "opts[\'permission\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/conversations/v1/service.js
+++ b/lib/rest/conversations/v1/service.js
@@ -75,8 +75,8 @@ ServiceList = function ServiceList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/conversations/v1/service/conversation/webhook.js
+++ b/lib/rest/conversations/v1/service/conversation/webhook.js
@@ -86,8 +86,8 @@ WebhookList = function WebhookList(version, chatServiceSid, conversationSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.target)) {
-      throw new Error('Required parameter "opts.target" missing.');
+    if (_.isUndefined(opts['target'])) {
+      throw new Error('Required parameter "opts[\'target\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/conversations/v1/service/role.js
+++ b/lib/rest/conversations/v1/service/role.js
@@ -73,14 +73,14 @@ RoleList = function RoleList(version, chatServiceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
-    if (_.isUndefined(opts.permission)) {
-      throw new Error('Required parameter "opts.permission" missing.');
+    if (_.isUndefined(opts['permission'])) {
+      throw new Error('Required parameter "opts[\'permission\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -629,8 +629,8 @@ RoleContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.permission)) {
-    throw new Error('Required parameter "opts.permission" missing.');
+  if (_.isUndefined(opts['permission'])) {
+    throw new Error('Required parameter "opts[\'permission\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/conversations/v1/service/user.js
+++ b/lib/rest/conversations/v1/service/user.js
@@ -80,8 +80,8 @@ UserList = function UserList(version, chatServiceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/conversations/v1/user.js
+++ b/lib/rest/conversations/v1/user.js
@@ -78,8 +78,8 @@ UserList = function UserList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/events/v1/sink.js
+++ b/lib/rest/events/v1/sink.js
@@ -76,14 +76,14 @@ SinkList = function SinkList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.description)) {
-      throw new Error('Required parameter "opts.description" missing.');
+    if (_.isUndefined(opts['description'])) {
+      throw new Error('Required parameter "opts[\'description\']" missing.');
     }
-    if (_.isUndefined(opts.sinkConfiguration)) {
-      throw new Error('Required parameter "opts.sinkConfiguration" missing.');
+    if (_.isUndefined(opts['sinkConfiguration'])) {
+      throw new Error('Required parameter "opts[\'sinkConfiguration\']" missing.');
     }
-    if (_.isUndefined(opts.sinkType)) {
-      throw new Error('Required parameter "opts.sinkType" missing.');
+    if (_.isUndefined(opts['sinkType'])) {
+      throw new Error('Required parameter "opts[\'sinkType\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -737,8 +737,8 @@ SinkContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.description)) {
-    throw new Error('Required parameter "opts.description" missing.');
+  if (_.isUndefined(opts['description'])) {
+    throw new Error('Required parameter "opts[\'description\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/events/v1/sink/sinkValidate.js
+++ b/lib/rest/events/v1/sink/sinkValidate.js
@@ -70,8 +70,8 @@ SinkValidateList = function SinkValidateList(version, sid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.testId)) {
-      throw new Error('Required parameter "opts.testId" missing.');
+    if (_.isUndefined(opts['testId'])) {
+      throw new Error('Required parameter "opts[\'testId\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/events/v1/subscription.js
+++ b/lib/rest/events/v1/subscription.js
@@ -324,14 +324,14 @@ SubscriptionList = function SubscriptionList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.description)) {
-      throw new Error('Required parameter "opts.description" missing.');
+    if (_.isUndefined(opts['description'])) {
+      throw new Error('Required parameter "opts[\'description\']" missing.');
     }
-    if (_.isUndefined(opts.sinkSid)) {
-      throw new Error('Required parameter "opts.sinkSid" missing.');
+    if (_.isUndefined(opts['sinkSid'])) {
+      throw new Error('Required parameter "opts[\'sinkSid\']" missing.');
     }
-    if (_.isUndefined(opts.types)) {
-      throw new Error('Required parameter "opts.types" missing.');
+    if (_.isUndefined(opts['types'])) {
+      throw new Error('Required parameter "opts[\'types\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/events/v1/subscription/subscribedEvent.js
+++ b/lib/rest/events/v1/subscription/subscribedEvent.js
@@ -318,8 +318,8 @@ SubscribedEventList = function SubscribedEventList(version, subscriptionSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/fax/v1/fax.js
+++ b/lib/rest/fax/v1/fax.js
@@ -351,11 +351,11 @@ FaxList = function FaxList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.to)) {
-      throw new Error('Required parameter "opts.to" missing.');
+    if (_.isUndefined(opts['to'])) {
+      throw new Error('Required parameter "opts[\'to\']" missing.');
     }
-    if (_.isUndefined(opts.mediaUrl)) {
-      throw new Error('Required parameter "opts.mediaUrl" missing.');
+    if (_.isUndefined(opts['mediaUrl'])) {
+      throw new Error('Required parameter "opts[\'mediaUrl\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/flexApi/v1/channel.js
+++ b/lib/rest/flexApi/v1/channel.js
@@ -324,17 +324,17 @@ ChannelList = function ChannelList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.flexFlowSid)) {
-      throw new Error('Required parameter "opts.flexFlowSid" missing.');
+    if (_.isUndefined(opts['flexFlowSid'])) {
+      throw new Error('Required parameter "opts[\'flexFlowSid\']" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
-    if (_.isUndefined(opts.chatUserFriendlyName)) {
-      throw new Error('Required parameter "opts.chatUserFriendlyName" missing.');
+    if (_.isUndefined(opts['chatUserFriendlyName'])) {
+      throw new Error('Required parameter "opts[\'chatUserFriendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.chatFriendlyName)) {
-      throw new Error('Required parameter "opts.chatFriendlyName" missing.');
+    if (_.isUndefined(opts['chatFriendlyName'])) {
+      throw new Error('Required parameter "opts[\'chatFriendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/flexApi/v1/flexFlow.js
+++ b/lib/rest/flexApi/v1/flexFlow.js
@@ -343,14 +343,14 @@ FlexFlowList = function FlexFlowList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.chatServiceSid)) {
-      throw new Error('Required parameter "opts.chatServiceSid" missing.');
+    if (_.isUndefined(opts['chatServiceSid'])) {
+      throw new Error('Required parameter "opts[\'chatServiceSid\']" missing.');
     }
-    if (_.isUndefined(opts.channelType)) {
-      throw new Error('Required parameter "opts.channelType" missing.');
+    if (_.isUndefined(opts['channelType'])) {
+      throw new Error('Required parameter "opts[\'channelType\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/flexApi/v1/webChannel.js
+++ b/lib/rest/flexApi/v1/webChannel.js
@@ -317,17 +317,17 @@ WebChannelList = function WebChannelList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.flexFlowSid)) {
-      throw new Error('Required parameter "opts.flexFlowSid" missing.');
+    if (_.isUndefined(opts['flexFlowSid'])) {
+      throw new Error('Required parameter "opts[\'flexFlowSid\']" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
-    if (_.isUndefined(opts.customerFriendlyName)) {
-      throw new Error('Required parameter "opts.customerFriendlyName" missing.');
+    if (_.isUndefined(opts['customerFriendlyName'])) {
+      throw new Error('Required parameter "opts[\'customerFriendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.chatFriendlyName)) {
-      throw new Error('Required parameter "opts.chatFriendlyName" missing.');
+    if (_.isUndefined(opts['chatFriendlyName'])) {
+      throw new Error('Required parameter "opts[\'chatFriendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v1/credential.js
+++ b/lib/rest/ipMessaging/v1/credential.js
@@ -319,8 +319,8 @@ CredentialList = function CredentialList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v1/service.js
+++ b/lib/rest/ipMessaging/v1/service.js
@@ -72,8 +72,8 @@ ServiceList = function ServiceList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v1/service/channel/invite.js
+++ b/lib/rest/ipMessaging/v1/service/channel/invite.js
@@ -73,8 +73,8 @@ InviteList = function InviteList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v1/service/channel/member.js
+++ b/lib/rest/ipMessaging/v1/service/channel/member.js
@@ -73,8 +73,8 @@ MemberList = function MemberList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v1/service/channel/message.js
+++ b/lib/rest/ipMessaging/v1/service/channel/message.js
@@ -72,8 +72,8 @@ MessageList = function MessageList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.body)) {
-      throw new Error('Required parameter "opts.body" missing.');
+    if (_.isUndefined(opts['body'])) {
+      throw new Error('Required parameter "opts[\'body\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v1/service/role.js
+++ b/lib/rest/ipMessaging/v1/service/role.js
@@ -72,14 +72,14 @@ RoleList = function RoleList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
-    if (_.isUndefined(opts.permission)) {
-      throw new Error('Required parameter "opts.permission" missing.');
+    if (_.isUndefined(opts['permission'])) {
+      throw new Error('Required parameter "opts[\'permission\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -688,8 +688,8 @@ RoleContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.permission)) {
-    throw new Error('Required parameter "opts.permission" missing.');
+  if (_.isUndefined(opts['permission'])) {
+    throw new Error('Required parameter "opts[\'permission\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v1/service/user.js
+++ b/lib/rest/ipMessaging/v1/service/user.js
@@ -73,8 +73,8 @@ UserList = function UserList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v2/credential.js
+++ b/lib/rest/ipMessaging/v2/credential.js
@@ -319,8 +319,8 @@ CredentialList = function CredentialList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v2/service.js
+++ b/lib/rest/ipMessaging/v2/service.js
@@ -73,8 +73,8 @@ ServiceList = function ServiceList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v2/service/channel/invite.js
+++ b/lib/rest/ipMessaging/v2/service/channel/invite.js
@@ -73,8 +73,8 @@ InviteList = function InviteList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v2/service/channel/member.js
+++ b/lib/rest/ipMessaging/v2/service/channel/member.js
@@ -81,8 +81,8 @@ MemberList = function MemberList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v2/service/channel/webhook.js
+++ b/lib/rest/ipMessaging/v2/service/channel/webhook.js
@@ -322,8 +322,8 @@ WebhookList = function WebhookList(version, serviceSid, channelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v2/service/role.js
+++ b/lib/rest/ipMessaging/v2/service/role.js
@@ -72,14 +72,14 @@ RoleList = function RoleList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
-    if (_.isUndefined(opts.permission)) {
-      throw new Error('Required parameter "opts.permission" missing.');
+    if (_.isUndefined(opts['permission'])) {
+      throw new Error('Required parameter "opts[\'permission\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -688,8 +688,8 @@ RoleContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.permission)) {
-    throw new Error('Required parameter "opts.permission" missing.');
+  if (_.isUndefined(opts['permission'])) {
+    throw new Error('Required parameter "opts[\'permission\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/ipMessaging/v2/service/user.js
+++ b/lib/rest/ipMessaging/v2/service/user.js
@@ -76,8 +76,8 @@ UserList = function UserList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/media/v1/mediaProcessor.js
+++ b/lib/rest/media/v1/mediaProcessor.js
@@ -76,11 +76,11 @@ MediaProcessorList = function MediaProcessorList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.extension)) {
-      throw new Error('Required parameter "opts.extension" missing.');
+    if (_.isUndefined(opts['extension'])) {
+      throw new Error('Required parameter "opts[\'extension\']" missing.');
     }
-    if (_.isUndefined(opts.extensionContext)) {
-      throw new Error('Required parameter "opts.extensionContext" missing.');
+    if (_.isUndefined(opts['extensionContext'])) {
+      throw new Error('Required parameter "opts[\'extensionContext\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -657,8 +657,8 @@ MediaProcessorContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.status)) {
-    throw new Error('Required parameter "opts.status" missing.');
+  if (_.isUndefined(opts['status'])) {
+    throw new Error('Required parameter "opts[\'status\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/media/v1/playerStreamer.js
+++ b/lib/rest/media/v1/playerStreamer.js
@@ -670,8 +670,8 @@ PlayerStreamerContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.status)) {
-    throw new Error('Required parameter "opts.status" missing.');
+  if (_.isUndefined(opts['status'])) {
+    throw new Error('Required parameter "opts[\'status\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/messaging/v1/brandRegistration.js
+++ b/lib/rest/messaging/v1/brandRegistration.js
@@ -324,11 +324,11 @@ BrandRegistrationList = function BrandRegistrationList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.customerProfileBundleSid)) {
-      throw new Error('Required parameter "opts.customerProfileBundleSid" missing.');
+    if (_.isUndefined(opts['customerProfileBundleSid'])) {
+      throw new Error('Required parameter "opts[\'customerProfileBundleSid\']" missing.');
     }
-    if (_.isUndefined(opts.a2PProfileBundleSid)) {
-      throw new Error('Required parameter "opts.a2PProfileBundleSid" missing.');
+    if (_.isUndefined(opts['a2PProfileBundleSid'])) {
+      throw new Error('Required parameter "opts[\'a2PProfileBundleSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/messaging/v1/brandRegistration/brandVetting.js
+++ b/lib/rest/messaging/v1/brandRegistration/brandVetting.js
@@ -74,8 +74,8 @@ BrandVettingList = function BrandVettingList(version, brandSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.vettingProvider)) {
-      throw new Error('Required parameter "opts.vettingProvider" missing.');
+    if (_.isUndefined(opts['vettingProvider'])) {
+      throw new Error('Required parameter "opts[\'vettingProvider\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/messaging/v1/externalCampaign.js
+++ b/lib/rest/messaging/v1/externalCampaign.js
@@ -72,11 +72,11 @@ ExternalCampaignList = function ExternalCampaignList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.campaignId)) {
-      throw new Error('Required parameter "opts.campaignId" missing.');
+    if (_.isUndefined(opts['campaignId'])) {
+      throw new Error('Required parameter "opts[\'campaignId\']" missing.');
     }
-    if (_.isUndefined(opts.messagingServiceSid)) {
-      throw new Error('Required parameter "opts.messagingServiceSid" missing.');
+    if (_.isUndefined(opts['messagingServiceSid'])) {
+      throw new Error('Required parameter "opts[\'messagingServiceSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/messaging/v1/service.js
+++ b/lib/rest/messaging/v1/service.js
@@ -106,8 +106,8 @@ ServiceList = function ServiceList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/messaging/v1/service/alphaSender.js
+++ b/lib/rest/messaging/v1/service/alphaSender.js
@@ -73,8 +73,8 @@ AlphaSenderList = function AlphaSenderList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.alphaSender)) {
-      throw new Error('Required parameter "opts.alphaSender" missing.');
+    if (_.isUndefined(opts['alphaSender'])) {
+      throw new Error('Required parameter "opts[\'alphaSender\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/messaging/v1/service/phoneNumber.js
+++ b/lib/rest/messaging/v1/service/phoneNumber.js
@@ -74,8 +74,8 @@ PhoneNumberList = function PhoneNumberList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.phoneNumberSid)) {
-      throw new Error('Required parameter "opts.phoneNumberSid" missing.');
+    if (_.isUndefined(opts['phoneNumberSid'])) {
+      throw new Error('Required parameter "opts[\'phoneNumberSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/messaging/v1/service/shortCode.js
+++ b/lib/rest/messaging/v1/service/shortCode.js
@@ -74,8 +74,8 @@ ShortCodeList = function ShortCodeList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.shortCodeSid)) {
-      throw new Error('Required parameter "opts.shortCodeSid" missing.');
+    if (_.isUndefined(opts['shortCodeSid'])) {
+      throw new Error('Required parameter "opts[\'shortCodeSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/messaging/v1/service/usAppToPerson.js
+++ b/lib/rest/messaging/v1/service/usAppToPerson.js
@@ -82,23 +82,23 @@ UsAppToPersonList = function UsAppToPersonList(version, messagingServiceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.brandRegistrationSid)) {
-      throw new Error('Required parameter "opts.brandRegistrationSid" missing.');
+    if (_.isUndefined(opts['brandRegistrationSid'])) {
+      throw new Error('Required parameter "opts[\'brandRegistrationSid\']" missing.');
     }
-    if (_.isUndefined(opts.description)) {
-      throw new Error('Required parameter "opts.description" missing.');
+    if (_.isUndefined(opts['description'])) {
+      throw new Error('Required parameter "opts[\'description\']" missing.');
     }
-    if (_.isUndefined(opts.messageSamples)) {
-      throw new Error('Required parameter "opts.messageSamples" missing.');
+    if (_.isUndefined(opts['messageSamples'])) {
+      throw new Error('Required parameter "opts[\'messageSamples\']" missing.');
     }
-    if (_.isUndefined(opts.usAppToPersonUsecase)) {
-      throw new Error('Required parameter "opts.usAppToPersonUsecase" missing.');
+    if (_.isUndefined(opts['usAppToPersonUsecase'])) {
+      throw new Error('Required parameter "opts[\'usAppToPersonUsecase\']" missing.');
     }
-    if (_.isUndefined(opts.hasEmbeddedLinks)) {
-      throw new Error('Required parameter "opts.hasEmbeddedLinks" missing.');
+    if (_.isUndefined(opts['hasEmbeddedLinks'])) {
+      throw new Error('Required parameter "opts[\'hasEmbeddedLinks\']" missing.');
     }
-    if (_.isUndefined(opts.hasEmbeddedPhone)) {
-      throw new Error('Required parameter "opts.hasEmbeddedPhone" missing.');
+    if (_.isUndefined(opts['hasEmbeddedPhone'])) {
+      throw new Error('Required parameter "opts[\'hasEmbeddedPhone\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/notify/v1/credential.js
+++ b/lib/rest/notify/v1/credential.js
@@ -327,8 +327,8 @@ CredentialList = function CredentialList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/notify/v1/service/binding.js
+++ b/lib/rest/notify/v1/service/binding.js
@@ -84,14 +84,14 @@ BindingList = function BindingList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
-    if (_.isUndefined(opts.bindingType)) {
-      throw new Error('Required parameter "opts.bindingType" missing.');
+    if (_.isUndefined(opts['bindingType'])) {
+      throw new Error('Required parameter "opts[\'bindingType\']" missing.');
     }
-    if (_.isUndefined(opts.address)) {
-      throw new Error('Required parameter "opts.address" missing.');
+    if (_.isUndefined(opts['address'])) {
+      throw new Error('Required parameter "opts[\'address\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/numbers/v2/regulatoryCompliance/bundle.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/bundle.js
@@ -81,11 +81,11 @@ BundleList = function BundleList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.email)) {
-      throw new Error('Required parameter "opts.email" missing.');
+    if (_.isUndefined(opts['email'])) {
+      throw new Error('Required parameter "opts[\'email\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/numbers/v2/regulatoryCompliance/bundle/itemAssignment.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/bundle/itemAssignment.js
@@ -70,8 +70,8 @@ ItemAssignmentList = function ItemAssignmentList(version, bundleSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.objectSid)) {
-      throw new Error('Required parameter "opts.objectSid" missing.');
+    if (_.isUndefined(opts['objectSid'])) {
+      throw new Error('Required parameter "opts[\'objectSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/numbers/v2/regulatoryCompliance/bundle/replaceItems.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/bundle/replaceItems.js
@@ -72,8 +72,8 @@ ReplaceItemsList = function ReplaceItemsList(version, bundleSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.fromBundleSid)) {
-      throw new Error('Required parameter "opts.fromBundleSid" missing.');
+    if (_.isUndefined(opts['fromBundleSid'])) {
+      throw new Error('Required parameter "opts[\'fromBundleSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/numbers/v2/regulatoryCompliance/endUser.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/endUser.js
@@ -73,11 +73,11 @@ EndUserList = function EndUserList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/numbers/v2/regulatoryCompliance/supportingDocument.js
+++ b/lib/rest/numbers/v2/regulatoryCompliance/supportingDocument.js
@@ -73,11 +73,11 @@ SupportingDocumentList = function SupportingDocumentList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/bulk_exports/export/exportCustomJob.js
+++ b/lib/rest/preview/bulk_exports/export/exportCustomJob.js
@@ -326,14 +326,14 @@ ExportCustomJobList = function ExportCustomJobList(version, resourceType) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.startDay)) {
-      throw new Error('Required parameter "opts.startDay" missing.');
+    if (_.isUndefined(opts['startDay'])) {
+      throw new Error('Required parameter "opts[\'startDay\']" missing.');
     }
-    if (_.isUndefined(opts.endDay)) {
-      throw new Error('Required parameter "opts.endDay" missing.');
+    if (_.isUndefined(opts['endDay'])) {
+      throw new Error('Required parameter "opts[\'endDay\']" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/deployed_devices/fleet/certificate.js
+++ b/lib/rest/preview/deployed_devices/fleet/certificate.js
@@ -77,8 +77,8 @@ CertificateList = function CertificateList(version, fleetSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.certificateData)) {
-      throw new Error('Required parameter "opts.certificateData" missing.');
+    if (_.isUndefined(opts['certificateData'])) {
+      throw new Error('Required parameter "opts[\'certificateData\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/hosted_numbers/authorizationDocument.js
+++ b/lib/rest/preview/hosted_numbers/authorizationDocument.js
@@ -340,20 +340,20 @@ AuthorizationDocumentList = function AuthorizationDocumentList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.hostedNumberOrderSids)) {
-      throw new Error('Required parameter "opts.hostedNumberOrderSids" missing.');
+    if (_.isUndefined(opts['hostedNumberOrderSids'])) {
+      throw new Error('Required parameter "opts[\'hostedNumberOrderSids\']" missing.');
     }
-    if (_.isUndefined(opts.addressSid)) {
-      throw new Error('Required parameter "opts.addressSid" missing.');
+    if (_.isUndefined(opts['addressSid'])) {
+      throw new Error('Required parameter "opts[\'addressSid\']" missing.');
     }
-    if (_.isUndefined(opts.email)) {
-      throw new Error('Required parameter "opts.email" missing.');
+    if (_.isUndefined(opts['email'])) {
+      throw new Error('Required parameter "opts[\'email\']" missing.');
     }
-    if (_.isUndefined(opts.contactTitle)) {
-      throw new Error('Required parameter "opts.contactTitle" missing.');
+    if (_.isUndefined(opts['contactTitle'])) {
+      throw new Error('Required parameter "opts[\'contactTitle\']" missing.');
     }
-    if (_.isUndefined(opts.contactPhoneNumber)) {
-      throw new Error('Required parameter "opts.contactPhoneNumber" missing.');
+    if (_.isUndefined(opts['contactPhoneNumber'])) {
+      throw new Error('Required parameter "opts[\'contactPhoneNumber\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/hosted_numbers/hostedNumberOrder.js
+++ b/lib/rest/preview/hosted_numbers/hostedNumberOrder.js
@@ -365,11 +365,11 @@ HostedNumberOrderList = function HostedNumberOrderList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.phoneNumber)) {
-      throw new Error('Required parameter "opts.phoneNumber" missing.');
+    if (_.isUndefined(opts['phoneNumber'])) {
+      throw new Error('Required parameter "opts[\'phoneNumber\']" missing.');
     }
-    if (_.isUndefined(opts.smsCapability)) {
-      throw new Error('Required parameter "opts.smsCapability" missing.');
+    if (_.isUndefined(opts['smsCapability'])) {
+      throw new Error('Required parameter "opts[\'smsCapability\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/marketplace/installedAddOn.js
+++ b/lib/rest/preview/marketplace/installedAddOn.js
@@ -82,11 +82,11 @@ InstalledAddOnList = function InstalledAddOnList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.availableAddOnSid)) {
-      throw new Error('Required parameter "opts.availableAddOnSid" missing.');
+    if (_.isUndefined(opts['availableAddOnSid'])) {
+      throw new Error('Required parameter "opts[\'availableAddOnSid\']" missing.');
     }
-    if (_.isUndefined(opts.acceptTermsOfService)) {
-      throw new Error('Required parameter "opts.acceptTermsOfService" missing.');
+    if (_.isUndefined(opts['acceptTermsOfService'])) {
+      throw new Error('Required parameter "opts[\'acceptTermsOfService\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/marketplace/installedAddOn/installedAddOnExtension.js
+++ b/lib/rest/preview/marketplace/installedAddOn/installedAddOnExtension.js
@@ -618,8 +618,8 @@ InstalledAddOnExtensionContext.prototype.update = function update(opts,
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.enabled)) {
-    throw new Error('Required parameter "opts.enabled" missing.');
+  if (_.isUndefined(opts['enabled'])) {
+    throw new Error('Required parameter "opts[\'enabled\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/preview/sync/service/document.js
+++ b/lib/rest/preview/sync/service/document.js
@@ -726,8 +726,8 @@ DocumentContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.data)) {
-    throw new Error('Required parameter "opts.data" missing.');
+  if (_.isUndefined(opts['data'])) {
+    throw new Error('Required parameter "opts[\'data\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/preview/sync/service/document/documentPermission.js
+++ b/lib/rest/preview/sync/service/document/documentPermission.js
@@ -681,14 +681,14 @@ DocumentPermissionContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.read)) {
-    throw new Error('Required parameter "opts.read" missing.');
+  if (_.isUndefined(opts['read'])) {
+    throw new Error('Required parameter "opts[\'read\']" missing.');
   }
-  if (_.isUndefined(opts.write)) {
-    throw new Error('Required parameter "opts.write" missing.');
+  if (_.isUndefined(opts['write'])) {
+    throw new Error('Required parameter "opts[\'write\']" missing.');
   }
-  if (_.isUndefined(opts.manage)) {
-    throw new Error('Required parameter "opts.manage" missing.');
+  if (_.isUndefined(opts['manage'])) {
+    throw new Error('Required parameter "opts[\'manage\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/preview/sync/service/syncList/syncListItem.js
+++ b/lib/rest/preview/sync/service/syncList/syncListItem.js
@@ -76,8 +76,8 @@ SyncListItemList = function SyncListItemList(version, serviceSid, listSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.data)) {
-      throw new Error('Required parameter "opts.data" missing.');
+    if (_.isUndefined(opts['data'])) {
+      throw new Error('Required parameter "opts[\'data\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -747,8 +747,8 @@ SyncListItemContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.data)) {
-    throw new Error('Required parameter "opts.data" missing.');
+  if (_.isUndefined(opts['data'])) {
+    throw new Error('Required parameter "opts[\'data\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/preview/sync/service/syncList/syncListPermission.js
+++ b/lib/rest/preview/sync/service/syncList/syncListPermission.js
@@ -677,14 +677,14 @@ SyncListPermissionContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.read)) {
-    throw new Error('Required parameter "opts.read" missing.');
+  if (_.isUndefined(opts['read'])) {
+    throw new Error('Required parameter "opts[\'read\']" missing.');
   }
-  if (_.isUndefined(opts.write)) {
-    throw new Error('Required parameter "opts.write" missing.');
+  if (_.isUndefined(opts['write'])) {
+    throw new Error('Required parameter "opts[\'write\']" missing.');
   }
-  if (_.isUndefined(opts.manage)) {
-    throw new Error('Required parameter "opts.manage" missing.');
+  if (_.isUndefined(opts['manage'])) {
+    throw new Error('Required parameter "opts[\'manage\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/preview/sync/service/syncMap/syncMapItem.js
+++ b/lib/rest/preview/sync/service/syncMap/syncMapItem.js
@@ -77,11 +77,11 @@ SyncMapItemList = function SyncMapItemList(version, serviceSid, mapSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.key)) {
-      throw new Error('Required parameter "opts.key" missing.');
+    if (_.isUndefined(opts['key'])) {
+      throw new Error('Required parameter "opts[\'key\']" missing.');
     }
-    if (_.isUndefined(opts.data)) {
-      throw new Error('Required parameter "opts.data" missing.');
+    if (_.isUndefined(opts['data'])) {
+      throw new Error('Required parameter "opts[\'data\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -745,8 +745,8 @@ SyncMapItemContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.data)) {
-    throw new Error('Required parameter "opts.data" missing.');
+  if (_.isUndefined(opts['data'])) {
+    throw new Error('Required parameter "opts[\'data\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/preview/sync/service/syncMap/syncMapPermission.js
+++ b/lib/rest/preview/sync/service/syncMap/syncMapPermission.js
@@ -676,14 +676,14 @@ SyncMapPermissionContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.read)) {
-    throw new Error('Required parameter "opts.read" missing.');
+  if (_.isUndefined(opts['read'])) {
+    throw new Error('Required parameter "opts[\'read\']" missing.');
   }
-  if (_.isUndefined(opts.write)) {
-    throw new Error('Required parameter "opts.write" missing.');
+  if (_.isUndefined(opts['write'])) {
+    throw new Error('Required parameter "opts[\'write\']" missing.');
   }
-  if (_.isUndefined(opts.manage)) {
-    throw new Error('Required parameter "opts.manage" missing.');
+  if (_.isUndefined(opts['manage'])) {
+    throw new Error('Required parameter "opts[\'manage\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/preview/trusted_comms/brandedChannel/channel.js
+++ b/lib/rest/preview/trusted_comms/brandedChannel/channel.js
@@ -70,8 +70,8 @@ ChannelList = function ChannelList(version, brandedChannelSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.phoneNumberSid)) {
-      throw new Error('Required parameter "opts.phoneNumberSid" missing.');
+    if (_.isUndefined(opts['phoneNumberSid'])) {
+      throw new Error('Required parameter "opts[\'phoneNumberSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/understand/assistant/fieldType.js
+++ b/lib/rest/preview/understand/assistant/fieldType.js
@@ -321,8 +321,8 @@ FieldTypeList = function FieldTypeList(version, assistantSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/understand/assistant/fieldType/fieldValue.js
+++ b/lib/rest/preview/understand/assistant/fieldType/fieldValue.js
@@ -330,11 +330,11 @@ FieldValueList = function FieldValueList(version, assistantSid, fieldTypeSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.language)) {
-      throw new Error('Required parameter "opts.language" missing.');
+    if (_.isUndefined(opts['language'])) {
+      throw new Error('Required parameter "opts[\'language\']" missing.');
     }
-    if (_.isUndefined(opts.value)) {
-      throw new Error('Required parameter "opts.value" missing.');
+    if (_.isUndefined(opts['value'])) {
+      throw new Error('Required parameter "opts[\'value\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/understand/assistant/query.js
+++ b/lib/rest/preview/understand/assistant/query.js
@@ -343,11 +343,11 @@ QueryList = function QueryList(version, assistantSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.language)) {
-      throw new Error('Required parameter "opts.language" missing.');
+    if (_.isUndefined(opts['language'])) {
+      throw new Error('Required parameter "opts[\'language\']" missing.');
     }
-    if (_.isUndefined(opts.query)) {
-      throw new Error('Required parameter "opts.query" missing.');
+    if (_.isUndefined(opts['query'])) {
+      throw new Error('Required parameter "opts[\'query\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/understand/assistant/task.js
+++ b/lib/rest/preview/understand/assistant/task.js
@@ -329,8 +329,8 @@ TaskList = function TaskList(version, assistantSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/understand/assistant/task/field.js
+++ b/lib/rest/preview/understand/assistant/task/field.js
@@ -321,11 +321,11 @@ FieldList = function FieldList(version, assistantSid, taskSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.fieldType)) {
-      throw new Error('Required parameter "opts.fieldType" missing.');
+    if (_.isUndefined(opts['fieldType'])) {
+      throw new Error('Required parameter "opts[\'fieldType\']" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/understand/assistant/task/sample.js
+++ b/lib/rest/preview/understand/assistant/task/sample.js
@@ -326,11 +326,11 @@ SampleList = function SampleList(version, assistantSid, taskSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.language)) {
-      throw new Error('Required parameter "opts.language" missing.');
+    if (_.isUndefined(opts['language'])) {
+      throw new Error('Required parameter "opts[\'language\']" missing.');
     }
-    if (_.isUndefined(opts.taggedText)) {
-      throw new Error('Required parameter "opts.taggedText" missing.');
+    if (_.isUndefined(opts['taggedText'])) {
+      throw new Error('Required parameter "opts[\'taggedText\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/preview/wireless/command.js
+++ b/lib/rest/preview/wireless/command.js
@@ -338,8 +338,8 @@ CommandList = function CommandList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.command)) {
-      throw new Error('Required parameter "opts.command" missing.');
+    if (_.isUndefined(opts['command'])) {
+      throw new Error('Required parameter "opts[\'command\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/proxy/v1/service.js
+++ b/lib/rest/proxy/v1/service.js
@@ -331,8 +331,8 @@ ServiceList = function ServiceList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/proxy/v1/service/session/participant.js
+++ b/lib/rest/proxy/v1/service/session/participant.js
@@ -328,8 +328,8 @@ ParticipantList = function ParticipantList(version, serviceSid, sessionSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identifier)) {
-      throw new Error('Required parameter "opts.identifier" missing.');
+    if (_.isUndefined(opts['identifier'])) {
+      throw new Error('Required parameter "opts[\'identifier\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/proxy/v1/service/shortCode.js
+++ b/lib/rest/proxy/v1/service/shortCode.js
@@ -73,8 +73,8 @@ ShortCodeList = function ShortCodeList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.sid)) {
-      throw new Error('Required parameter "opts.sid" missing.');
+    if (_.isUndefined(opts['sid'])) {
+      throw new Error('Required parameter "opts[\'sid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/serverless/v1/service.js
+++ b/lib/rest/serverless/v1/service.js
@@ -326,11 +326,11 @@ ServiceList = function ServiceList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/serverless/v1/service/asset.js
+++ b/lib/rest/serverless/v1/service/asset.js
@@ -318,8 +318,8 @@ AssetList = function AssetList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -715,8 +715,8 @@ AssetContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.friendlyName)) {
-    throw new Error('Required parameter "opts.friendlyName" missing.');
+  if (_.isUndefined(opts['friendlyName'])) {
+    throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/serverless/v1/service/environment.js
+++ b/lib/rest/serverless/v1/service/environment.js
@@ -323,8 +323,8 @@ EnvironmentList = function EnvironmentList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/serverless/v1/service/environment/variable.js
+++ b/lib/rest/serverless/v1/service/environment/variable.js
@@ -322,11 +322,11 @@ VariableList = function VariableList(version, serviceSid, environmentSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.key)) {
-      throw new Error('Required parameter "opts.key" missing.');
+    if (_.isUndefined(opts['key'])) {
+      throw new Error('Required parameter "opts[\'key\']" missing.');
     }
-    if (_.isUndefined(opts.value)) {
-      throw new Error('Required parameter "opts.value" missing.');
+    if (_.isUndefined(opts['value'])) {
+      throw new Error('Required parameter "opts[\'value\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/serverless/v1/service/function.js
+++ b/lib/rest/serverless/v1/service/function.js
@@ -319,8 +319,8 @@ FunctionList = function FunctionList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -717,8 +717,8 @@ FunctionContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.friendlyName)) {
-    throw new Error('Required parameter "opts.friendlyName" missing.');
+  if (_.isUndefined(opts['friendlyName'])) {
+    throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/studio/v1/flow/engagement.js
+++ b/lib/rest/studio/v1/flow/engagement.js
@@ -322,11 +322,11 @@ EngagementList = function EngagementList(version, flowSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.to)) {
-      throw new Error('Required parameter "opts.to" missing.');
+    if (_.isUndefined(opts['to'])) {
+      throw new Error('Required parameter "opts[\'to\']" missing.');
     }
-    if (_.isUndefined(opts.from)) {
-      throw new Error('Required parameter "opts.from" missing.');
+    if (_.isUndefined(opts['from'])) {
+      throw new Error('Required parameter "opts[\'from\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/studio/v1/flow/execution.js
+++ b/lib/rest/studio/v1/flow/execution.js
@@ -336,11 +336,11 @@ ExecutionList = function ExecutionList(version, flowSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.to)) {
-      throw new Error('Required parameter "opts.to" missing.');
+    if (_.isUndefined(opts['to'])) {
+      throw new Error('Required parameter "opts[\'to\']" missing.');
     }
-    if (_.isUndefined(opts.from)) {
-      throw new Error('Required parameter "opts.from" missing.');
+    if (_.isUndefined(opts['from'])) {
+      throw new Error('Required parameter "opts[\'from\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -751,8 +751,8 @@ ExecutionContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.status)) {
-    throw new Error('Required parameter "opts.status" missing.');
+  if (_.isUndefined(opts['status'])) {
+    throw new Error('Required parameter "opts[\'status\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/studio/v2/flow.js
+++ b/lib/rest/studio/v2/flow.js
@@ -77,14 +77,14 @@ FlowList = function FlowList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.status)) {
-      throw new Error('Required parameter "opts.status" missing.');
+    if (_.isUndefined(opts['status'])) {
+      throw new Error('Required parameter "opts[\'status\']" missing.');
     }
-    if (_.isUndefined(opts.definition)) {
-      throw new Error('Required parameter "opts.definition" missing.');
+    if (_.isUndefined(opts['definition'])) {
+      throw new Error('Required parameter "opts[\'definition\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -700,8 +700,8 @@ FlowContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.status)) {
-    throw new Error('Required parameter "opts.status" missing.');
+  if (_.isUndefined(opts['status'])) {
+    throw new Error('Required parameter "opts[\'status\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/studio/v2/flow/execution.js
+++ b/lib/rest/studio/v2/flow/execution.js
@@ -336,11 +336,11 @@ ExecutionList = function ExecutionList(version, flowSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.to)) {
-      throw new Error('Required parameter "opts.to" missing.');
+    if (_.isUndefined(opts['to'])) {
+      throw new Error('Required parameter "opts[\'to\']" missing.');
     }
-    if (_.isUndefined(opts.from)) {
-      throw new Error('Required parameter "opts.from" missing.');
+    if (_.isUndefined(opts['from'])) {
+      throw new Error('Required parameter "opts[\'from\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -749,8 +749,8 @@ ExecutionContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.status)) {
-    throw new Error('Required parameter "opts.status" missing.');
+  if (_.isUndefined(opts['status'])) {
+    throw new Error('Required parameter "opts[\'status\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/studio/v2/flow/testUser.js
+++ b/lib/rest/studio/v2/flow/testUser.js
@@ -320,8 +320,8 @@ FlowTestUserContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.testUsers)) {
-    throw new Error('Required parameter "opts.testUsers" missing.');
+  if (_.isUndefined(opts['testUsers'])) {
+    throw new Error('Required parameter "opts[\'testUsers\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/studio/v2/flowValidate.js
+++ b/lib/rest/studio/v2/flowValidate.js
@@ -71,14 +71,14 @@ FlowValidateList = function FlowValidateList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.status)) {
-      throw new Error('Required parameter "opts.status" missing.');
+    if (_.isUndefined(opts['status'])) {
+      throw new Error('Required parameter "opts[\'status\']" missing.');
     }
-    if (_.isUndefined(opts.definition)) {
-      throw new Error('Required parameter "opts.definition" missing.');
+    if (_.isUndefined(opts['definition'])) {
+      throw new Error('Required parameter "opts[\'definition\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/supersim/v1/command.js
+++ b/lib/rest/supersim/v1/command.js
@@ -77,11 +77,11 @@ CommandList = function CommandList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.sim)) {
-      throw new Error('Required parameter "opts.sim" missing.');
+    if (_.isUndefined(opts['sim'])) {
+      throw new Error('Required parameter "opts[\'sim\']" missing.');
     }
-    if (_.isUndefined(opts.command)) {
-      throw new Error('Required parameter "opts.command" missing.');
+    if (_.isUndefined(opts['command'])) {
+      throw new Error('Required parameter "opts[\'command\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/supersim/v1/esimProfile.js
+++ b/lib/rest/supersim/v1/esimProfile.js
@@ -76,8 +76,8 @@ EsimProfileList = function EsimProfileList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.eid)) {
-      throw new Error('Required parameter "opts.eid" missing.');
+    if (_.isUndefined(opts['eid'])) {
+      throw new Error('Required parameter "opts[\'eid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/supersim/v1/fleet.js
+++ b/lib/rest/supersim/v1/fleet.js
@@ -91,8 +91,8 @@ FleetList = function FleetList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.networkAccessProfile)) {
-      throw new Error('Required parameter "opts.networkAccessProfile" missing.');
+    if (_.isUndefined(opts['networkAccessProfile'])) {
+      throw new Error('Required parameter "opts[\'networkAccessProfile\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/supersim/v1/ipCommand.js
+++ b/lib/rest/supersim/v1/ipCommand.js
@@ -81,14 +81,14 @@ IpCommandList = function IpCommandList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.sim)) {
-      throw new Error('Required parameter "opts.sim" missing.');
+    if (_.isUndefined(opts['sim'])) {
+      throw new Error('Required parameter "opts[\'sim\']" missing.');
     }
-    if (_.isUndefined(opts.payload)) {
-      throw new Error('Required parameter "opts.payload" missing.');
+    if (_.isUndefined(opts['payload'])) {
+      throw new Error('Required parameter "opts[\'payload\']" missing.');
     }
-    if (_.isUndefined(opts.devicePort)) {
-      throw new Error('Required parameter "opts.devicePort" missing.');
+    if (_.isUndefined(opts['devicePort'])) {
+      throw new Error('Required parameter "opts[\'devicePort\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/supersim/v1/networkAccessProfile/networkAccessProfileNetwork.js
+++ b/lib/rest/supersim/v1/networkAccessProfile/networkAccessProfileNetwork.js
@@ -322,8 +322,8 @@ NetworkAccessProfileNetworkList = function
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.network)) {
-      throw new Error('Required parameter "opts.network" missing.');
+    if (_.isUndefined(opts['network'])) {
+      throw new Error('Required parameter "opts[\'network\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/supersim/v1/sim.js
+++ b/lib/rest/supersim/v1/sim.js
@@ -75,11 +75,11 @@ SimList = function SimList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.iccid)) {
-      throw new Error('Required parameter "opts.iccid" missing.');
+    if (_.isUndefined(opts['iccid'])) {
+      throw new Error('Required parameter "opts[\'iccid\']" missing.');
     }
-    if (_.isUndefined(opts.registrationCode)) {
-      throw new Error('Required parameter "opts.registrationCode" missing.');
+    if (_.isUndefined(opts['registrationCode'])) {
+      throw new Error('Required parameter "opts[\'registrationCode\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/supersim/v1/smsCommand.js
+++ b/lib/rest/supersim/v1/smsCommand.js
@@ -77,11 +77,11 @@ SmsCommandList = function SmsCommandList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.sim)) {
-      throw new Error('Required parameter "opts.sim" missing.');
+    if (_.isUndefined(opts['sim'])) {
+      throw new Error('Required parameter "opts[\'sim\']" missing.');
     }
-    if (_.isUndefined(opts.payload)) {
-      throw new Error('Required parameter "opts.payload" missing.');
+    if (_.isUndefined(opts['payload'])) {
+      throw new Error('Required parameter "opts[\'payload\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/sync/v1/service/document/documentPermission.js
+++ b/lib/rest/sync/v1/service/document/documentPermission.js
@@ -671,14 +671,14 @@ DocumentPermissionContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.read)) {
-    throw new Error('Required parameter "opts.read" missing.');
+  if (_.isUndefined(opts['read'])) {
+    throw new Error('Required parameter "opts[\'read\']" missing.');
   }
-  if (_.isUndefined(opts.write)) {
-    throw new Error('Required parameter "opts.write" missing.');
+  if (_.isUndefined(opts['write'])) {
+    throw new Error('Required parameter "opts[\'write\']" missing.');
   }
-  if (_.isUndefined(opts.manage)) {
-    throw new Error('Required parameter "opts.manage" missing.');
+  if (_.isUndefined(opts['manage'])) {
+    throw new Error('Required parameter "opts[\'manage\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/sync/v1/service/syncList/syncListItem.js
+++ b/lib/rest/sync/v1/service/syncList/syncListItem.js
@@ -79,8 +79,8 @@ SyncListItemList = function SyncListItemList(version, serviceSid, listSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.data)) {
-      throw new Error('Required parameter "opts.data" missing.');
+    if (_.isUndefined(opts['data'])) {
+      throw new Error('Required parameter "opts[\'data\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/sync/v1/service/syncList/syncListPermission.js
+++ b/lib/rest/sync/v1/service/syncList/syncListPermission.js
@@ -668,14 +668,14 @@ SyncListPermissionContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.read)) {
-    throw new Error('Required parameter "opts.read" missing.');
+  if (_.isUndefined(opts['read'])) {
+    throw new Error('Required parameter "opts[\'read\']" missing.');
   }
-  if (_.isUndefined(opts.write)) {
-    throw new Error('Required parameter "opts.write" missing.');
+  if (_.isUndefined(opts['write'])) {
+    throw new Error('Required parameter "opts[\'write\']" missing.');
   }
-  if (_.isUndefined(opts.manage)) {
-    throw new Error('Required parameter "opts.manage" missing.');
+  if (_.isUndefined(opts['manage'])) {
+    throw new Error('Required parameter "opts[\'manage\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/sync/v1/service/syncMap/syncMapItem.js
+++ b/lib/rest/sync/v1/service/syncMap/syncMapItem.js
@@ -80,11 +80,11 @@ SyncMapItemList = function SyncMapItemList(version, serviceSid, mapSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.key)) {
-      throw new Error('Required parameter "opts.key" missing.');
+    if (_.isUndefined(opts['key'])) {
+      throw new Error('Required parameter "opts[\'key\']" missing.');
     }
-    if (_.isUndefined(opts.data)) {
-      throw new Error('Required parameter "opts.data" missing.');
+    if (_.isUndefined(opts['data'])) {
+      throw new Error('Required parameter "opts[\'data\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/sync/v1/service/syncMap/syncMapPermission.js
+++ b/lib/rest/sync/v1/service/syncMap/syncMapPermission.js
@@ -665,14 +665,14 @@ SyncMapPermissionContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.read)) {
-    throw new Error('Required parameter "opts.read" missing.');
+  if (_.isUndefined(opts['read'])) {
+    throw new Error('Required parameter "opts[\'read\']" missing.');
   }
-  if (_.isUndefined(opts.write)) {
-    throw new Error('Required parameter "opts.write" missing.');
+  if (_.isUndefined(opts['write'])) {
+    throw new Error('Required parameter "opts[\'write\']" missing.');
   }
-  if (_.isUndefined(opts.manage)) {
-    throw new Error('Required parameter "opts.manage" missing.');
+  if (_.isUndefined(opts['manage'])) {
+    throw new Error('Required parameter "opts[\'manage\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/sync/v1/service/syncStream/streamMessage.js
+++ b/lib/rest/sync/v1/service/syncStream/streamMessage.js
@@ -71,8 +71,8 @@ StreamMessageList = function StreamMessageList(version, serviceSid, streamSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.data)) {
-      throw new Error('Required parameter "opts.data" missing.');
+    if (_.isUndefined(opts['data'])) {
+      throw new Error('Required parameter "opts[\'data\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/taskrouter/v1/workspace.js
+++ b/lib/rest/taskrouter/v1/workspace.js
@@ -341,8 +341,8 @@ WorkspaceList = function WorkspaceList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/taskrouter/v1/workspace/activity.js
+++ b/lib/rest/taskrouter/v1/workspace/activity.js
@@ -331,8 +331,8 @@ ActivityList = function ActivityList(version, workspaceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/taskrouter/v1/workspace/taskChannel.js
+++ b/lib/rest/taskrouter/v1/workspace/taskChannel.js
@@ -320,11 +320,11 @@ TaskChannelList = function TaskChannelList(version, workspaceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/taskrouter/v1/workspace/taskQueue.js
+++ b/lib/rest/taskrouter/v1/workspace/taskQueue.js
@@ -357,8 +357,8 @@ TaskQueueList = function TaskQueueList(version, workspaceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/taskrouter/v1/workspace/worker.js
+++ b/lib/rest/taskrouter/v1/workspace/worker.js
@@ -381,8 +381,8 @@ WorkerList = function WorkerList(version, workspaceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/taskrouter/v1/workspace/workflow.js
+++ b/lib/rest/taskrouter/v1/workspace/workflow.js
@@ -336,11 +336,11 @@ WorkflowList = function WorkflowList(version, workspaceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.configuration)) {
-      throw new Error('Required parameter "opts.configuration" missing.');
+    if (_.isUndefined(opts['configuration'])) {
+      throw new Error('Required parameter "opts[\'configuration\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trunking/v1/trunk/credentialList.js
+++ b/lib/rest/trunking/v1/trunk/credentialList.js
@@ -71,8 +71,8 @@ CredentialListList = function CredentialListList(version, trunkSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.credentialListSid)) {
-      throw new Error('Required parameter "opts.credentialListSid" missing.');
+    if (_.isUndefined(opts['credentialListSid'])) {
+      throw new Error('Required parameter "opts[\'credentialListSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trunking/v1/trunk/ipAccessControlList.js
+++ b/lib/rest/trunking/v1/trunk/ipAccessControlList.js
@@ -70,8 +70,8 @@ IpAccessControlListList = function IpAccessControlListList(version, trunkSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.ipAccessControlListSid)) {
-      throw new Error('Required parameter "opts.ipAccessControlListSid" missing.');
+    if (_.isUndefined(opts['ipAccessControlListSid'])) {
+      throw new Error('Required parameter "opts[\'ipAccessControlListSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trunking/v1/trunk/originationUrl.js
+++ b/lib/rest/trunking/v1/trunk/originationUrl.js
@@ -76,20 +76,20 @@ OriginationUrlList = function OriginationUrlList(version, trunkSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.weight)) {
-      throw new Error('Required parameter "opts.weight" missing.');
+    if (_.isUndefined(opts['weight'])) {
+      throw new Error('Required parameter "opts[\'weight\']" missing.');
     }
-    if (_.isUndefined(opts.priority)) {
-      throw new Error('Required parameter "opts.priority" missing.');
+    if (_.isUndefined(opts['priority'])) {
+      throw new Error('Required parameter "opts[\'priority\']" missing.');
     }
-    if (_.isUndefined(opts.enabled)) {
-      throw new Error('Required parameter "opts.enabled" missing.');
+    if (_.isUndefined(opts['enabled'])) {
+      throw new Error('Required parameter "opts[\'enabled\']" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.sipUrl)) {
-      throw new Error('Required parameter "opts.sipUrl" missing.');
+    if (_.isUndefined(opts['sipUrl'])) {
+      throw new Error('Required parameter "opts[\'sipUrl\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trunking/v1/trunk/phoneNumber.js
+++ b/lib/rest/trunking/v1/trunk/phoneNumber.js
@@ -71,8 +71,8 @@ PhoneNumberList = function PhoneNumberList(version, trunkSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.phoneNumberSid)) {
-      throw new Error('Required parameter "opts.phoneNumberSid" missing.');
+    if (_.isUndefined(opts['phoneNumberSid'])) {
+      throw new Error('Required parameter "opts[\'phoneNumberSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trusthub/v1/customerProfiles.js
+++ b/lib/rest/trusthub/v1/customerProfiles.js
@@ -79,14 +79,14 @@ CustomerProfilesList = function CustomerProfilesList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.email)) {
-      throw new Error('Required parameter "opts.email" missing.');
+    if (_.isUndefined(opts['email'])) {
+      throw new Error('Required parameter "opts[\'email\']" missing.');
     }
-    if (_.isUndefined(opts.policySid)) {
-      throw new Error('Required parameter "opts.policySid" missing.');
+    if (_.isUndefined(opts['policySid'])) {
+      throw new Error('Required parameter "opts[\'policySid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trusthub/v1/customerProfiles/customerProfilesChannelEndpointAssignment.js
+++ b/lib/rest/trusthub/v1/customerProfiles/customerProfilesChannelEndpointAssignment.js
@@ -75,11 +75,11 @@ CustomerProfilesChannelEndpointAssignmentList = function
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.channelEndpointType)) {
-      throw new Error('Required parameter "opts.channelEndpointType" missing.');
+    if (_.isUndefined(opts['channelEndpointType'])) {
+      throw new Error('Required parameter "opts[\'channelEndpointType\']" missing.');
     }
-    if (_.isUndefined(opts.channelEndpointSid)) {
-      throw new Error('Required parameter "opts.channelEndpointSid" missing.');
+    if (_.isUndefined(opts['channelEndpointSid'])) {
+      throw new Error('Required parameter "opts[\'channelEndpointSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trusthub/v1/customerProfiles/customerProfilesEntityAssignments.js
+++ b/lib/rest/trusthub/v1/customerProfiles/customerProfilesEntityAssignments.js
@@ -72,8 +72,8 @@ CustomerProfilesEntityAssignmentsList = function
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.objectSid)) {
-      throw new Error('Required parameter "opts.objectSid" missing.');
+    if (_.isUndefined(opts['objectSid'])) {
+      throw new Error('Required parameter "opts[\'objectSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trusthub/v1/customerProfiles/customerProfilesEvaluations.js
+++ b/lib/rest/trusthub/v1/customerProfiles/customerProfilesEvaluations.js
@@ -72,8 +72,8 @@ CustomerProfilesEvaluationsList = function
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.policySid)) {
-      throw new Error('Required parameter "opts.policySid" missing.');
+    if (_.isUndefined(opts['policySid'])) {
+      throw new Error('Required parameter "opts[\'policySid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trusthub/v1/endUser.js
+++ b/lib/rest/trusthub/v1/endUser.js
@@ -73,11 +73,11 @@ EndUserList = function EndUserList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trusthub/v1/supportingDocument.js
+++ b/lib/rest/trusthub/v1/supportingDocument.js
@@ -73,11 +73,11 @@ SupportingDocumentList = function SupportingDocumentList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.type)) {
-      throw new Error('Required parameter "opts.type" missing.');
+    if (_.isUndefined(opts['type'])) {
+      throw new Error('Required parameter "opts[\'type\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trusthub/v1/trustProducts.js
+++ b/lib/rest/trusthub/v1/trustProducts.js
@@ -79,14 +79,14 @@ TrustProductsList = function TrustProductsList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.email)) {
-      throw new Error('Required parameter "opts.email" missing.');
+    if (_.isUndefined(opts['email'])) {
+      throw new Error('Required parameter "opts[\'email\']" missing.');
     }
-    if (_.isUndefined(opts.policySid)) {
-      throw new Error('Required parameter "opts.policySid" missing.');
+    if (_.isUndefined(opts['policySid'])) {
+      throw new Error('Required parameter "opts[\'policySid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trusthub/v1/trustProducts/trustProductsChannelEndpointAssignment.js
+++ b/lib/rest/trusthub/v1/trustProducts/trustProductsChannelEndpointAssignment.js
@@ -73,11 +73,11 @@ TrustProductsChannelEndpointAssignmentList = function
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.channelEndpointType)) {
-      throw new Error('Required parameter "opts.channelEndpointType" missing.');
+    if (_.isUndefined(opts['channelEndpointType'])) {
+      throw new Error('Required parameter "opts[\'channelEndpointType\']" missing.');
     }
-    if (_.isUndefined(opts.channelEndpointSid)) {
-      throw new Error('Required parameter "opts.channelEndpointSid" missing.');
+    if (_.isUndefined(opts['channelEndpointSid'])) {
+      throw new Error('Required parameter "opts[\'channelEndpointSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trusthub/v1/trustProducts/trustProductsEntityAssignments.js
+++ b/lib/rest/trusthub/v1/trustProducts/trustProductsEntityAssignments.js
@@ -72,8 +72,8 @@ TrustProductsEntityAssignmentsList = function
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.objectSid)) {
-      throw new Error('Required parameter "opts.objectSid" missing.');
+    if (_.isUndefined(opts['objectSid'])) {
+      throw new Error('Required parameter "opts[\'objectSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/trusthub/v1/trustProducts/trustProductsEvaluations.js
+++ b/lib/rest/trusthub/v1/trustProducts/trustProductsEvaluations.js
@@ -70,8 +70,8 @@ TrustProductsEvaluationsList = function TrustProductsEvaluationsList(version,
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.policySid)) {
-      throw new Error('Required parameter "opts.policySid" missing.');
+    if (_.isUndefined(opts['policySid'])) {
+      throw new Error('Required parameter "opts[\'policySid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/verify/v2/service.js
+++ b/lib/rest/verify/v2/service.js
@@ -110,8 +110,8 @@ ServiceList = function ServiceList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/verify/v2/service/accessToken.js
+++ b/lib/rest/verify/v2/service/accessToken.js
@@ -72,11 +72,11 @@ AccessTokenList = function AccessTokenList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
-    if (_.isUndefined(opts.factorType)) {
-      throw new Error('Required parameter "opts.factorType" missing.');
+    if (_.isUndefined(opts['factorType'])) {
+      throw new Error('Required parameter "opts[\'factorType\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/verify/v2/service/entity.js
+++ b/lib/rest/verify/v2/service/entity.js
@@ -75,8 +75,8 @@ EntityList = function EntityList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.identity)) {
-      throw new Error('Required parameter "opts.identity" missing.');
+    if (_.isUndefined(opts['identity'])) {
+      throw new Error('Required parameter "opts[\'identity\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/verify/v2/service/entity/challenge.js
+++ b/lib/rest/verify/v2/service/entity/challenge.js
@@ -84,8 +84,8 @@ ChallengeList = function ChallengeList(version, serviceSid, identity) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.factorSid)) {
-      throw new Error('Required parameter "opts.factorSid" missing.');
+    if (_.isUndefined(opts['factorSid'])) {
+      throw new Error('Required parameter "opts[\'factorSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/verify/v2/service/entity/newFactor.js
+++ b/lib/rest/verify/v2/service/entity/newFactor.js
@@ -93,11 +93,11 @@ NewFactorList = function NewFactorList(version, serviceSid, identity) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.factorType)) {
-      throw new Error('Required parameter "opts.factorType" missing.');
+    if (_.isUndefined(opts['factorType'])) {
+      throw new Error('Required parameter "opts[\'factorType\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/verify/v2/service/messagingConfiguration.js
+++ b/lib/rest/verify/v2/service/messagingConfiguration.js
@@ -74,11 +74,11 @@ MessagingConfigurationList = function MessagingConfigurationList(version,
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.country)) {
-      throw new Error('Required parameter "opts.country" missing.');
+    if (_.isUndefined(opts['country'])) {
+      throw new Error('Required parameter "opts[\'country\']" missing.');
     }
-    if (_.isUndefined(opts.messagingServiceSid)) {
-      throw new Error('Required parameter "opts.messagingServiceSid" missing.');
+    if (_.isUndefined(opts['messagingServiceSid'])) {
+      throw new Error('Required parameter "opts[\'messagingServiceSid\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -639,8 +639,8 @@ MessagingConfigurationContext.prototype.update = function update(opts, callback)
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.messagingServiceSid)) {
-    throw new Error('Required parameter "opts.messagingServiceSid" missing.');
+  if (_.isUndefined(opts['messagingServiceSid'])) {
+    throw new Error('Required parameter "opts[\'messagingServiceSid\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/verify/v2/service/rateLimit.js
+++ b/lib/rest/verify/v2/service/rateLimit.js
@@ -73,8 +73,8 @@ RateLimitList = function RateLimitList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.uniqueName)) {
-      throw new Error('Required parameter "opts.uniqueName" missing.');
+    if (_.isUndefined(opts['uniqueName'])) {
+      throw new Error('Required parameter "opts[\'uniqueName\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/verify/v2/service/rateLimit/bucket.js
+++ b/lib/rest/verify/v2/service/rateLimit/bucket.js
@@ -73,11 +73,11 @@ BucketList = function BucketList(version, serviceSid, rateLimitSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.max)) {
-      throw new Error('Required parameter "opts.max" missing.');
+    if (_.isUndefined(opts['max'])) {
+      throw new Error('Required parameter "opts[\'max\']" missing.');
     }
-    if (_.isUndefined(opts.interval)) {
-      throw new Error('Required parameter "opts.interval" missing.');
+    if (_.isUndefined(opts['interval'])) {
+      throw new Error('Required parameter "opts[\'interval\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/verify/v2/service/verification.js
+++ b/lib/rest/verify/v2/service/verification.js
@@ -93,11 +93,11 @@ VerificationList = function VerificationList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.to)) {
-      throw new Error('Required parameter "opts.to" missing.');
+    if (_.isUndefined(opts['to'])) {
+      throw new Error('Required parameter "opts[\'to\']" missing.');
     }
-    if (_.isUndefined(opts.channel)) {
-      throw new Error('Required parameter "opts.channel" missing.');
+    if (_.isUndefined(opts['channel'])) {
+      throw new Error('Required parameter "opts[\'channel\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -415,8 +415,8 @@ VerificationContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.status)) {
-    throw new Error('Required parameter "opts.status" missing.');
+  if (_.isUndefined(opts['status'])) {
+    throw new Error('Required parameter "opts[\'status\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/verify/v2/service/verificationCheck.js
+++ b/lib/rest/verify/v2/service/verificationCheck.js
@@ -76,8 +76,8 @@ VerificationCheckList = function VerificationCheckList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.code)) {
-      throw new Error('Required parameter "opts.code" missing.');
+    if (_.isUndefined(opts['code'])) {
+      throw new Error('Required parameter "opts[\'code\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/verify/v2/service/webhook.js
+++ b/lib/rest/verify/v2/service/webhook.js
@@ -79,14 +79,14 @@ WebhookList = function WebhookList(version, serviceSid) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
-    if (_.isUndefined(opts.eventTypes)) {
-      throw new Error('Required parameter "opts.eventTypes" missing.');
+    if (_.isUndefined(opts['eventTypes'])) {
+      throw new Error('Required parameter "opts[\'eventTypes\']" missing.');
     }
-    if (_.isUndefined(opts.webhookUrl)) {
-      throw new Error('Required parameter "opts.webhookUrl" missing.');
+    if (_.isUndefined(opts['webhookUrl'])) {
+      throw new Error('Required parameter "opts[\'webhookUrl\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/video/v1/composition.js
+++ b/lib/rest/video/v1/composition.js
@@ -358,8 +358,8 @@ CompositionList = function CompositionList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.roomSid)) {
-      throw new Error('Required parameter "opts.roomSid" missing.');
+    if (_.isUndefined(opts['roomSid'])) {
+      throw new Error('Required parameter "opts[\'roomSid\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/video/v1/compositionHook.js
+++ b/lib/rest/video/v1/compositionHook.js
@@ -358,8 +358,8 @@ CompositionHookList = function CompositionHookList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.friendlyName)) {
-      throw new Error('Required parameter "opts.friendlyName" missing.');
+    if (_.isUndefined(opts['friendlyName'])) {
+      throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -780,8 +780,8 @@ CompositionHookContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.friendlyName)) {
-    throw new Error('Required parameter "opts.friendlyName" missing.');
+  if (_.isUndefined(opts['friendlyName'])) {
+    throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/video/v1/compositionSettings.js
+++ b/lib/rest/video/v1/compositionSettings.js
@@ -353,8 +353,8 @@ CompositionSettingsContext.prototype.create = function create(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.friendlyName)) {
-    throw new Error('Required parameter "opts.friendlyName" missing.');
+  if (_.isUndefined(opts['friendlyName'])) {
+    throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/video/v1/recordingSettings.js
+++ b/lib/rest/video/v1/recordingSettings.js
@@ -351,8 +351,8 @@ RecordingSettingsContext.prototype.create = function create(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.friendlyName)) {
-    throw new Error('Required parameter "opts.friendlyName" missing.');
+  if (_.isUndefined(opts['friendlyName'])) {
+    throw new Error('Required parameter "opts[\'friendlyName\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/video/v1/room.js
+++ b/lib/rest/video/v1/room.js
@@ -775,8 +775,8 @@ RoomContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.status)) {
-    throw new Error('Required parameter "opts.status" missing.');
+  if (_.isUndefined(opts['status'])) {
+    throw new Error('Required parameter "opts[\'status\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/voice/v1/connectionPolicy/connectionPolicyTarget.js
+++ b/lib/rest/voice/v1/connectionPolicy/connectionPolicyTarget.js
@@ -78,8 +78,8 @@ ConnectionPolicyTargetList = function ConnectionPolicyTargetList(version,
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.target)) {
-      throw new Error('Required parameter "opts.target" missing.');
+    if (_.isUndefined(opts['target'])) {
+      throw new Error('Required parameter "opts[\'target\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/voice/v1/dialingPermissions/bulkCountryUpdate.js
+++ b/lib/rest/voice/v1/dialingPermissions/bulkCountryUpdate.js
@@ -71,8 +71,8 @@ BulkCountryUpdateList = function BulkCountryUpdateList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.updateRequest)) {
-      throw new Error('Required parameter "opts.updateRequest" missing.');
+    if (_.isUndefined(opts['updateRequest'])) {
+      throw new Error('Required parameter "opts[\'updateRequest\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/voice/v1/ipRecord.js
+++ b/lib/rest/voice/v1/ipRecord.js
@@ -72,8 +72,8 @@ IpRecordList = function IpRecordList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.ipAddress)) {
-      throw new Error('Required parameter "opts.ipAddress" missing.');
+    if (_.isUndefined(opts['ipAddress'])) {
+      throw new Error('Required parameter "opts[\'ipAddress\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/lib/rest/voice/v1/sourceIpMapping.js
+++ b/lib/rest/voice/v1/sourceIpMapping.js
@@ -71,11 +71,11 @@ SourceIpMappingList = function SourceIpMappingList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.ipRecordSid)) {
-      throw new Error('Required parameter "opts.ipRecordSid" missing.');
+    if (_.isUndefined(opts['ipRecordSid'])) {
+      throw new Error('Required parameter "opts[\'ipRecordSid\']" missing.');
     }
-    if (_.isUndefined(opts.sipDomainSid)) {
-      throw new Error('Required parameter "opts.sipDomainSid" missing.');
+    if (_.isUndefined(opts['sipDomainSid'])) {
+      throw new Error('Required parameter "opts[\'sipDomainSid\']" missing.');
     }
 
     var deferred = Q.defer();
@@ -643,8 +643,8 @@ SourceIpMappingContext.prototype.update = function update(opts, callback) {
   if (_.isUndefined(opts)) {
     throw new Error('Required parameter "opts" missing.');
   }
-  if (_.isUndefined(opts.sipDomainSid)) {
-    throw new Error('Required parameter "opts.sipDomainSid" missing.');
+  if (_.isUndefined(opts['sipDomainSid'])) {
+    throw new Error('Required parameter "opts[\'sipDomainSid\']" missing.');
   }
 
   var deferred = Q.defer();

--- a/lib/rest/wireless/v1/command.js
+++ b/lib/rest/wireless/v1/command.js
@@ -348,8 +348,8 @@ CommandList = function CommandList(version) {
     if (_.isUndefined(opts)) {
       throw new Error('Required parameter "opts" missing.');
     }
-    if (_.isUndefined(opts.command)) {
-      throw new Error('Required parameter "opts.command" missing.');
+    if (_.isUndefined(opts['command'])) {
+      throw new Error('Required parameter "opts[\'command\']" missing.');
     }
 
     var deferred = Q.defer();

--- a/spec/integration/rest/accounts/v1/credential/aws.spec.js
+++ b/spec/integration/rest/accounts/v1/credential/aws.spec.js
@@ -206,7 +206,7 @@ describe('Aws', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {credentials: 'AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'};
+      var opts = {'credentials': 'AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'};
       var promise = client.accounts.v1.credentials
                                       .aws.create(opts);
       promise.then(function() {
@@ -218,7 +218,7 @@ describe('Aws', function() {
 
       var url = 'https://accounts.twilio.com/v1/Credentials/AWS';
 
-      var values = {Credentials: 'AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY', };
+      var values = {'Credentials': 'AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -239,7 +239,7 @@ describe('Aws', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {credentials: 'AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'};
+      var opts = {'credentials': 'AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'};
       var promise = client.accounts.v1.credentials
                                       .aws.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/accounts/v1/credential/publicKey.spec.js
+++ b/spec/integration/rest/accounts/v1/credential/publicKey.spec.js
@@ -206,7 +206,7 @@ describe('PublicKey', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {publicKey: 'publickey'};
+      var opts = {'publicKey': 'publickey'};
       var promise = client.accounts.v1.credentials
                                       .publicKey.create(opts);
       promise.then(function() {
@@ -218,7 +218,7 @@ describe('PublicKey', function() {
 
       var url = 'https://accounts.twilio.com/v1/Credentials/PublicKeys';
 
-      var values = {PublicKey: 'publickey', };
+      var values = {'PublicKey': 'publickey', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -239,7 +239,7 @@ describe('PublicKey', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {publicKey: 'publickey'};
+      var opts = {'publicKey': 'publickey'};
       var promise = client.accounts.v1.credentials
                                       .publicKey.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/api/v2010/account/address.spec.js
+++ b/spec/integration/rest/api/v2010/account/address.spec.js
@@ -34,12 +34,12 @@ describe('Address', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        customerName: 'customer_name',
-        street: 'street',
-        city: 'city',
-        region: 'region',
-        postalCode: 'postal_code',
-        isoCountry: 'US'
+        'customerName': 'customer_name',
+        'street': 'street',
+        'city': 'city',
+        'region': 'region',
+        'postalCode': 'postal_code',
+        'isoCountry': 'US'
       };
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .addresses.create(opts);
@@ -54,12 +54,12 @@ describe('Address', function() {
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Addresses.json`;
 
       var values = {
-        CustomerName: 'customer_name',
-        Street: 'street',
-        City: 'city',
-        Region: 'region',
-        PostalCode: 'postal_code',
-        IsoCountry: 'US',
+        'CustomerName': 'customer_name',
+        'Street': 'street',
+        'City': 'city',
+        'Region': 'region',
+        'PostalCode': 'postal_code',
+        'IsoCountry': 'US',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -91,12 +91,12 @@ describe('Address', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        customerName: 'customer_name',
-        street: 'street',
-        city: 'city',
-        region: 'region',
-        postalCode: 'postal_code',
-        isoCountry: 'US'
+        'customerName': 'customer_name',
+        'street': 'street',
+        'city': 'city',
+        'region': 'region',
+        'postalCode': 'postal_code',
+        'isoCountry': 'US'
       };
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .addresses.create(opts);

--- a/spec/integration/rest/api/v2010/account/call.spec.js
+++ b/spec/integration/rest/api/v2010/account/call.spec.js
@@ -33,7 +33,7 @@ describe('Call', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {to: '+15558675310', from: '+15017122661'};
+      var opts = {'to': '+15558675310', 'from': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('Call', function() {
       var accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Calls.json`;
 
-      var values = {To: '+15558675310', From: '+15017122661', };
+      var values = {'To': '+15558675310', 'From': '+15017122661', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -96,7 +96,7 @@ describe('Call', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310', from: '+15017122661'};
+      var opts = {'to': '+15558675310', 'from': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls.create(opts);
       promise.then(function(response) {
@@ -149,7 +149,7 @@ describe('Call', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310', from: '+15017122661'};
+      var opts = {'to': '+15558675310', 'from': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/api/v2010/account/call/feedback.spec.js
+++ b/spec/integration/rest/api/v2010/account/call/feedback.spec.js
@@ -84,7 +84,7 @@ describe('Feedback', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {qualityScore: 1};
+      var opts = {'qualityScore': 1};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .feedback().create(opts);
@@ -99,7 +99,7 @@ describe('Feedback', function() {
       var callSid = 'CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Calls/${callSid}/Feedback.json`;
 
-      var values = {QualityScore: 1, };
+      var values = {'QualityScore': 1, };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -123,7 +123,7 @@ describe('Feedback', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {qualityScore: 1};
+      var opts = {'qualityScore': 1};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .feedback().create(opts);

--- a/spec/integration/rest/api/v2010/account/call/feedbackSummary.spec.js
+++ b/spec/integration/rest/api/v2010/account/call/feedbackSummary.spec.js
@@ -35,7 +35,7 @@ describe('FeedbackSummary', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {startDate: new Date(Date.UTC(2008, 0, 2)), endDate: new Date(Date.UTC(2008, 0, 2))};
+      var opts = {'startDate': new Date(Date.UTC(2008, 0, 2)), 'endDate': new Date(Date.UTC(2008, 0, 2))};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls
                                     .feedbackSummaries.create(opts);
@@ -50,8 +50,8 @@ describe('FeedbackSummary', function() {
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Calls/FeedbackSummary.json`;
 
       var values = {
-        StartDate: serialize.iso8601Date(new Date(Date.UTC(2008, 0, 2))),
-        EndDate: serialize.iso8601Date(new Date(Date.UTC(2008, 0, 2))),
+        'StartDate': serialize.iso8601Date(new Date(Date.UTC(2008, 0, 2))),
+        'EndDate': serialize.iso8601Date(new Date(Date.UTC(2008, 0, 2))),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -87,7 +87,7 @@ describe('FeedbackSummary', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {startDate: new Date(Date.UTC(2008, 0, 2)), endDate: new Date(Date.UTC(2008, 0, 2))};
+      var opts = {'startDate': new Date(Date.UTC(2008, 0, 2)), 'endDate': new Date(Date.UTC(2008, 0, 2))};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls
                                     .feedbackSummaries.create(opts);

--- a/spec/integration/rest/api/v2010/account/call/payment.spec.js
+++ b/spec/integration/rest/api/v2010/account/call/payment.spec.js
@@ -33,7 +33,7 @@ describe('Payment', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {idempotencyKey: 'idempotency_key', statusCallback: 'https://example.com'};
+      var opts = {'idempotencyKey': 'idempotency_key', 'statusCallback': 'https://example.com'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .payments.create(opts);
@@ -48,7 +48,7 @@ describe('Payment', function() {
       var callSid = 'CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Calls/${callSid}/Payments.json`;
 
-      var values = {IdempotencyKey: 'idempotency_key', StatusCallback: 'https://example.com', };
+      var values = {'IdempotencyKey': 'idempotency_key', 'StatusCallback': 'https://example.com', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -69,7 +69,7 @@ describe('Payment', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {idempotencyKey: 'idempotency_key', statusCallback: 'https://example.com'};
+      var opts = {'idempotencyKey': 'idempotency_key', 'statusCallback': 'https://example.com'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .payments.create(opts);
@@ -85,7 +85,7 @@ describe('Payment', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {idempotencyKey: 'idempotency_key', statusCallback: 'https://example.com'};
+      var opts = {'idempotencyKey': 'idempotency_key', 'statusCallback': 'https://example.com'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .payments('PKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -101,7 +101,7 @@ describe('Payment', function() {
       var sid = 'PKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Calls/${callSid}/Payments/${sid}.json`;
 
-      var values = {IdempotencyKey: 'idempotency_key', StatusCallback: 'https://example.com', };
+      var values = {'IdempotencyKey': 'idempotency_key', 'StatusCallback': 'https://example.com', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -122,7 +122,7 @@ describe('Payment', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {idempotencyKey: 'idempotency_key', statusCallback: 'https://example.com'};
+      var opts = {'idempotencyKey': 'idempotency_key', 'statusCallback': 'https://example.com'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .payments('PKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -147,7 +147,7 @@ describe('Payment', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {idempotencyKey: 'idempotency_key', statusCallback: 'https://example.com'};
+      var opts = {'idempotencyKey': 'idempotency_key', 'statusCallback': 'https://example.com'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .payments('PKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -172,7 +172,7 @@ describe('Payment', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {idempotencyKey: 'idempotency_key', statusCallback: 'https://example.com'};
+      var opts = {'idempotencyKey': 'idempotency_key', 'statusCallback': 'https://example.com'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .payments('PKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/api/v2010/account/call/recording.spec.js
+++ b/spec/integration/rest/api/v2010/account/call/recording.spec.js
@@ -93,7 +93,7 @@ describe('Recording', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {status: 'in-progress'};
+      var opts = {'status': 'in-progress'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .recordings('REXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -109,7 +109,7 @@ describe('Recording', function() {
       var sid = 'REXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Calls/${callSid}/Recordings/${sid}.json`;
 
-      var values = {Status: 'in-progress', };
+      var values = {'Status': 'in-progress', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -142,7 +142,7 @@ describe('Recording', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'in-progress'};
+      var opts = {'status': 'in-progress'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .recordings('REXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/api/v2010/account/call/siprec.spec.js
+++ b/spec/integration/rest/api/v2010/account/call/siprec.spec.js
@@ -105,7 +105,7 @@ describe('Siprec', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {status: 'stopped'};
+      var opts = {'status': 'stopped'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .siprec('SRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -121,7 +121,7 @@ describe('Siprec', function() {
       var sid = 'SRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Calls/${callSid}/Siprec/${sid}.json`;
 
-      var values = {Status: 'stopped', };
+      var values = {'Status': 'stopped', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -142,7 +142,7 @@ describe('Siprec', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'stopped'};
+      var opts = {'status': 'stopped'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .siprec('SRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -167,7 +167,7 @@ describe('Siprec', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'stopped'};
+      var opts = {'status': 'stopped'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .calls('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .siprec('SRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/api/v2010/account/conference/participant.spec.js
+++ b/spec/integration/rest/api/v2010/account/conference/participant.spec.js
@@ -339,7 +339,7 @@ describe('Participant', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -354,7 +354,7 @@ describe('Participant', function() {
       var conferenceSid = 'CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Conferences/${conferenceSid}/Participants.json`;
 
-      var values = {From: '+15017122661', To: '+15558675310', };
+      var values = {'From': '+15017122661', 'To': '+15558675310', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -383,7 +383,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -416,7 +416,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -449,7 +449,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -482,7 +482,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -515,7 +515,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -548,7 +548,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -581,7 +581,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -614,7 +614,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -647,7 +647,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -680,7 +680,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);
@@ -713,7 +713,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {from: '+15017122661', to: '+15558675310'};
+      var opts = {'from': '+15017122661', 'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .participants.create(opts);

--- a/spec/integration/rest/api/v2010/account/conference/recording.spec.js
+++ b/spec/integration/rest/api/v2010/account/conference/recording.spec.js
@@ -33,7 +33,7 @@ describe('Recording', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {status: 'in-progress'};
+      var opts = {'status': 'in-progress'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .recordings('REXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -49,7 +49,7 @@ describe('Recording', function() {
       var sid = 'REXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Conferences/${conferenceSid}/Recordings/${sid}.json`;
 
-      var values = {Status: 'in-progress', };
+      var values = {'Status': 'in-progress', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -81,7 +81,7 @@ describe('Recording', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'in-progress'};
+      var opts = {'status': 'in-progress'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .conferences('CFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .recordings('REXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/api/v2010/account/incomingPhoneNumber/assignedAddOn.spec.js
+++ b/spec/integration/rest/api/v2010/account/incomingPhoneNumber/assignedAddOn.spec.js
@@ -303,7 +303,7 @@ describe('AssignedAddOn', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {installedAddOnSid: 'XEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'installedAddOnSid': 'XEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .incomingPhoneNumbers('PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .assignedAddOns.create(opts);
@@ -318,7 +318,7 @@ describe('AssignedAddOn', function() {
       var resourceSid = 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/IncomingPhoneNumbers/${resourceSid}/AssignedAddOns.json`;
 
-      var values = {InstalledAddOnSid: 'XEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'InstalledAddOnSid': 'XEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -348,7 +348,7 @@ describe('AssignedAddOn', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {installedAddOnSid: 'XEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'installedAddOnSid': 'XEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .incomingPhoneNumbers('PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .assignedAddOns.create(opts);

--- a/spec/integration/rest/api/v2010/account/incomingPhoneNumber/local.spec.js
+++ b/spec/integration/rest/api/v2010/account/incomingPhoneNumber/local.spec.js
@@ -336,7 +336,7 @@ describe('Local', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {phoneNumber: '+15017122661'};
+      var opts = {'phoneNumber': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .incomingPhoneNumbers
                                     .local.create(opts);
@@ -350,7 +350,7 @@ describe('Local', function() {
       var accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/IncomingPhoneNumbers/Local.json`;
 
-      var values = {PhoneNumber: '+15017122661', };
+      var values = {'PhoneNumber': '+15017122661', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -404,7 +404,7 @@ describe('Local', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumber: '+15017122661'};
+      var opts = {'phoneNumber': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .incomingPhoneNumbers
                                     .local.create(opts);

--- a/spec/integration/rest/api/v2010/account/incomingPhoneNumber/mobile.spec.js
+++ b/spec/integration/rest/api/v2010/account/incomingPhoneNumber/mobile.spec.js
@@ -336,7 +336,7 @@ describe('Mobile', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {phoneNumber: '+15017122661'};
+      var opts = {'phoneNumber': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .incomingPhoneNumbers
                                     .mobile.create(opts);
@@ -350,7 +350,7 @@ describe('Mobile', function() {
       var accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/IncomingPhoneNumbers/Mobile.json`;
 
-      var values = {PhoneNumber: '+15017122661', };
+      var values = {'PhoneNumber': '+15017122661', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -404,7 +404,7 @@ describe('Mobile', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumber: '+15017122661'};
+      var opts = {'phoneNumber': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .incomingPhoneNumbers
                                     .mobile.create(opts);

--- a/spec/integration/rest/api/v2010/account/incomingPhoneNumber/tollFree.spec.js
+++ b/spec/integration/rest/api/v2010/account/incomingPhoneNumber/tollFree.spec.js
@@ -336,7 +336,7 @@ describe('TollFree', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {phoneNumber: '+15017122661'};
+      var opts = {'phoneNumber': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .incomingPhoneNumbers
                                     .tollFree.create(opts);
@@ -350,7 +350,7 @@ describe('TollFree', function() {
       var accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/IncomingPhoneNumbers/TollFree.json`;
 
-      var values = {PhoneNumber: '+15017122661', };
+      var values = {'PhoneNumber': '+15017122661', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -404,7 +404,7 @@ describe('TollFree', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumber: '+15017122661'};
+      var opts = {'phoneNumber': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .incomingPhoneNumbers
                                     .tollFree.create(opts);

--- a/spec/integration/rest/api/v2010/account/message.spec.js
+++ b/spec/integration/rest/api/v2010/account/message.spec.js
@@ -33,7 +33,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {to: '+15558675310'};
+      var opts = {'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messages.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('Message', function() {
       var accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
 
-      var values = {To: '+15558675310', };
+      var values = {'To': '+15558675310', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -83,7 +83,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310'};
+      var opts = {'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messages.create(opts);
       promise.then(function(response) {
@@ -123,7 +123,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310'};
+      var opts = {'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messages.create(opts);
       promise.then(function(response) {
@@ -163,7 +163,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310'};
+      var opts = {'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messages.create(opts);
       promise.then(function(response) {
@@ -203,7 +203,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310'};
+      var opts = {'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messages.create(opts);
       promise.then(function(response) {
@@ -243,7 +243,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310'};
+      var opts = {'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messages.create(opts);
       promise.then(function(response) {
@@ -283,7 +283,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310'};
+      var opts = {'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messages.create(opts);
       promise.then(function(response) {
@@ -323,7 +323,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310'};
+      var opts = {'to': '+15558675310'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messages.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/api/v2010/account/queue.spec.js
+++ b/spec/integration/rest/api/v2010/account/queue.spec.js
@@ -369,7 +369,7 @@ describe('Queue', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .queues.create(opts);
       promise.then(function() {
@@ -382,7 +382,7 @@ describe('Queue', function() {
       var accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Queues.json`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -409,7 +409,7 @@ describe('Queue', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .queues.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/api/v2010/account/queue/member.spec.js
+++ b/spec/integration/rest/api/v2010/account/queue/member.spec.js
@@ -106,7 +106,7 @@ describe('Member', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {url: 'https://example.com'};
+      var opts = {'url': 'https://example.com'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .queues('QUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .members('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -122,7 +122,7 @@ describe('Member', function() {
       var callSid = 'CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Queues/${queueSid}/Members/${callSid}.json`;
 
-      var values = {Url: 'https://example.com', };
+      var values = {'Url': 'https://example.com', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -143,7 +143,7 @@ describe('Member', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {url: 'https://example.com'};
+      var opts = {'url': 'https://example.com'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .queues('QUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .members('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -168,7 +168,7 @@ describe('Member', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {url: 'https://example.com'};
+      var opts = {'url': 'https://example.com'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .queues('QUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .members('CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/api/v2010/account/sip/credentialList.spec.js
+++ b/spec/integration/rest/api/v2010/account/sip/credentialList.spec.js
@@ -220,7 +220,7 @@ describe('CredentialList', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .credentialLists.create(opts);
@@ -234,7 +234,7 @@ describe('CredentialList', function() {
       var accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/CredentialLists.json`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -258,7 +258,7 @@ describe('CredentialList', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .credentialLists.create(opts);
@@ -325,7 +325,7 @@ describe('CredentialList', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .credentialLists('CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -340,7 +340,7 @@ describe('CredentialList', function() {
       var sid = 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/CredentialLists/${sid}.json`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -364,7 +364,7 @@ describe('CredentialList', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .credentialLists('CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/api/v2010/account/sip/credentialList/credential.spec.js
+++ b/spec/integration/rest/api/v2010/account/sip/credentialList/credential.spec.js
@@ -219,7 +219,7 @@ describe('Credential', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {username: 'username', password: 'password'};
+      var opts = {'username': 'username', 'password': 'password'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .credentialLists('CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
@@ -235,7 +235,7 @@ describe('Credential', function() {
       var credentialListSid = 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/CredentialLists/${credentialListSid}/Credentials.json`;
 
-      var values = {Username: 'username', Password: 'password', };
+      var values = {'Username': 'username', 'Password': 'password', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -257,7 +257,7 @@ describe('Credential', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {username: 'username', password: 'password'};
+      var opts = {'username': 'username', 'password': 'password'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .credentialLists('CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')

--- a/spec/integration/rest/api/v2010/account/sip/domain.spec.js
+++ b/spec/integration/rest/api/v2010/account/sip/domain.spec.js
@@ -280,7 +280,7 @@ describe('Domain', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {domainName: 'domain_name'};
+      var opts = {'domainName': 'domain_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains.create(opts);
@@ -294,7 +294,7 @@ describe('Domain', function() {
       var accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/Domains.json`;
 
-      var values = {DomainName: 'domain_name', };
+      var values = {'DomainName': 'domain_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -333,7 +333,7 @@ describe('Domain', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {domainName: 'domain_name'};
+      var opts = {'domainName': 'domain_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains.create(opts);

--- a/spec/integration/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsCredentialListMapping.spec.js
+++ b/spec/integration/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsCredentialListMapping.spec.js
@@ -35,7 +35,7 @@ describe('AuthCallsCredentialListMapping', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {credentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'credentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains('SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
@@ -53,7 +53,7 @@ describe('AuthCallsCredentialListMapping', function() {
       var domainSid = 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/Domains/${domainSid}/Auth/Calls/CredentialListMappings.json`;
 
-      var values = {CredentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'CredentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -73,7 +73,7 @@ describe('AuthCallsCredentialListMapping', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {credentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'credentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains('SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')

--- a/spec/integration/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsIpAccessControlListMapping.spec.js
+++ b/spec/integration/rest/api/v2010/account/sip/domain/authTypes/authCallsMapping/authCallsIpAccessControlListMapping.spec.js
@@ -35,7 +35,7 @@ describe('AuthCallsIpAccessControlListMapping', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ipAccessControlListSid: 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'ipAccessControlListSid': 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains('SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
@@ -53,7 +53,7 @@ describe('AuthCallsIpAccessControlListMapping', function() {
       var domainSid = 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/Domains/${domainSid}/Auth/Calls/IpAccessControlListMappings.json`;
 
-      var values = {IpAccessControlListSid: 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'IpAccessControlListSid': 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -73,7 +73,7 @@ describe('AuthCallsIpAccessControlListMapping', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {ipAccessControlListSid: 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'ipAccessControlListSid': 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains('SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')

--- a/spec/integration/rest/api/v2010/account/sip/domain/authTypes/authRegistrationsMapping/authRegistrationsCredentialListMapping.spec.js
+++ b/spec/integration/rest/api/v2010/account/sip/domain/authTypes/authRegistrationsMapping/authRegistrationsCredentialListMapping.spec.js
@@ -35,7 +35,7 @@ describe('AuthRegistrationsCredentialListMapping', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {credentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'credentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains('SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
@@ -53,7 +53,7 @@ describe('AuthRegistrationsCredentialListMapping', function() {
       var domainSid = 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/Domains/${domainSid}/Auth/Registrations/CredentialListMappings.json`;
 
-      var values = {CredentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'CredentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -73,7 +73,7 @@ describe('AuthRegistrationsCredentialListMapping', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {credentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'credentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains('SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')

--- a/spec/integration/rest/api/v2010/account/sip/domain/credentialListMapping.spec.js
+++ b/spec/integration/rest/api/v2010/account/sip/domain/credentialListMapping.spec.js
@@ -33,7 +33,7 @@ describe('CredentialListMapping', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {credentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'credentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains('SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
@@ -49,7 +49,7 @@ describe('CredentialListMapping', function() {
       var domainSid = 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/Domains/${domainSid}/CredentialListMappings.json`;
 
-      var values = {CredentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'CredentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -71,7 +71,7 @@ describe('CredentialListMapping', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {credentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'credentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains('SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')

--- a/spec/integration/rest/api/v2010/account/sip/domain/ipAccessControlListMapping.spec.js
+++ b/spec/integration/rest/api/v2010/account/sip/domain/ipAccessControlListMapping.spec.js
@@ -85,7 +85,7 @@ describe('IpAccessControlListMapping', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ipAccessControlListSid: 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'ipAccessControlListSid': 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains('SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
@@ -101,7 +101,7 @@ describe('IpAccessControlListMapping', function() {
       var domainSid = 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/Domains/${domainSid}/IpAccessControlListMappings.json`;
 
-      var values = {IpAccessControlListSid: 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'IpAccessControlListSid': 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -123,7 +123,7 @@ describe('IpAccessControlListMapping', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {ipAccessControlListSid: 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'ipAccessControlListSid': 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .domains('SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')

--- a/spec/integration/rest/api/v2010/account/sip/ipAccessControlList.spec.js
+++ b/spec/integration/rest/api/v2010/account/sip/ipAccessControlList.spec.js
@@ -220,7 +220,7 @@ describe('IpAccessControlList', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .ipAccessControlLists.create(opts);
@@ -234,7 +234,7 @@ describe('IpAccessControlList', function() {
       var accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/IpAccessControlLists.json`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -258,7 +258,7 @@ describe('IpAccessControlList', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .ipAccessControlLists.create(opts);
@@ -325,7 +325,7 @@ describe('IpAccessControlList', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .ipAccessControlLists('ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -340,7 +340,7 @@ describe('IpAccessControlList', function() {
       var sid = 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/IpAccessControlLists/${sid}.json`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -364,7 +364,7 @@ describe('IpAccessControlList', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .ipAccessControlLists('ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/api/v2010/account/sip/ipAccessControlList/ipAddress.spec.js
+++ b/spec/integration/rest/api/v2010/account/sip/ipAccessControlList/ipAddress.spec.js
@@ -227,7 +227,7 @@ describe('IpAddress', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', ipAddress: 'ip_address'};
+      var opts = {'friendlyName': 'friendly_name', 'ipAddress': 'ip_address'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .ipAccessControlLists('ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
@@ -243,7 +243,7 @@ describe('IpAddress', function() {
       var ipAccessControlListSid = 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/SIP/IpAccessControlLists/${ipAccessControlListSid}/IpAddresses.json`;
 
-      var values = {FriendlyName: 'friendly_name', IpAddress: 'ip_address', };
+      var values = {'FriendlyName': 'friendly_name', 'IpAddress': 'ip_address', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -267,7 +267,7 @@ describe('IpAddress', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', ipAddress: 'ip_address'};
+      var opts = {'friendlyName': 'friendly_name', 'ipAddress': 'ip_address'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sip
                                     .ipAccessControlLists('ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')

--- a/spec/integration/rest/api/v2010/account/usage/trigger.spec.js
+++ b/spec/integration/rest/api/v2010/account/usage/trigger.spec.js
@@ -191,9 +191,9 @@ describe('Trigger', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        callbackUrl: 'https://example.com',
-        triggerValue: 'trigger_value',
-        usageCategory: 'agent-conference'
+        'callbackUrl': 'https://example.com',
+        'triggerValue': 'trigger_value',
+        'usageCategory': 'agent-conference'
       };
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .usage
@@ -209,9 +209,9 @@ describe('Trigger', function() {
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Usage/Triggers.json`;
 
       var values = {
-        CallbackUrl: 'https://example.com',
-        TriggerValue: 'trigger_value',
-        UsageCategory: 'agent-conference',
+        'CallbackUrl': 'https://example.com',
+        'TriggerValue': 'trigger_value',
+        'UsageCategory': 'agent-conference',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -244,9 +244,9 @@ describe('Trigger', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        callbackUrl: 'https://example.com',
-        triggerValue: 'trigger_value',
-        usageCategory: 'agent-conference'
+        'callbackUrl': 'https://example.com',
+        'triggerValue': 'trigger_value',
+        'usageCategory': 'agent-conference'
       };
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .usage

--- a/spec/integration/rest/api/v2010/account/validationRequest.spec.js
+++ b/spec/integration/rest/api/v2010/account/validationRequest.spec.js
@@ -33,7 +33,7 @@ describe('ValidationRequest', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {phoneNumber: '+15017122661'};
+      var opts = {'phoneNumber': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .validationRequests.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('ValidationRequest', function() {
       var accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/OutgoingCallerIds.json`;
 
-      var values = {PhoneNumber: '+15017122661', };
+      var values = {'PhoneNumber': '+15017122661', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -66,7 +66,7 @@ describe('ValidationRequest', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumber: '+15017122661'};
+      var opts = {'phoneNumber': '+15017122661'};
       var promise = client.api.v2010.accounts('ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .validationRequests.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/autopilot/v1/assistant/fieldType.spec.js
+++ b/spec/integration/rest/autopilot/v1/assistant/fieldType.spec.js
@@ -278,7 +278,7 @@ describe('FieldType', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .fieldTypes.create(opts);
       promise.then(function() {
@@ -291,7 +291,7 @@ describe('FieldType', function() {
       var assistantSid = 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://autopilot.twilio.com/v1/Assistants/${assistantSid}/FieldTypes`;
 
-      var values = {UniqueName: 'unique_name', };
+      var values = {'UniqueName': 'unique_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -317,7 +317,7 @@ describe('FieldType', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .fieldTypes.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/autopilot/v1/assistant/fieldType/fieldValue.spec.js
+++ b/spec/integration/rest/autopilot/v1/assistant/fieldType/fieldValue.spec.js
@@ -283,7 +283,7 @@ describe('FieldValue', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {language: 'language', value: 'value'};
+      var opts = {'language': 'language', 'value': 'value'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .fieldTypes('UBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .fieldValues.create(opts);
@@ -298,7 +298,7 @@ describe('FieldValue', function() {
       var fieldTypeSid = 'UBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://autopilot.twilio.com/v1/Assistants/${assistantSid}/FieldTypes/${fieldTypeSid}/FieldValues`;
 
-      var values = {Language: 'language', Value: 'value', };
+      var values = {'Language': 'language', 'Value': 'value', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -323,7 +323,7 @@ describe('FieldValue', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {language: 'language', value: 'value'};
+      var opts = {'language': 'language', 'value': 'value'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .fieldTypes('UBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .fieldValues.create(opts);

--- a/spec/integration/rest/autopilot/v1/assistant/query.spec.js
+++ b/spec/integration/rest/autopilot/v1/assistant/query.spec.js
@@ -338,7 +338,7 @@ describe('Query', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {language: 'language', query: 'query'};
+      var opts = {'language': 'language', 'query': 'query'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .queries.create(opts);
       promise.then(function() {
@@ -351,7 +351,7 @@ describe('Query', function() {
       var assistantSid = 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://autopilot.twilio.com/v1/Assistants/${assistantSid}/Queries`;
 
-      var values = {Language: 'language', Query: 'query', };
+      var values = {'Language': 'language', 'Query': 'query', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -389,7 +389,7 @@ describe('Query', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {language: 'language', query: 'query'};
+      var opts = {'language': 'language', 'query': 'query'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .queries.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/autopilot/v1/assistant/task.spec.js
+++ b/spec/integration/rest/autopilot/v1/assistant/task.spec.js
@@ -298,7 +298,7 @@ describe('Task', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .tasks.create(opts);
       promise.then(function() {
@@ -311,7 +311,7 @@ describe('Task', function() {
       var assistantSid = 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://autopilot.twilio.com/v1/Assistants/${assistantSid}/Tasks`;
 
-      var values = {UniqueName: 'unique_name', };
+      var values = {'UniqueName': 'unique_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -341,7 +341,7 @@ describe('Task', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .tasks.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/autopilot/v1/assistant/task/field.spec.js
+++ b/spec/integration/rest/autopilot/v1/assistant/task/field.spec.js
@@ -278,7 +278,7 @@ describe('Field', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {fieldType: 'field_type', uniqueName: 'unique_name'};
+      var opts = {'fieldType': 'field_type', 'uniqueName': 'unique_name'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .tasks('UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .fields.create(opts);
@@ -293,7 +293,7 @@ describe('Field', function() {
       var taskSid = 'UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://autopilot.twilio.com/v1/Assistants/${assistantSid}/Tasks/${taskSid}/Fields`;
 
-      var values = {FieldType: 'field_type', UniqueName: 'unique_name', };
+      var values = {'FieldType': 'field_type', 'UniqueName': 'unique_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -317,7 +317,7 @@ describe('Field', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {fieldType: 'field_type', uniqueName: 'unique_name'};
+      var opts = {'fieldType': 'field_type', 'uniqueName': 'unique_name'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .tasks('UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .fields.create(opts);

--- a/spec/integration/rest/autopilot/v1/assistant/task/sample.spec.js
+++ b/spec/integration/rest/autopilot/v1/assistant/task/sample.spec.js
@@ -283,7 +283,7 @@ describe('Sample', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {language: 'language', taggedText: 'tagged_text'};
+      var opts = {'language': 'language', 'taggedText': 'tagged_text'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .tasks('UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .samples.create(opts);
@@ -298,7 +298,7 @@ describe('Sample', function() {
       var taskSid = 'UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://autopilot.twilio.com/v1/Assistants/${assistantSid}/Tasks/${taskSid}/Samples`;
 
-      var values = {Language: 'language', TaggedText: 'tagged_text', };
+      var values = {'Language': 'language', 'TaggedText': 'tagged_text', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -323,7 +323,7 @@ describe('Sample', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {language: 'language', taggedText: 'tagged_text'};
+      var opts = {'language': 'language', 'taggedText': 'tagged_text'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .tasks('UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .samples.create(opts);

--- a/spec/integration/rest/autopilot/v1/assistant/webhook.spec.js
+++ b/spec/integration/rest/autopilot/v1/assistant/webhook.spec.js
@@ -273,7 +273,7 @@ describe('Webhook', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {uniqueName: 'unique_name', events: 'events', webhookUrl: 'https://example.com'};
+      var opts = {'uniqueName': 'unique_name', 'events': 'events', 'webhookUrl': 'https://example.com'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .webhooks.create(opts);
       promise.then(function() {
@@ -286,7 +286,7 @@ describe('Webhook', function() {
       var assistantSid = 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://autopilot.twilio.com/v1/Assistants/${assistantSid}/Webhooks`;
 
-      var values = {UniqueName: 'unique_name', Events: 'events', WebhookUrl: 'https://example.com', };
+      var values = {'UniqueName': 'unique_name', 'Events': 'events', 'WebhookUrl': 'https://example.com', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -311,7 +311,7 @@ describe('Webhook', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {uniqueName: 'unique_name', events: 'events', webhookUrl: 'https://example.com'};
+      var opts = {'uniqueName': 'unique_name', 'events': 'events', 'webhookUrl': 'https://example.com'};
       var promise = client.autopilot.v1.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .webhooks.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/autopilot/v1/restoreAssistant.spec.js
+++ b/spec/integration/rest/autopilot/v1/restoreAssistant.spec.js
@@ -33,7 +33,7 @@ describe('RestoreAssistant', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {assistant: 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'assistant': 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.autopilot.v1.restoreAssistant.update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('RestoreAssistant', function() {
 
       var url = 'https://autopilot.twilio.com/v1/Assistants/Restore';
 
-      var values = {Assistant: 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'Assistant': 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -71,7 +71,7 @@ describe('RestoreAssistant', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {assistant: 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'assistant': 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.autopilot.v1.restoreAssistant.update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/bulkexports/v1/export/exportCustomJob.spec.js
+++ b/spec/integration/rest/bulkexports/v1/export/exportCustomJob.spec.js
@@ -227,7 +227,7 @@ describe('ExportCustomJob', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {startDay: 'start_day', endDay: 'end_day', friendlyName: 'friendly_name'};
+      var opts = {'startDay': 'start_day', 'endDay': 'end_day', 'friendlyName': 'friendly_name'};
       var promise = client.bulkexports.v1.exports('resource_type')
                                          .exportCustomJobs.create(opts);
       promise.then(function() {
@@ -240,7 +240,7 @@ describe('ExportCustomJob', function() {
       var resourceType = 'resource_type';
       var url = `https://bulkexports.twilio.com/v1/Exports/${resourceType}/Jobs`;
 
-      var values = {StartDay: 'start_day', EndDay: 'end_day', FriendlyName: 'friendly_name', };
+      var values = {'StartDay': 'start_day', 'EndDay': 'end_day', 'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -266,7 +266,7 @@ describe('ExportCustomJob', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {startDay: 'start_day', endDay: 'end_day', friendlyName: 'friendly_name'};
+      var opts = {'startDay': 'start_day', 'endDay': 'end_day', 'friendlyName': 'friendly_name'};
       var promise = client.bulkexports.v1.exports('resource_type')
                                          .exportCustomJobs.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/chat/v1/credential.spec.js
+++ b/spec/integration/rest/chat/v1/credential.spec.js
@@ -208,7 +208,7 @@ describe('Credential', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {type: 'gcm'};
+      var opts = {'type': 'gcm'};
       var promise = client.chat.v1.credentials.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -219,7 +219,7 @@ describe('Credential', function() {
 
       var url = 'https://chat.twilio.com/v1/Credentials';
 
-      var values = {Type: 'gcm', };
+      var values = {'Type': 'gcm', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -242,7 +242,7 @@ describe('Credential', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {type: 'gcm'};
+      var opts = {'type': 'gcm'};
       var promise = client.chat.v1.credentials.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/chat/v1/service.spec.js
+++ b/spec/integration/rest/chat/v1/service.spec.js
@@ -133,7 +133,7 @@ describe('Service', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.chat.v1.services.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -144,7 +144,7 @@ describe('Service', function() {
 
       var url = 'https://chat.twilio.com/v1/Services';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -186,7 +186,7 @@ describe('Service', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.chat.v1.services.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/chat/v1/service/channel/invite.spec.js
+++ b/spec/integration/rest/chat/v1/service/channel/invite.spec.js
@@ -86,7 +86,7 @@ describe('Invite', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .invites.create(opts);
@@ -101,7 +101,7 @@ describe('Invite', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://chat.twilio.com/v1/Services/${serviceSid}/Channels/${channelSid}/Invites`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -126,7 +126,7 @@ describe('Invite', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .invites.create(opts);

--- a/spec/integration/rest/chat/v1/service/channel/member.spec.js
+++ b/spec/integration/rest/chat/v1/service/channel/member.spec.js
@@ -87,7 +87,7 @@ describe('Member', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .members.create(opts);
@@ -102,7 +102,7 @@ describe('Member', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://chat.twilio.com/v1/Services/${serviceSid}/Channels/${channelSid}/Members`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -128,7 +128,7 @@ describe('Member', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .members.create(opts);

--- a/spec/integration/rest/chat/v1/service/channel/message.spec.js
+++ b/spec/integration/rest/chat/v1/service/channel/message.spec.js
@@ -89,7 +89,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {body: 'body'};
+      var opts = {'body': 'body'};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .messages.create(opts);
@@ -104,7 +104,7 @@ describe('Message', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://chat.twilio.com/v1/Services/${serviceSid}/Channels/${channelSid}/Messages`;
 
-      var values = {Body: 'body', };
+      var values = {'Body': 'body', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -132,7 +132,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {body: 'body'};
+      var opts = {'body': 'body'};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .messages.create(opts);
@@ -164,7 +164,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {body: 'body'};
+      var opts = {'body': 'body'};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .messages.create(opts);

--- a/spec/integration/rest/chat/v1/service/role.spec.js
+++ b/spec/integration/rest/chat/v1/service/role.spec.js
@@ -128,7 +128,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', type: 'channel', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'channel', 'permission': ['permission']};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .roles.create(opts);
       promise.then(function() {
@@ -142,9 +142,9 @@ describe('Role', function() {
       var url = `https://chat.twilio.com/v1/Services/${serviceSid}/Roles`;
 
       var values = {
-        FriendlyName: 'friendly_name',
-        Type: 'channel',
-        Permission: serialize.map(['permission'], function(e) { return e; }),
+        'FriendlyName': 'friendly_name',
+        'Type': 'channel',
+        'Permission': serialize.map(['permission'], function(e) { return e; }),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -174,7 +174,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', type: 'channel', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'channel', 'permission': ['permission']};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .roles.create(opts);
       promise.then(function(response) {
@@ -395,7 +395,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -409,7 +409,7 @@ describe('Role', function() {
       var sid = 'RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://chat.twilio.com/v1/Services/${serviceSid}/Roles/${sid}`;
 
-      var values = {Permission: serialize.map(['permission'], function(e) { return e; }), };
+      var values = {'Permission': serialize.map(['permission'], function(e) { return e; }), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -438,7 +438,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/chat/v1/service/user.spec.js
+++ b/spec/integration/rest/chat/v1/service/user.spec.js
@@ -128,7 +128,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .users.create(opts);
       promise.then(function() {
@@ -141,7 +141,7 @@ describe('User', function() {
       var serviceSid = 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://chat.twilio.com/v1/Services/${serviceSid}/Users`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -172,7 +172,7 @@ describe('User', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.chat.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .users.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/chat/v2/credential.spec.js
+++ b/spec/integration/rest/chat/v2/credential.spec.js
@@ -208,7 +208,7 @@ describe('Credential', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {type: 'gcm'};
+      var opts = {'type': 'gcm'};
       var promise = client.chat.v2.credentials.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -219,7 +219,7 @@ describe('Credential', function() {
 
       var url = 'https://chat.twilio.com/v2/Credentials';
 
-      var values = {Type: 'gcm', };
+      var values = {'Type': 'gcm', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -242,7 +242,7 @@ describe('Credential', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {type: 'gcm'};
+      var opts = {'type': 'gcm'};
       var promise = client.chat.v2.credentials.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/chat/v2/service.spec.js
+++ b/spec/integration/rest/chat/v2/service.spec.js
@@ -142,7 +142,7 @@ describe('Service', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.chat.v2.services.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -153,7 +153,7 @@ describe('Service', function() {
 
       var url = 'https://chat.twilio.com/v2/Services';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -204,7 +204,7 @@ describe('Service', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.chat.v2.services.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/chat/v2/service/channel.spec.js
+++ b/spec/integration/rest/chat/v2/service/channel.spec.js
@@ -93,7 +93,7 @@ describe('Channel', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
       promise.then(function() {
@@ -135,7 +135,7 @@ describe('Channel', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels.create(opts);
       promise.then(function() {
@@ -427,7 +427,7 @@ describe('Channel', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {

--- a/spec/integration/rest/chat/v2/service/channel/invite.spec.js
+++ b/spec/integration/rest/chat/v2/service/channel/invite.spec.js
@@ -86,7 +86,7 @@ describe('Invite', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .invites.create(opts);
@@ -101,7 +101,7 @@ describe('Invite', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://chat.twilio.com/v2/Services/${serviceSid}/Channels/${channelSid}/Invites`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -126,7 +126,7 @@ describe('Invite', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .invites.create(opts);

--- a/spec/integration/rest/chat/v2/service/channel/member.spec.js
+++ b/spec/integration/rest/chat/v2/service/channel/member.spec.js
@@ -88,7 +88,7 @@ describe('Member', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity', xTwilioWebhookEnabled: 'true'};
+      var opts = {'identity': 'identity', 'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .members.create(opts);
@@ -103,7 +103,7 @@ describe('Member', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://chat.twilio.com/v2/Services/${serviceSid}/Channels/${channelSid}/Members`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -137,7 +137,7 @@ describe('Member', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .members.create(opts);
@@ -358,7 +358,7 @@ describe('Member', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .members('MBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
@@ -403,7 +403,7 @@ describe('Member', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .members('MBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/chat/v2/service/channel/message.spec.js
+++ b/spec/integration/rest/chat/v2/service/channel/message.spec.js
@@ -131,7 +131,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .messages.create(opts);
@@ -578,7 +578,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .messages('IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
@@ -623,7 +623,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .messages('IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/chat/v2/service/channel/webhook.spec.js
+++ b/spec/integration/rest/chat/v2/service/channel/webhook.spec.js
@@ -440,7 +440,7 @@ describe('Webhook', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {type: 'webhook'};
+      var opts = {'type': 'webhook'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .webhooks.create(opts);
@@ -455,7 +455,7 @@ describe('Webhook', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://chat.twilio.com/v2/Services/${serviceSid}/Channels/${channelSid}/Webhooks`;
 
-      var values = {Type: 'webhook', };
+      var values = {'Type': 'webhook', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -487,7 +487,7 @@ describe('Webhook', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {type: 'webhook'};
+      var opts = {'type': 'webhook'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .webhooks.create(opts);

--- a/spec/integration/rest/chat/v2/service/role.spec.js
+++ b/spec/integration/rest/chat/v2/service/role.spec.js
@@ -128,7 +128,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', type: 'channel', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'channel', 'permission': ['permission']};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .roles.create(opts);
       promise.then(function() {
@@ -142,9 +142,9 @@ describe('Role', function() {
       var url = `https://chat.twilio.com/v2/Services/${serviceSid}/Roles`;
 
       var values = {
-        FriendlyName: 'friendly_name',
-        Type: 'channel',
-        Permission: serialize.map(['permission'], function(e) { return e; }),
+        'FriendlyName': 'friendly_name',
+        'Type': 'channel',
+        'Permission': serialize.map(['permission'], function(e) { return e; }),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -174,7 +174,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', type: 'channel', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'channel', 'permission': ['permission']};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .roles.create(opts);
       promise.then(function(response) {
@@ -395,7 +395,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -409,7 +409,7 @@ describe('Role', function() {
       var sid = 'RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://chat.twilio.com/v2/Services/${serviceSid}/Roles/${sid}`;
 
-      var values = {Permission: serialize.map(['permission'], function(e) { return e; }), };
+      var values = {'Permission': serialize.map(['permission'], function(e) { return e; }), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -438,7 +438,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/chat/v2/service/user.spec.js
+++ b/spec/integration/rest/chat/v2/service/user.spec.js
@@ -129,7 +129,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity', xTwilioWebhookEnabled: 'true'};
+      var opts = {'identity': 'identity', 'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .users.create(opts);
       promise.then(function() {
@@ -142,7 +142,7 @@ describe('User', function() {
       var serviceSid = 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://chat.twilio.com/v2/Services/${serviceSid}/Users`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -181,7 +181,7 @@ describe('User', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .users.create(opts);
       promise.then(function(response) {
@@ -414,7 +414,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.chat.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .users('USXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {

--- a/spec/integration/rest/conversations/v1/conversation.spec.js
+++ b/spec/integration/rest/conversations/v1/conversation.spec.js
@@ -33,7 +33,7 @@ describe('Conversation', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.conversations.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -127,7 +127,7 @@ describe('Conversation', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -188,7 +188,7 @@ describe('Conversation', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
       promise.then(function() {
         throw new Error('failed');

--- a/spec/integration/rest/conversations/v1/conversation/message.spec.js
+++ b/spec/integration/rest/conversations/v1/conversation/message.spec.js
@@ -33,7 +33,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .messages.create(opts);
       promise.then(function() {
@@ -185,7 +185,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .messages('IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -251,7 +251,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .messages('IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
       promise.then(function() {

--- a/spec/integration/rest/conversations/v1/conversation/participant.spec.js
+++ b/spec/integration/rest/conversations/v1/conversation/participant.spec.js
@@ -33,7 +33,7 @@ describe('Participant', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .participants.create(opts);
       promise.then(function() {
@@ -216,7 +216,7 @@ describe('Participant', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .participants('MBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -307,7 +307,7 @@ describe('Participant', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .participants('MBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
       promise.then(function() {

--- a/spec/integration/rest/conversations/v1/conversation/webhook.spec.js
+++ b/spec/integration/rest/conversations/v1/conversation/webhook.spec.js
@@ -409,7 +409,7 @@ describe('Webhook', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {target: 'webhook'};
+      var opts = {'target': 'webhook'};
       var promise = client.conversations.v1.conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .webhooks.create(opts);
       promise.then(function() {
@@ -422,7 +422,7 @@ describe('Webhook', function() {
       var conversationSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://conversations.twilio.com/v1/Conversations/${conversationSid}/Webhooks`;
 
-      var values = {Target: 'webhook', };
+      var values = {'Target': 'webhook', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -452,7 +452,7 @@ describe('Webhook', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {target: 'webhook'};
+      var opts = {'target': 'webhook'};
       var promise = client.conversations.v1.conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .webhooks.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/conversations/v1/credential.spec.js
+++ b/spec/integration/rest/conversations/v1/credential.spec.js
@@ -33,7 +33,7 @@ describe('Credential', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {type: 'apn'};
+      var opts = {'type': 'apn'};
       var promise = client.conversations.v1.credentials.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('Credential', function() {
 
       var url = 'https://conversations.twilio.com/v1/Credentials';
 
-      var values = {Type: 'apn', };
+      var values = {'Type': 'apn', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -67,7 +67,7 @@ describe('Credential', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {type: 'apn'};
+      var opts = {'type': 'apn'};
       var promise = client.conversations.v1.credentials.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/conversations/v1/role.spec.js
+++ b/spec/integration/rest/conversations/v1/role.spec.js
@@ -35,7 +35,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', type: 'conversation', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'conversation', 'permission': ['permission']};
       var promise = client.conversations.v1.roles.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -47,9 +47,9 @@ describe('Role', function() {
       var url = 'https://conversations.twilio.com/v1/Roles';
 
       var values = {
-        FriendlyName: 'friendly_name',
-        Type: 'conversation',
-        Permission: serialize.map(['permission'], function(e) { return e; }),
+        'FriendlyName': 'friendly_name',
+        'Type': 'conversation',
+        'Permission': serialize.map(['permission'], function(e) { return e; }),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -79,7 +79,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', type: 'conversation', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'conversation', 'permission': ['permission']};
       var promise = client.conversations.v1.roles.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -93,7 +93,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.conversations.v1.roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -105,7 +105,7 @@ describe('Role', function() {
       var sid = 'RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://conversations.twilio.com/v1/Roles/${sid}`;
 
-      var values = {Permission: serialize.map(['permission'], function(e) { return e; }), };
+      var values = {'Permission': serialize.map(['permission'], function(e) { return e; }), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -134,7 +134,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.conversations.v1.roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/conversations/v1/service.spec.js
+++ b/spec/integration/rest/conversations/v1/service.spec.js
@@ -33,7 +33,7 @@ describe('Service', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.conversations.v1.services.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('Service', function() {
 
       var url = 'https://conversations.twilio.com/v1/Services';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -73,7 +73,7 @@ describe('Service', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.conversations.v1.services.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/conversations/v1/service/conversation.spec.js
+++ b/spec/integration/rest/conversations/v1/service/conversation.spec.js
@@ -33,7 +33,7 @@ describe('Conversation', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations.create(opts);
       promise.then(function() {
@@ -131,7 +131,7 @@ describe('Conversation', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -195,7 +195,7 @@ describe('Conversation', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
       promise.then(function() {

--- a/spec/integration/rest/conversations/v1/service/conversation/message.spec.js
+++ b/spec/integration/rest/conversations/v1/service/conversation/message.spec.js
@@ -33,7 +33,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .messages.create(opts);
@@ -193,7 +193,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .messages('IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -263,7 +263,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .messages('IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);

--- a/spec/integration/rest/conversations/v1/service/conversation/participant.spec.js
+++ b/spec/integration/rest/conversations/v1/service/conversation/participant.spec.js
@@ -33,7 +33,7 @@ describe('Participant', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .participants.create(opts);
@@ -228,7 +228,7 @@ describe('Participant', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .participants('MBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
@@ -325,7 +325,7 @@ describe('Participant', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .participants('MBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);

--- a/spec/integration/rest/conversations/v1/service/conversation/webhook.spec.js
+++ b/spec/integration/rest/conversations/v1/service/conversation/webhook.spec.js
@@ -33,7 +33,7 @@ describe('Webhook', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {target: 'webhook'};
+      var opts = {'target': 'webhook'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .webhooks.create(opts);
@@ -48,7 +48,7 @@ describe('Webhook', function() {
       var conversationSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://conversations.twilio.com/v1/Services/${chatServiceSid}/Conversations/${conversationSid}/Webhooks`;
 
-      var values = {Target: 'webhook', };
+      var values = {'Target': 'webhook', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -79,7 +79,7 @@ describe('Webhook', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {target: 'webhook'};
+      var opts = {'target': 'webhook'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .conversations('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .webhooks.create(opts);

--- a/spec/integration/rest/conversations/v1/service/role.spec.js
+++ b/spec/integration/rest/conversations/v1/service/role.spec.js
@@ -35,7 +35,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', type: 'conversation', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'conversation', 'permission': ['permission']};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .roles.create(opts);
       promise.then(function() {
@@ -49,9 +49,9 @@ describe('Role', function() {
       var url = `https://conversations.twilio.com/v1/Services/${chatServiceSid}/Roles`;
 
       var values = {
-        FriendlyName: 'friendly_name',
-        Type: 'conversation',
-        Permission: serialize.map(['permission'], function(e) { return e; }),
+        'FriendlyName': 'friendly_name',
+        'Type': 'conversation',
+        'Permission': serialize.map(['permission'], function(e) { return e; }),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -81,7 +81,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', type: 'conversation', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'conversation', 'permission': ['permission']};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .roles.create(opts);
       promise.then(function(response) {
@@ -96,7 +96,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -110,7 +110,7 @@ describe('Role', function() {
       var sid = 'RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://conversations.twilio.com/v1/Services/${chatServiceSid}/Roles/${sid}`;
 
-      var values = {Permission: serialize.map(['permission'], function(e) { return e; }), };
+      var values = {'Permission': serialize.map(['permission'], function(e) { return e; }), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -139,7 +139,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/conversations/v1/service/user.spec.js
+++ b/spec/integration/rest/conversations/v1/service/user.spec.js
@@ -33,7 +33,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity', xTwilioWebhookEnabled: 'true'};
+      var opts = {'identity': 'identity', 'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .users.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('User', function() {
       var chatServiceSid = 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://conversations.twilio.com/v1/Services/${chatServiceSid}/Users`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -83,7 +83,7 @@ describe('User', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .users.create(opts);
       promise.then(function(response) {
@@ -98,7 +98,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .users('USXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -156,7 +156,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                            .users('USXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
       promise.then(function() {

--- a/spec/integration/rest/conversations/v1/user.spec.js
+++ b/spec/integration/rest/conversations/v1/user.spec.js
@@ -33,7 +33,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity', xTwilioWebhookEnabled: 'true'};
+      var opts = {'identity': 'identity', 'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.users.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('User', function() {
 
       var url = 'https://conversations.twilio.com/v1/Users';
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -81,7 +81,7 @@ describe('User', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.conversations.v1.users.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -95,7 +95,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.users('USXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -150,7 +150,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.conversations.v1.users('USXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
       promise.then(function() {
         throw new Error('failed');

--- a/spec/integration/rest/events/v1/sink.spec.js
+++ b/spec/integration/rest/events/v1/sink.spec.js
@@ -88,7 +88,7 @@ describe('Sink', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {description: 'description', sinkConfiguration: {}, sinkType: 'kinesis'};
+      var opts = {'description': 'description', 'sinkConfiguration': {}, 'sinkType': 'kinesis'};
       var promise = client.events.v1.sinks.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -100,9 +100,9 @@ describe('Sink', function() {
       var url = 'https://events.twilio.com/v1/Sinks';
 
       var values = {
-        Description: 'description',
-        SinkConfiguration: serialize.object({}),
-        SinkType: 'kinesis',
+        'Description': 'description',
+        'SinkConfiguration': serialize.object({}),
+        'SinkType': 'kinesis',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -134,7 +134,7 @@ describe('Sink', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {description: 'description', sinkConfiguration: {}, sinkType: 'kinesis'};
+      var opts = {'description': 'description', 'sinkConfiguration': {}, 'sinkType': 'kinesis'};
       var promise = client.events.v1.sinks.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -165,7 +165,7 @@ describe('Sink', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {description: 'description', sinkConfiguration: {}, sinkType: 'kinesis'};
+      var opts = {'description': 'description', 'sinkConfiguration': {}, 'sinkType': 'kinesis'};
       var promise = client.events.v1.sinks.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -692,7 +692,7 @@ describe('Sink', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {description: 'description'};
+      var opts = {'description': 'description'};
       var promise = client.events.v1.sinks('DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -704,7 +704,7 @@ describe('Sink', function() {
       var sid = 'DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://events.twilio.com/v1/Sinks/${sid}`;
 
-      var values = {Description: 'description', };
+      var values = {'Description': 'description', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -735,7 +735,7 @@ describe('Sink', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {description: 'description'};
+      var opts = {'description': 'description'};
       var promise = client.events.v1.sinks('DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/events/v1/sink/sinkValidate.spec.js
+++ b/spec/integration/rest/events/v1/sink/sinkValidate.spec.js
@@ -33,7 +33,7 @@ describe('SinkValidate', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {testId: 'test_id'};
+      var opts = {'testId': 'test_id'};
       var promise = client.events.v1.sinks('DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sinkValidate.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('SinkValidate', function() {
       var sid = 'DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://events.twilio.com/v1/Sinks/${sid}/Validate`;
 
-      var values = {TestId: 'test_id', };
+      var values = {'TestId': 'test_id', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -62,7 +62,7 @@ describe('SinkValidate', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {testId: 'test_id'};
+      var opts = {'testId': 'test_id'};
       var promise = client.events.v1.sinks('DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .sinkValidate.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/events/v1/subscription.spec.js
+++ b/spec/integration/rest/events/v1/subscription.spec.js
@@ -364,7 +364,11 @@ describe('Subscription', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {description: 'description', sinkSid: 'DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', types: [{}]};
+      var opts = {
+        'description': 'description',
+        'sinkSid': 'DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'types': [{}]
+      };
       var promise = client.events.v1.subscriptions.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -376,9 +380,9 @@ describe('Subscription', function() {
       var url = 'https://events.twilio.com/v1/Subscriptions';
 
       var values = {
-        Description: 'description',
-        SinkSid: 'DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        Types: serialize.map([{}], function(e) { return serialize.object(e); }),
+        'Description': 'description',
+        'SinkSid': 'DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'Types': serialize.map([{}], function(e) { return serialize.object(e); }),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -404,7 +408,11 @@ describe('Subscription', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {description: 'description', sinkSid: 'DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', types: [{}]};
+      var opts = {
+        'description': 'description',
+        'sinkSid': 'DGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'types': [{}]
+      };
       var promise = client.events.v1.subscriptions.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/events/v1/subscription/subscribedEvent.spec.js
+++ b/spec/integration/rest/events/v1/subscription/subscribedEvent.spec.js
@@ -231,7 +231,7 @@ describe('SubscribedEvent', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {type: 'type'};
+      var opts = {'type': 'type'};
       var promise = client.events.v1.subscriptions('DFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .subscribedEvents.create(opts);
       promise.then(function() {
@@ -244,7 +244,7 @@ describe('SubscribedEvent', function() {
       var subscriptionSid = 'DFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://events.twilio.com/v1/Subscriptions/${subscriptionSid}/SubscribedEvents`;
 
-      var values = {Type: 'type', };
+      var values = {'Type': 'type', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -264,7 +264,7 @@ describe('SubscribedEvent', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {type: 'type'};
+      var opts = {'type': 'type'};
       var promise = client.events.v1.subscriptions('DFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .subscribedEvents.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/fax/v1/fax.spec.js
+++ b/spec/integration/rest/fax/v1/fax.spec.js
@@ -313,7 +313,7 @@ describe('Fax', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {to: 'to', mediaUrl: 'https://example.com'};
+      var opts = {'to': 'to', 'mediaUrl': 'https://example.com'};
       var promise = client.fax.v1.faxes.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -324,7 +324,7 @@ describe('Fax', function() {
 
       var url = 'https://fax.twilio.com/v1/Faxes';
 
-      var values = {To: 'to', MediaUrl: 'https://example.com', };
+      var values = {'To': 'to', 'MediaUrl': 'https://example.com', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -359,7 +359,7 @@ describe('Fax', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: 'to', mediaUrl: 'https://example.com'};
+      var opts = {'to': 'to', 'mediaUrl': 'https://example.com'};
       var promise = client.fax.v1.faxes.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/flexApi/v1/channel.spec.js
+++ b/spec/integration/rest/flexApi/v1/channel.spec.js
@@ -254,10 +254,10 @@ describe('Channel', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        flexFlowSid: 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        identity: 'identity',
-        chatUserFriendlyName: 'chat_user_friendly_name',
-        chatFriendlyName: 'chat_friendly_name'
+        'flexFlowSid': 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'identity': 'identity',
+        'chatUserFriendlyName': 'chat_user_friendly_name',
+        'chatFriendlyName': 'chat_friendly_name'
       };
       var promise = client.flexApi.v1.channel.create(opts);
       promise.then(function() {
@@ -270,10 +270,10 @@ describe('Channel', function() {
       var url = 'https://flex-api.twilio.com/v1/Channels';
 
       var values = {
-        FlexFlowSid: 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        Identity: 'identity',
-        ChatUserFriendlyName: 'chat_user_friendly_name',
-        ChatFriendlyName: 'chat_friendly_name',
+        'FlexFlowSid': 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'Identity': 'identity',
+        'ChatUserFriendlyName': 'chat_user_friendly_name',
+        'ChatFriendlyName': 'chat_friendly_name',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -298,10 +298,10 @@ describe('Channel', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        flexFlowSid: 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        identity: 'identity',
-        chatUserFriendlyName: 'chat_user_friendly_name',
-        chatFriendlyName: 'chat_friendly_name'
+        'flexFlowSid': 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'identity': 'identity',
+        'chatUserFriendlyName': 'chat_user_friendly_name',
+        'chatFriendlyName': 'chat_friendly_name'
       };
       var promise = client.flexApi.v1.channel.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/flexApi/v1/flexFlow.spec.js
+++ b/spec/integration/rest/flexApi/v1/flexFlow.spec.js
@@ -299,9 +299,9 @@ describe('FlexFlow', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        friendlyName: 'friendly_name',
-        chatServiceSid: 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        channelType: 'web'
+        'friendlyName': 'friendly_name',
+        'chatServiceSid': 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'channelType': 'web'
       };
       var promise = client.flexApi.v1.flexFlow.create(opts);
       promise.then(function() {
@@ -314,9 +314,9 @@ describe('FlexFlow', function() {
       var url = 'https://flex-api.twilio.com/v1/FlexFlows';
 
       var values = {
-        FriendlyName: 'friendly_name',
-        ChatServiceSid: 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        ChannelType: 'web',
+        'FriendlyName': 'friendly_name',
+        'ChatServiceSid': 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'ChannelType': 'web',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -350,9 +350,9 @@ describe('FlexFlow', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        friendlyName: 'friendly_name',
-        chatServiceSid: 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        channelType: 'web'
+        'friendlyName': 'friendly_name',
+        'chatServiceSid': 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'channelType': 'web'
       };
       var promise = client.flexApi.v1.flexFlow.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/flexApi/v1/webChannel.spec.js
+++ b/spec/integration/rest/flexApi/v1/webChannel.spec.js
@@ -244,10 +244,10 @@ describe('WebChannel', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        flexFlowSid: 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        identity: 'identity',
-        customerFriendlyName: 'customer_friendly_name',
-        chatFriendlyName: 'chat_friendly_name'
+        'flexFlowSid': 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'identity': 'identity',
+        'customerFriendlyName': 'customer_friendly_name',
+        'chatFriendlyName': 'chat_friendly_name'
       };
       var promise = client.flexApi.v1.webChannel.create(opts);
       promise.then(function() {
@@ -260,10 +260,10 @@ describe('WebChannel', function() {
       var url = 'https://flex-api.twilio.com/v1/WebChannels';
 
       var values = {
-        FlexFlowSid: 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        Identity: 'identity',
-        CustomerFriendlyName: 'customer_friendly_name',
-        ChatFriendlyName: 'chat_friendly_name',
+        'FlexFlowSid': 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'Identity': 'identity',
+        'CustomerFriendlyName': 'customer_friendly_name',
+        'ChatFriendlyName': 'chat_friendly_name',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -286,10 +286,10 @@ describe('WebChannel', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        flexFlowSid: 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        identity: 'identity',
-        customerFriendlyName: 'customer_friendly_name',
-        chatFriendlyName: 'chat_friendly_name'
+        'flexFlowSid': 'FOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'identity': 'identity',
+        'customerFriendlyName': 'customer_friendly_name',
+        'chatFriendlyName': 'chat_friendly_name'
       };
       var promise = client.flexApi.v1.webChannel.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/ipMessaging/v1/credential.spec.js
+++ b/spec/integration/rest/ipMessaging/v1/credential.spec.js
@@ -208,7 +208,7 @@ describe('Credential', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {type: 'gcm'};
+      var opts = {'type': 'gcm'};
       var promise = client.ipMessaging.v1.credentials.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -219,7 +219,7 @@ describe('Credential', function() {
 
       var url = 'https://ip-messaging.twilio.com/v1/Credentials';
 
-      var values = {Type: 'gcm', };
+      var values = {'Type': 'gcm', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -242,7 +242,7 @@ describe('Credential', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {type: 'gcm'};
+      var opts = {'type': 'gcm'};
       var promise = client.ipMessaging.v1.credentials.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/ipMessaging/v1/service.spec.js
+++ b/spec/integration/rest/ipMessaging/v1/service.spec.js
@@ -133,7 +133,7 @@ describe('Service', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.ipMessaging.v1.services.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -144,7 +144,7 @@ describe('Service', function() {
 
       var url = 'https://ip-messaging.twilio.com/v1/Services';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -186,7 +186,7 @@ describe('Service', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.ipMessaging.v1.services.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/ipMessaging/v1/service/channel/invite.spec.js
+++ b/spec/integration/rest/ipMessaging/v1/service/channel/invite.spec.js
@@ -86,7 +86,7 @@ describe('Invite', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .invites.create(opts);
@@ -101,7 +101,7 @@ describe('Invite', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://ip-messaging.twilio.com/v1/Services/${serviceSid}/Channels/${channelSid}/Invites`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -126,7 +126,7 @@ describe('Invite', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .invites.create(opts);

--- a/spec/integration/rest/ipMessaging/v1/service/channel/member.spec.js
+++ b/spec/integration/rest/ipMessaging/v1/service/channel/member.spec.js
@@ -87,7 +87,7 @@ describe('Member', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .members.create(opts);
@@ -102,7 +102,7 @@ describe('Member', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://ip-messaging.twilio.com/v1/Services/${serviceSid}/Channels/${channelSid}/Members`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -128,7 +128,7 @@ describe('Member', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .members.create(opts);

--- a/spec/integration/rest/ipMessaging/v1/service/channel/message.spec.js
+++ b/spec/integration/rest/ipMessaging/v1/service/channel/message.spec.js
@@ -89,7 +89,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {body: 'body'};
+      var opts = {'body': 'body'};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .messages.create(opts);
@@ -104,7 +104,7 @@ describe('Message', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://ip-messaging.twilio.com/v1/Services/${serviceSid}/Channels/${channelSid}/Messages`;
 
-      var values = {Body: 'body', };
+      var values = {'Body': 'body', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -132,7 +132,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {body: 'body'};
+      var opts = {'body': 'body'};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .messages.create(opts);
@@ -164,7 +164,7 @@ describe('Message', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {body: 'body'};
+      var opts = {'body': 'body'};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .messages.create(opts);

--- a/spec/integration/rest/ipMessaging/v1/service/role.spec.js
+++ b/spec/integration/rest/ipMessaging/v1/service/role.spec.js
@@ -128,7 +128,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', type: 'channel', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'channel', 'permission': ['permission']};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .roles.create(opts);
       promise.then(function() {
@@ -142,9 +142,9 @@ describe('Role', function() {
       var url = `https://ip-messaging.twilio.com/v1/Services/${serviceSid}/Roles`;
 
       var values = {
-        FriendlyName: 'friendly_name',
-        Type: 'channel',
-        Permission: serialize.map(['permission'], function(e) { return e; }),
+        'FriendlyName': 'friendly_name',
+        'Type': 'channel',
+        'Permission': serialize.map(['permission'], function(e) { return e; }),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -174,7 +174,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', type: 'channel', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'channel', 'permission': ['permission']};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .roles.create(opts);
       promise.then(function(response) {
@@ -395,7 +395,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -409,7 +409,7 @@ describe('Role', function() {
       var sid = 'RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://ip-messaging.twilio.com/v1/Services/${serviceSid}/Roles/${sid}`;
 
-      var values = {Permission: serialize.map(['permission'], function(e) { return e; }), };
+      var values = {'Permission': serialize.map(['permission'], function(e) { return e; }), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -438,7 +438,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/ipMessaging/v1/service/user.spec.js
+++ b/spec/integration/rest/ipMessaging/v1/service/user.spec.js
@@ -128,7 +128,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .users.create(opts);
       promise.then(function() {
@@ -141,7 +141,7 @@ describe('User', function() {
       var serviceSid = 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://ip-messaging.twilio.com/v1/Services/${serviceSid}/Users`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -172,7 +172,7 @@ describe('User', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.ipMessaging.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .users.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/ipMessaging/v2/credential.spec.js
+++ b/spec/integration/rest/ipMessaging/v2/credential.spec.js
@@ -208,7 +208,7 @@ describe('Credential', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {type: 'gcm'};
+      var opts = {'type': 'gcm'};
       var promise = client.ipMessaging.v2.credentials.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -219,7 +219,7 @@ describe('Credential', function() {
 
       var url = 'https://ip-messaging.twilio.com/v2/Credentials';
 
-      var values = {Type: 'gcm', };
+      var values = {'Type': 'gcm', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -242,7 +242,7 @@ describe('Credential', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {type: 'gcm'};
+      var opts = {'type': 'gcm'};
       var promise = client.ipMessaging.v2.credentials.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/ipMessaging/v2/service.spec.js
+++ b/spec/integration/rest/ipMessaging/v2/service.spec.js
@@ -142,7 +142,7 @@ describe('Service', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.ipMessaging.v2.services.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -153,7 +153,7 @@ describe('Service', function() {
 
       var url = 'https://ip-messaging.twilio.com/v2/Services';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -204,7 +204,7 @@ describe('Service', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.ipMessaging.v2.services.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/ipMessaging/v2/service/channel.spec.js
+++ b/spec/integration/rest/ipMessaging/v2/service/channel.spec.js
@@ -93,7 +93,7 @@ describe('Channel', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
       promise.then(function() {
@@ -135,7 +135,7 @@ describe('Channel', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels.create(opts);
       promise.then(function() {
@@ -427,7 +427,7 @@ describe('Channel', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {

--- a/spec/integration/rest/ipMessaging/v2/service/channel/invite.spec.js
+++ b/spec/integration/rest/ipMessaging/v2/service/channel/invite.spec.js
@@ -86,7 +86,7 @@ describe('Invite', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .invites.create(opts);
@@ -101,7 +101,7 @@ describe('Invite', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://ip-messaging.twilio.com/v2/Services/${serviceSid}/Channels/${channelSid}/Invites`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -126,7 +126,7 @@ describe('Invite', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .invites.create(opts);

--- a/spec/integration/rest/ipMessaging/v2/service/channel/member.spec.js
+++ b/spec/integration/rest/ipMessaging/v2/service/channel/member.spec.js
@@ -88,7 +88,7 @@ describe('Member', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity', xTwilioWebhookEnabled: 'true'};
+      var opts = {'identity': 'identity', 'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .members.create(opts);
@@ -103,7 +103,7 @@ describe('Member', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://ip-messaging.twilio.com/v2/Services/${serviceSid}/Channels/${channelSid}/Members`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -137,7 +137,7 @@ describe('Member', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .members.create(opts);
@@ -358,7 +358,7 @@ describe('Member', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .members('MBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
@@ -403,7 +403,7 @@ describe('Member', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .members('MBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/ipMessaging/v2/service/channel/message.spec.js
+++ b/spec/integration/rest/ipMessaging/v2/service/channel/message.spec.js
@@ -131,7 +131,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .messages.create(opts);
@@ -578,7 +578,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .messages('IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
@@ -623,7 +623,7 @@ describe('Message', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .messages('IMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/ipMessaging/v2/service/channel/webhook.spec.js
+++ b/spec/integration/rest/ipMessaging/v2/service/channel/webhook.spec.js
@@ -440,7 +440,7 @@ describe('Webhook', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {type: 'webhook'};
+      var opts = {'type': 'webhook'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .webhooks.create(opts);
@@ -455,7 +455,7 @@ describe('Webhook', function() {
       var channelSid = 'CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://ip-messaging.twilio.com/v2/Services/${serviceSid}/Channels/${channelSid}/Webhooks`;
 
-      var values = {Type: 'webhook', };
+      var values = {'Type': 'webhook', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -487,7 +487,7 @@ describe('Webhook', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {type: 'webhook'};
+      var opts = {'type': 'webhook'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .channels('CHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .webhooks.create(opts);

--- a/spec/integration/rest/ipMessaging/v2/service/role.spec.js
+++ b/spec/integration/rest/ipMessaging/v2/service/role.spec.js
@@ -128,7 +128,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', type: 'channel', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'channel', 'permission': ['permission']};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .roles.create(opts);
       promise.then(function() {
@@ -142,9 +142,9 @@ describe('Role', function() {
       var url = `https://ip-messaging.twilio.com/v2/Services/${serviceSid}/Roles`;
 
       var values = {
-        FriendlyName: 'friendly_name',
-        Type: 'channel',
-        Permission: serialize.map(['permission'], function(e) { return e; }),
+        'FriendlyName': 'friendly_name',
+        'Type': 'channel',
+        'Permission': serialize.map(['permission'], function(e) { return e; }),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -174,7 +174,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', type: 'channel', permission: ['permission']};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'channel', 'permission': ['permission']};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .roles.create(opts);
       promise.then(function(response) {
@@ -395,7 +395,7 @@ describe('Role', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -409,7 +409,7 @@ describe('Role', function() {
       var sid = 'RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://ip-messaging.twilio.com/v2/Services/${serviceSid}/Roles/${sid}`;
 
-      var values = {Permission: serialize.map(['permission'], function(e) { return e; }), };
+      var values = {'Permission': serialize.map(['permission'], function(e) { return e; }), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -438,7 +438,7 @@ describe('Role', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {permission: ['permission']};
+      var opts = {'permission': ['permission']};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .roles('RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/ipMessaging/v2/service/user.spec.js
+++ b/spec/integration/rest/ipMessaging/v2/service/user.spec.js
@@ -129,7 +129,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity', xTwilioWebhookEnabled: 'true'};
+      var opts = {'identity': 'identity', 'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .users.create(opts);
       promise.then(function() {
@@ -142,7 +142,7 @@ describe('User', function() {
       var serviceSid = 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://ip-messaging.twilio.com/v2/Services/${serviceSid}/Users`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -181,7 +181,7 @@ describe('User', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .users.create(opts);
       promise.then(function(response) {
@@ -414,7 +414,7 @@ describe('User', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xTwilioWebhookEnabled: 'true'};
+      var opts = {'xTwilioWebhookEnabled': 'true'};
       var promise = client.ipMessaging.v2.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                          .users('USXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {

--- a/spec/integration/rest/media/v1/mediaProcessor.spec.js
+++ b/spec/integration/rest/media/v1/mediaProcessor.spec.js
@@ -33,7 +33,7 @@ describe('MediaProcessor', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {extension: 'extension', extensionContext: 'extension_context'};
+      var opts = {'extension': 'extension', 'extensionContext': 'extension_context'};
       var promise = client.media.v1.mediaProcessor.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('MediaProcessor', function() {
 
       var url = 'https://media.twilio.com/v1/MediaProcessors';
 
-      var values = {Extension: 'extension', ExtensionContext: 'extension_context', };
+      var values = {'Extension': 'extension', 'ExtensionContext': 'extension_context', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -71,7 +71,7 @@ describe('MediaProcessor', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {extension: 'extension', extensionContext: 'extension_context'};
+      var opts = {'extension': 'extension', 'extensionContext': 'extension_context'};
       var promise = client.media.v1.mediaProcessor.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -134,7 +134,7 @@ describe('MediaProcessor', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {status: 'ended'};
+      var opts = {'status': 'ended'};
       var promise = client.media.v1.mediaProcessor('ZXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -146,7 +146,7 @@ describe('MediaProcessor', function() {
       var sid = 'ZXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://media.twilio.com/v1/MediaProcessors/${sid}`;
 
-      var values = {Status: 'ended', };
+      var values = {'Status': 'ended', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -173,7 +173,7 @@ describe('MediaProcessor', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'ended'};
+      var opts = {'status': 'ended'};
       var promise = client.media.v1.mediaProcessor('ZXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/media/v1/playerStreamer.spec.js
+++ b/spec/integration/rest/media/v1/playerStreamer.spec.js
@@ -134,7 +134,7 @@ describe('PlayerStreamer', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {status: 'ended'};
+      var opts = {'status': 'ended'};
       var promise = client.media.v1.playerStreamer('VJXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -146,7 +146,7 @@ describe('PlayerStreamer', function() {
       var sid = 'VJXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://media.twilio.com/v1/PlayerStreamers/${sid}`;
 
-      var values = {Status: 'ended', };
+      var values = {'Status': 'ended', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -175,7 +175,7 @@ describe('PlayerStreamer', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'ended'};
+      var opts = {'status': 'ended'};
       var promise = client.media.v1.playerStreamer('VJXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/messaging/v1/brandRegistration.spec.js
+++ b/spec/integration/rest/messaging/v1/brandRegistration.spec.js
@@ -313,8 +313,8 @@ describe('BrandRegistration', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        customerProfileBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        a2PProfileBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'customerProfileBundleSid': 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'a2PProfileBundleSid': 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.messaging.v1.brandRegistrations.create(opts);
       promise.then(function() {
@@ -327,8 +327,8 @@ describe('BrandRegistration', function() {
       var url = 'https://messaging.twilio.com/v1/a2p/BrandRegistrations';
 
       var values = {
-        CustomerProfileBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        A2PProfileBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'CustomerProfileBundleSid': 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'A2PProfileBundleSid': 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -370,8 +370,8 @@ describe('BrandRegistration', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        customerProfileBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        a2PProfileBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'customerProfileBundleSid': 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'a2PProfileBundleSid': 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.messaging.v1.brandRegistrations.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/messaging/v1/brandRegistration/brandVetting.spec.js
+++ b/spec/integration/rest/messaging/v1/brandRegistration/brandVetting.spec.js
@@ -33,7 +33,7 @@ describe('BrandVetting', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {vettingProvider: 'campaign-verify'};
+      var opts = {'vettingProvider': 'campaign-verify'};
       var promise = client.messaging.v1.brandRegistrations('BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .brandVettings.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('BrandVetting', function() {
       var brandSid = 'BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://messaging.twilio.com/v1/a2p/BrandRegistrations/${brandSid}/Vettings`;
 
-      var values = {VettingProvider: 'campaign-verify', };
+      var values = {'VettingProvider': 'campaign-verify', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -71,7 +71,7 @@ describe('BrandVetting', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {vettingProvider: 'campaign-verify'};
+      var opts = {'vettingProvider': 'campaign-verify'};
       var promise = client.messaging.v1.brandRegistrations('BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .brandVettings.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/messaging/v1/externalCampaign.spec.js
+++ b/spec/integration/rest/messaging/v1/externalCampaign.spec.js
@@ -33,7 +33,10 @@ describe('ExternalCampaign', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {campaignId: 'campaign_id', messagingServiceSid: 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {
+        'campaignId': 'campaign_id',
+        'messagingServiceSid': 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+      };
       var promise = client.messaging.v1.externalCampaign.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +47,10 @@ describe('ExternalCampaign', function() {
 
       var url = 'https://messaging.twilio.com/v1/Services/PreregisteredUsa2p';
 
-      var values = {CampaignId: 'campaign_id', MessagingServiceSid: 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {
+        'CampaignId': 'campaign_id',
+        'MessagingServiceSid': 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+      };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -64,7 +70,10 @@ describe('ExternalCampaign', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {campaignId: 'campaign_id', messagingServiceSid: 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {
+        'campaignId': 'campaign_id',
+        'messagingServiceSid': 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+      };
       var promise = client.messaging.v1.externalCampaign.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/messaging/v1/service.spec.js
+++ b/spec/integration/rest/messaging/v1/service.spec.js
@@ -33,7 +33,7 @@ describe('Service', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.messaging.v1.services.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('Service', function() {
 
       var url = 'https://messaging.twilio.com/v1/Services';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -90,7 +90,7 @@ describe('Service', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.messaging.v1.services.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/messaging/v1/service/alphaSender.spec.js
+++ b/spec/integration/rest/messaging/v1/service/alphaSender.spec.js
@@ -33,7 +33,7 @@ describe('AlphaSender', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {alphaSender: 'alpha_sender'};
+      var opts = {'alphaSender': 'alpha_sender'};
       var promise = client.messaging.v1.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .alphaSenders.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('AlphaSender', function() {
       var serviceSid = 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://messaging.twilio.com/v1/Services/${serviceSid}/AlphaSenders`;
 
-      var values = {AlphaSender: 'alpha_sender', };
+      var values = {'AlphaSender': 'alpha_sender', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -71,7 +71,7 @@ describe('AlphaSender', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {alphaSender: 'alpha_sender'};
+      var opts = {'alphaSender': 'alpha_sender'};
       var promise = client.messaging.v1.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .alphaSenders.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/messaging/v1/service/phoneNumber.spec.js
+++ b/spec/integration/rest/messaging/v1/service/phoneNumber.spec.js
@@ -33,7 +33,7 @@ describe('PhoneNumber', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {phoneNumberSid: 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'phoneNumberSid': 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.messaging.v1.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .phoneNumbers.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('PhoneNumber', function() {
       var serviceSid = 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://messaging.twilio.com/v1/Services/${serviceSid}/PhoneNumbers`;
 
-      var values = {PhoneNumberSid: 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'PhoneNumberSid': 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -70,7 +70,7 @@ describe('PhoneNumber', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumberSid: 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'phoneNumberSid': 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.messaging.v1.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .phoneNumbers.create(opts);
       promise.then(function(response) {
@@ -101,7 +101,7 @@ describe('PhoneNumber', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumberSid: 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'phoneNumberSid': 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.messaging.v1.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .phoneNumbers.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/messaging/v1/service/shortCode.spec.js
+++ b/spec/integration/rest/messaging/v1/service/shortCode.spec.js
@@ -33,7 +33,7 @@ describe('ShortCode', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {shortCodeSid: 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'shortCodeSid': 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.messaging.v1.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .shortCodes.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('ShortCode', function() {
       var serviceSid = 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://messaging.twilio.com/v1/Services/${serviceSid}/ShortCodes`;
 
-      var values = {ShortCodeSid: 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'ShortCodeSid': 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -72,7 +72,7 @@ describe('ShortCode', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {shortCodeSid: 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'shortCodeSid': 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.messaging.v1.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .shortCodes.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/messaging/v1/service/usAppToPerson.spec.js
+++ b/spec/integration/rest/messaging/v1/service/usAppToPerson.spec.js
@@ -36,12 +36,12 @@ describe('UsAppToPerson', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        brandRegistrationSid: 'BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        description: 'description',
-        messageSamples: ['message_samples'],
-        usAppToPersonUsecase: 'us_app_to_person_usecase',
-        hasEmbeddedLinks: true,
-        hasEmbeddedPhone: true
+        'brandRegistrationSid': 'BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'description': 'description',
+        'messageSamples': ['message_samples'],
+        'usAppToPersonUsecase': 'us_app_to_person_usecase',
+        'hasEmbeddedLinks': true,
+        'hasEmbeddedPhone': true
       };
       var promise = client.messaging.v1.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .usAppToPerson.create(opts);
@@ -56,12 +56,12 @@ describe('UsAppToPerson', function() {
       var url = `https://messaging.twilio.com/v1/Services/${messagingServiceSid}/Compliance/Usa2p`;
 
       var values = {
-        BrandRegistrationSid: 'BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        Description: 'description',
-        MessageSamples: serialize.map(['message_samples'], function(e) { return e; }),
-        UsAppToPersonUsecase: 'us_app_to_person_usecase',
-        HasEmbeddedLinks: serialize.bool(true),
-        HasEmbeddedPhone: serialize.bool(true),
+        'BrandRegistrationSid': 'BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'Description': 'description',
+        'MessageSamples': serialize.map(['message_samples'], function(e) { return e; }),
+        'UsAppToPersonUsecase': 'us_app_to_person_usecase',
+        'HasEmbeddedLinks': serialize.bool(true),
+        'HasEmbeddedPhone': serialize.bool(true),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -106,12 +106,12 @@ describe('UsAppToPerson', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        brandRegistrationSid: 'BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        description: 'description',
-        messageSamples: ['message_samples'],
-        usAppToPersonUsecase: 'us_app_to_person_usecase',
-        hasEmbeddedLinks: true,
-        hasEmbeddedPhone: true
+        'brandRegistrationSid': 'BNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'description': 'description',
+        'messageSamples': ['message_samples'],
+        'usAppToPersonUsecase': 'us_app_to_person_usecase',
+        'hasEmbeddedLinks': true,
+        'hasEmbeddedPhone': true
       };
       var promise = client.messaging.v1.services('MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .usAppToPerson.create(opts);

--- a/spec/integration/rest/notify/v1/credential.spec.js
+++ b/spec/integration/rest/notify/v1/credential.spec.js
@@ -208,7 +208,7 @@ describe('Credential', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {type: 'gcm'};
+      var opts = {'type': 'gcm'};
       var promise = client.notify.v1.credentials.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -219,7 +219,7 @@ describe('Credential', function() {
 
       var url = 'https://notify.twilio.com/v1/Credentials';
 
-      var values = {Type: 'gcm', };
+      var values = {'Type': 'gcm', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -242,7 +242,7 @@ describe('Credential', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {type: 'gcm'};
+      var opts = {'type': 'gcm'};
       var promise = client.notify.v1.credentials.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/notify/v1/service/binding.spec.js
+++ b/spec/integration/rest/notify/v1/service/binding.spec.js
@@ -130,7 +130,7 @@ describe('Binding', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity', bindingType: 'apn', address: 'address'};
+      var opts = {'identity': 'identity', 'bindingType': 'apn', 'address': 'address'};
       var promise = client.notify.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .bindings.create(opts);
       promise.then(function() {
@@ -143,7 +143,7 @@ describe('Binding', function() {
       var serviceSid = 'ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://notify.twilio.com/v1/Services/${serviceSid}/Bindings`;
 
-      var values = {Identity: 'identity', BindingType: 'apn', Address: 'address', };
+      var values = {'Identity': 'identity', 'BindingType': 'apn', 'Address': 'address', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -176,7 +176,7 @@ describe('Binding', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity', bindingType: 'apn', address: 'address'};
+      var opts = {'identity': 'identity', 'bindingType': 'apn', 'address': 'address'};
       var promise = client.notify.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .bindings.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/numbers/v2/regulatoryCompliance/bundle.spec.js
+++ b/spec/integration/rest/numbers/v2/regulatoryCompliance/bundle.spec.js
@@ -33,7 +33,7 @@ describe('Bundle', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', email: 'email'};
+      var opts = {'friendlyName': 'friendly_name', 'email': 'email'};
       var promise = client.numbers.v2.regulatoryCompliance
                                      .bundles.create(opts);
       promise.then(function() {
@@ -45,7 +45,7 @@ describe('Bundle', function() {
 
       var url = 'https://numbers.twilio.com/v2/RegulatoryCompliance/Bundles';
 
-      var values = {FriendlyName: 'friendly_name', Email: 'email', };
+      var values = {'FriendlyName': 'friendly_name', 'Email': 'email', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -76,7 +76,7 @@ describe('Bundle', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', email: 'email'};
+      var opts = {'friendlyName': 'friendly_name', 'email': 'email'};
       var promise = client.numbers.v2.regulatoryCompliance
                                      .bundles.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/numbers/v2/regulatoryCompliance/bundle/itemAssignment.spec.js
+++ b/spec/integration/rest/numbers/v2/regulatoryCompliance/bundle/itemAssignment.spec.js
@@ -33,7 +33,7 @@ describe('ItemAssignment', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {objectSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'objectSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.numbers.v2.regulatoryCompliance
                                      .bundles('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                      .itemAssignments.create(opts);
@@ -47,7 +47,7 @@ describe('ItemAssignment', function() {
       var bundleSid = 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://numbers.twilio.com/v2/RegulatoryCompliance/Bundles/${bundleSid}/ItemAssignments`;
 
-      var values = {ObjectSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'ObjectSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -68,7 +68,7 @@ describe('ItemAssignment', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {objectSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'objectSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.numbers.v2.regulatoryCompliance
                                      .bundles('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                      .itemAssignments.create(opts);

--- a/spec/integration/rest/numbers/v2/regulatoryCompliance/bundle/replaceItems.spec.js
+++ b/spec/integration/rest/numbers/v2/regulatoryCompliance/bundle/replaceItems.spec.js
@@ -33,7 +33,7 @@ describe('ReplaceItems', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {fromBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'fromBundleSid': 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.numbers.v2.regulatoryCompliance
                                      .bundles('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                      .replaceItems.create(opts);
@@ -47,7 +47,7 @@ describe('ReplaceItems', function() {
       var bundleSid = 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://numbers.twilio.com/v2/RegulatoryCompliance/Bundles/${bundleSid}/ReplaceItems`;
 
-      var values = {FromBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'FromBundleSid': 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -72,7 +72,7 @@ describe('ReplaceItems', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {fromBundleSid: 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'fromBundleSid': 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.numbers.v2.regulatoryCompliance
                                      .bundles('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                      .replaceItems.create(opts);

--- a/spec/integration/rest/numbers/v2/regulatoryCompliance/endUser.spec.js
+++ b/spec/integration/rest/numbers/v2/regulatoryCompliance/endUser.spec.js
@@ -33,7 +33,7 @@ describe('EndUser', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', type: 'individual'};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'individual'};
       var promise = client.numbers.v2.regulatoryCompliance
                                      .endUsers.create(opts);
       promise.then(function() {
@@ -45,7 +45,7 @@ describe('EndUser', function() {
 
       var url = 'https://numbers.twilio.com/v2/RegulatoryCompliance/EndUsers';
 
-      var values = {FriendlyName: 'friendly_name', Type: 'individual', };
+      var values = {'FriendlyName': 'friendly_name', 'Type': 'individual', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -70,7 +70,7 @@ describe('EndUser', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', type: 'individual'};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'individual'};
       var promise = client.numbers.v2.regulatoryCompliance
                                      .endUsers.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/numbers/v2/regulatoryCompliance/supportingDocument.spec.js
+++ b/spec/integration/rest/numbers/v2/regulatoryCompliance/supportingDocument.spec.js
@@ -33,7 +33,7 @@ describe('SupportingDocument', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', type: 'type'};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'type'};
       var promise = client.numbers.v2.regulatoryCompliance
                                      .supportingDocuments.create(opts);
       promise.then(function() {
@@ -45,7 +45,7 @@ describe('SupportingDocument', function() {
 
       var url = 'https://numbers.twilio.com/v2/RegulatoryCompliance/SupportingDocuments';
 
-      var values = {FriendlyName: 'friendly_name', Type: 'type', };
+      var values = {'FriendlyName': 'friendly_name', 'Type': 'type', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -73,7 +73,7 @@ describe('SupportingDocument', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', type: 'type'};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'type'};
       var promise = client.numbers.v2.regulatoryCompliance
                                      .supportingDocuments.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/preview/bulk_exports/export/exportCustomJob.spec.js
+++ b/spec/integration/rest/preview/bulk_exports/export/exportCustomJob.spec.js
@@ -219,7 +219,7 @@ describe('ExportCustomJob', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {startDay: 'start_day', endDay: 'end_day', friendlyName: 'friendly_name'};
+      var opts = {'startDay': 'start_day', 'endDay': 'end_day', 'friendlyName': 'friendly_name'};
       var promise = client.preview.bulk_exports.exports('resource_type')
                                                .exportCustomJobs.create(opts);
       promise.then(function() {
@@ -232,7 +232,7 @@ describe('ExportCustomJob', function() {
       var resourceType = 'resource_type';
       var url = `https://preview.twilio.com/BulkExports/Exports/${resourceType}/Jobs`;
 
-      var values = {StartDay: 'start_day', EndDay: 'end_day', FriendlyName: 'friendly_name', };
+      var values = {'StartDay': 'start_day', 'EndDay': 'end_day', 'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -256,7 +256,7 @@ describe('ExportCustomJob', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {startDay: 'start_day', endDay: 'end_day', friendlyName: 'friendly_name'};
+      var opts = {'startDay': 'start_day', 'endDay': 'end_day', 'friendlyName': 'friendly_name'};
       var promise = client.preview.bulk_exports.exports('resource_type')
                                                .exportCustomJobs.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/preview/deployed_devices/fleet/certificate.spec.js
+++ b/spec/integration/rest/preview/deployed_devices/fleet/certificate.spec.js
@@ -121,7 +121,7 @@ describe('Certificate', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {certificateData: 'certificate_data'};
+      var opts = {'certificateData': 'certificate_data'};
       var promise = client.preview.deployed_devices.fleets('FLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                                    .certificates.create(opts);
       promise.then(function() {
@@ -134,7 +134,7 @@ describe('Certificate', function() {
       var fleetSid = 'FLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/DeployedDevices/Fleets/${fleetSid}/Certificates`;
 
-      var values = {CertificateData: 'certificate_data', };
+      var values = {'CertificateData': 'certificate_data', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -158,7 +158,7 @@ describe('Certificate', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {certificateData: 'certificate_data'};
+      var opts = {'certificateData': 'certificate_data'};
       var promise = client.preview.deployed_devices.fleets('FLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                                    .certificates.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/preview/hosted_numbers/authorizationDocument.spec.js
+++ b/spec/integration/rest/preview/hosted_numbers/authorizationDocument.spec.js
@@ -337,11 +337,11 @@ describe('AuthorizationDocument', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        hostedNumberOrderSids: ['hosted_number_order_sids'],
-        addressSid: 'ADXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        email: 'email',
-        contactTitle: 'contact_title',
-        contactPhoneNumber: 'contact_phone_number'
+        'hostedNumberOrderSids': ['hosted_number_order_sids'],
+        'addressSid': 'ADXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'email': 'email',
+        'contactTitle': 'contact_title',
+        'contactPhoneNumber': 'contact_phone_number'
       };
       var promise = client.preview.hosted_numbers.authorizationDocuments.create(opts);
       promise.then(function() {
@@ -354,11 +354,11 @@ describe('AuthorizationDocument', function() {
       var url = 'https://preview.twilio.com/HostedNumbers/AuthorizationDocuments';
 
       var values = {
-        HostedNumberOrderSids: serialize.map(['hosted_number_order_sids'], function(e) { return e; }),
-        AddressSid: 'ADXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        Email: 'email',
-        ContactTitle: 'contact_title',
-        ContactPhoneNumber: 'contact_phone_number',
+        'HostedNumberOrderSids': serialize.map(['hosted_number_order_sids'], function(e) { return e; }),
+        'AddressSid': 'ADXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'Email': 'email',
+        'ContactTitle': 'contact_title',
+        'ContactPhoneNumber': 'contact_phone_number',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -389,11 +389,11 @@ describe('AuthorizationDocument', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        hostedNumberOrderSids: ['hosted_number_order_sids'],
-        addressSid: 'ADXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        email: 'email',
-        contactTitle: 'contact_title',
-        contactPhoneNumber: 'contact_phone_number'
+        'hostedNumberOrderSids': ['hosted_number_order_sids'],
+        'addressSid': 'ADXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'email': 'email',
+        'contactTitle': 'contact_title',
+        'contactPhoneNumber': 'contact_phone_number'
       };
       var promise = client.preview.hosted_numbers.authorizationDocuments.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/preview/hosted_numbers/hostedNumberOrder.spec.js
+++ b/spec/integration/rest/preview/hosted_numbers/hostedNumberOrder.spec.js
@@ -480,7 +480,7 @@ describe('HostedNumberOrder', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {phoneNumber: '+15017122661', smsCapability: true};
+      var opts = {'phoneNumber': '+15017122661', 'smsCapability': true};
       var promise = client.preview.hosted_numbers.hostedNumberOrders.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -491,7 +491,7 @@ describe('HostedNumberOrder', function() {
 
       var url = 'https://preview.twilio.com/HostedNumbers/HostedNumberOrders';
 
-      var values = {PhoneNumber: '+15017122661', SmsCapability: serialize.bool(true), };
+      var values = {'PhoneNumber': '+15017122661', 'SmsCapability': serialize.bool(true), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -532,7 +532,7 @@ describe('HostedNumberOrder', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumber: '+15017122661', smsCapability: true};
+      var opts = {'phoneNumber': '+15017122661', 'smsCapability': true};
       var promise = client.preview.hosted_numbers.hostedNumberOrders.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -575,7 +575,7 @@ describe('HostedNumberOrder', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumber: '+15017122661', smsCapability: true};
+      var opts = {'phoneNumber': '+15017122661', 'smsCapability': true};
       var promise = client.preview.hosted_numbers.hostedNumberOrders.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -618,7 +618,7 @@ describe('HostedNumberOrder', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumber: '+15017122661', smsCapability: true};
+      var opts = {'phoneNumber': '+15017122661', 'smsCapability': true};
       var promise = client.preview.hosted_numbers.hostedNumberOrders.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/preview/marketplace/installedAddOn.spec.js
+++ b/spec/integration/rest/preview/marketplace/installedAddOn.spec.js
@@ -35,7 +35,10 @@ describe('InstalledAddOn', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {availableAddOnSid: 'XBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', acceptTermsOfService: true};
+      var opts = {
+        'availableAddOnSid': 'XBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'acceptTermsOfService': true
+      };
       var promise = client.preview.marketplace.installedAddOns.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -47,8 +50,8 @@ describe('InstalledAddOn', function() {
       var url = 'https://preview.twilio.com/marketplace/InstalledAddOns';
 
       var values = {
-        AvailableAddOnSid: 'XBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        AcceptTermsOfService: serialize.bool(true),
+        'AvailableAddOnSid': 'XBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'AcceptTermsOfService': serialize.bool(true),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -79,7 +82,10 @@ describe('InstalledAddOn', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {availableAddOnSid: 'XBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', acceptTermsOfService: true};
+      var opts = {
+        'availableAddOnSid': 'XBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'acceptTermsOfService': true
+      };
       var promise = client.preview.marketplace.installedAddOns.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/preview/marketplace/installedAddOn/installedAddOnExtension.spec.js
+++ b/spec/integration/rest/preview/marketplace/installedAddOn/installedAddOnExtension.spec.js
@@ -82,7 +82,7 @@ describe('InstalledAddOnExtension', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {enabled: true};
+      var opts = {'enabled': true};
       var promise = client.preview.marketplace.installedAddOns('XEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                               .extensions('XFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -96,7 +96,7 @@ describe('InstalledAddOnExtension', function() {
       var sid = 'XFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/marketplace/InstalledAddOns/${installedAddOnSid}/Extensions/${sid}`;
 
-      var values = {Enabled: serialize.bool(true), };
+      var values = {'Enabled': serialize.bool(true), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -118,7 +118,7 @@ describe('InstalledAddOnExtension', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {enabled: true};
+      var opts = {'enabled': true};
       var promise = client.preview.marketplace.installedAddOns('XEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                               .extensions('XFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/preview/sync/service/document.spec.js
+++ b/spec/integration/rest/preview/sync/service/document.spec.js
@@ -381,7 +381,7 @@ describe('Document', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {data: {}, ifMatch: 'if_match'};
+      var opts = {'data': {}, 'ifMatch': 'if_match'};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .documents('ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -395,7 +395,7 @@ describe('Document', function() {
       var sid = 'ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/Sync/Services/${serviceSid}/Documents/${sid}`;
 
-      var values = {Data: serialize.object({}), };
+      var values = {'Data': serialize.object({}), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -430,7 +430,7 @@ describe('Document', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {data: {}};
+      var opts = {'data': {}};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .documents('ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/preview/sync/service/document/documentPermission.spec.js
+++ b/spec/integration/rest/preview/sync/service/document/documentPermission.spec.js
@@ -317,7 +317,7 @@ describe('DocumentPermission', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .documents('ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .documentPermissions('identity').update(opts);
@@ -334,9 +334,9 @@ describe('DocumentPermission', function() {
       var url = `https://preview.twilio.com/Sync/Services/${serviceSid}/Documents/${documentSid}/Permissions/${identity}`;
 
       var values = {
-        Read: serialize.bool(true),
-        Write: serialize.bool(true),
-        Manage: serialize.bool(true),
+        'Read': serialize.bool(true),
+        'Write': serialize.bool(true),
+        'Manage': serialize.bool(true),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -360,7 +360,7 @@ describe('DocumentPermission', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .documents('ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .documentPermissions('identity').update(opts);

--- a/spec/integration/rest/preview/sync/service/syncList/syncListItem.spec.js
+++ b/spec/integration/rest/preview/sync/service/syncList/syncListItem.spec.js
@@ -88,7 +88,7 @@ describe('SyncListItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncListItems(1).remove(opts);
@@ -133,7 +133,7 @@ describe('SyncListItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {data: {}};
+      var opts = {'data': {}};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncListItems.create(opts);
@@ -148,7 +148,7 @@ describe('SyncListItem', function() {
       var listSid = 'ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/Sync/Services/${serviceSid}/Lists/${listSid}/Items`;
 
-      var values = {Data: serialize.object({}), };
+      var values = {'Data': serialize.object({}), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -173,7 +173,7 @@ describe('SyncListItem', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {data: {}};
+      var opts = {'data': {}};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncListItems.create(opts);
@@ -386,7 +386,7 @@ describe('SyncListItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {data: {}, ifMatch: 'if_match'};
+      var opts = {'data': {}, 'ifMatch': 'if_match'};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncListItems(1).update(opts);
@@ -402,7 +402,7 @@ describe('SyncListItem', function() {
       var index = 1;
       var url = `https://preview.twilio.com/Sync/Services/${serviceSid}/Lists/${listSid}/Items/${index}`;
 
-      var values = {Data: serialize.object({}), };
+      var values = {'Data': serialize.object({}), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -434,7 +434,7 @@ describe('SyncListItem', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {data: {}};
+      var opts = {'data': {}};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncListItems(1).update(opts);

--- a/spec/integration/rest/preview/sync/service/syncList/syncListPermission.spec.js
+++ b/spec/integration/rest/preview/sync/service/syncList/syncListPermission.spec.js
@@ -317,7 +317,7 @@ describe('SyncListPermission', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncListPermissions('identity').update(opts);
@@ -334,9 +334,9 @@ describe('SyncListPermission', function() {
       var url = `https://preview.twilio.com/Sync/Services/${serviceSid}/Lists/${listSid}/Permissions/${identity}`;
 
       var values = {
-        Read: serialize.bool(true),
-        Write: serialize.bool(true),
-        Manage: serialize.bool(true),
+        'Read': serialize.bool(true),
+        'Write': serialize.bool(true),
+        'Manage': serialize.bool(true),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -360,7 +360,7 @@ describe('SyncListPermission', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncListPermissions('identity').update(opts);

--- a/spec/integration/rest/preview/sync/service/syncMap/syncMapItem.spec.js
+++ b/spec/integration/rest/preview/sync/service/syncMap/syncMapItem.spec.js
@@ -88,7 +88,7 @@ describe('SyncMapItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMapItems('key').remove(opts);
@@ -133,7 +133,7 @@ describe('SyncMapItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {key: 'key', data: {}};
+      var opts = {'key': 'key', 'data': {}};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMapItems.create(opts);
@@ -148,7 +148,7 @@ describe('SyncMapItem', function() {
       var mapSid = 'MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/Sync/Services/${serviceSid}/Maps/${mapSid}/Items`;
 
-      var values = {Key: 'key', Data: serialize.object({}), };
+      var values = {'Key': 'key', 'Data': serialize.object({}), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -173,7 +173,7 @@ describe('SyncMapItem', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {key: 'key', data: {}};
+      var opts = {'key': 'key', 'data': {}};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMapItems.create(opts);
@@ -386,7 +386,7 @@ describe('SyncMapItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {data: {}, ifMatch: 'if_match'};
+      var opts = {'data': {}, 'ifMatch': 'if_match'};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMapItems('key').update(opts);
@@ -402,7 +402,7 @@ describe('SyncMapItem', function() {
       var key = 'key';
       var url = `https://preview.twilio.com/Sync/Services/${serviceSid}/Maps/${mapSid}/Items/${key}`;
 
-      var values = {Data: serialize.object({}), };
+      var values = {'Data': serialize.object({}), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -434,7 +434,7 @@ describe('SyncMapItem', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {data: {}};
+      var opts = {'data': {}};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMapItems('key').update(opts);

--- a/spec/integration/rest/preview/sync/service/syncMap/syncMapPermission.spec.js
+++ b/spec/integration/rest/preview/sync/service/syncMap/syncMapPermission.spec.js
@@ -317,7 +317,7 @@ describe('SyncMapPermission', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMapPermissions('identity').update(opts);
@@ -334,9 +334,9 @@ describe('SyncMapPermission', function() {
       var url = `https://preview.twilio.com/Sync/Services/${serviceSid}/Maps/${mapSid}/Permissions/${identity}`;
 
       var values = {
-        Read: serialize.bool(true),
-        Write: serialize.bool(true),
-        Manage: serialize.bool(true),
+        'Read': serialize.bool(true),
+        'Write': serialize.bool(true),
+        'Manage': serialize.bool(true),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -360,7 +360,7 @@ describe('SyncMapPermission', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.preview.sync.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                        .syncMapPermissions('identity').update(opts);

--- a/spec/integration/rest/preview/trusted_comms/brandedChannel/channel.spec.js
+++ b/spec/integration/rest/preview/trusted_comms/brandedChannel/channel.spec.js
@@ -33,7 +33,7 @@ describe('Channel', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {phoneNumberSid: 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'phoneNumberSid': 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.preview.trusted_comms.brandedChannels('BWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                                 .channels.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('Channel', function() {
       var brandedChannelSid = 'BWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/TrustedComms/BrandedChannels/${brandedChannelSid}/Channels`;
 
-      var values = {PhoneNumberSid: 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'PhoneNumberSid': 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -68,7 +68,7 @@ describe('Channel', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumberSid: 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'phoneNumberSid': 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.preview.trusted_comms.brandedChannels('BWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                                 .channels.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/preview/trusted_comms/brandsInformation.spec.js
+++ b/spec/integration/rest/preview/trusted_comms/brandsInformation.spec.js
@@ -33,7 +33,7 @@ describe('BrandsInformation', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifNoneMatch: 'if_none_match'};
+      var opts = {'ifNoneMatch': 'if_none_match'};
       var promise = client.preview.trusted_comms.brandsInformation().fetch(opts);
       promise.then(function() {
         throw new Error('failed');

--- a/spec/integration/rest/preview/trusted_comms/cps.spec.js
+++ b/spec/integration/rest/preview/trusted_comms/cps.spec.js
@@ -33,7 +33,7 @@ describe('Cps', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {xXcnamSensitivePhoneNumber: 'x_xcnam_sensitive_phone_number'};
+      var opts = {'xXcnamSensitivePhoneNumber': 'x_xcnam_sensitive_phone_number'};
       var promise = client.preview.trusted_comms.cps().fetch(opts);
       promise.then(function() {
         throw new Error('failed');

--- a/spec/integration/rest/preview/trusted_comms/currentCall.spec.js
+++ b/spec/integration/rest/preview/trusted_comms/currentCall.spec.js
@@ -34,8 +34,8 @@ describe('CurrentCall', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        xXcnamSensitivePhoneNumberFrom: 'x_xcnam_sensitive_phone_number_from',
-        xXcnamSensitivePhoneNumberTo: 'x_xcnam_sensitive_phone_number_to'
+        'xXcnamSensitivePhoneNumberFrom': 'x_xcnam_sensitive_phone_number_from',
+        'xXcnamSensitivePhoneNumberTo': 'x_xcnam_sensitive_phone_number_to'
       };
       var promise = client.preview.trusted_comms.currentCalls().fetch(opts);
       promise.then(function() {

--- a/spec/integration/rest/preview/understand/assistant/fieldType.spec.js
+++ b/spec/integration/rest/preview/understand/assistant/fieldType.spec.js
@@ -278,7 +278,7 @@ describe('FieldType', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .fieldTypes.create(opts);
       promise.then(function() {
@@ -291,7 +291,7 @@ describe('FieldType', function() {
       var assistantSid = 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/understand/Assistants/${assistantSid}/FieldTypes`;
 
-      var values = {UniqueName: 'unique_name', };
+      var values = {'UniqueName': 'unique_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -317,7 +317,7 @@ describe('FieldType', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .fieldTypes.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/preview/understand/assistant/fieldType/fieldValue.spec.js
+++ b/spec/integration/rest/preview/understand/assistant/fieldType/fieldValue.spec.js
@@ -283,7 +283,7 @@ describe('FieldValue', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {language: 'language', value: 'value'};
+      var opts = {'language': 'language', 'value': 'value'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .fieldTypes('UBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .fieldValues.create(opts);
@@ -298,7 +298,7 @@ describe('FieldValue', function() {
       var fieldTypeSid = 'UBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/understand/Assistants/${assistantSid}/FieldTypes/${fieldTypeSid}/FieldValues`;
 
-      var values = {Language: 'language', Value: 'value', };
+      var values = {'Language': 'language', 'Value': 'value', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -323,7 +323,7 @@ describe('FieldValue', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {language: 'language', value: 'value'};
+      var opts = {'language': 'language', 'value': 'value'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .fieldTypes('UBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .fieldValues.create(opts);

--- a/spec/integration/rest/preview/understand/assistant/query.spec.js
+++ b/spec/integration/rest/preview/understand/assistant/query.spec.js
@@ -353,7 +353,7 @@ describe('Query', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {language: 'language', query: 'query'};
+      var opts = {'language': 'language', 'query': 'query'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .queries.create(opts);
       promise.then(function() {
@@ -366,7 +366,7 @@ describe('Query', function() {
       var assistantSid = 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/understand/Assistants/${assistantSid}/Queries`;
 
-      var values = {Language: 'language', Query: 'query', };
+      var values = {'Language': 'language', 'Query': 'query', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -407,7 +407,7 @@ describe('Query', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {language: 'language', query: 'query'};
+      var opts = {'language': 'language', 'query': 'query'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .queries.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/preview/understand/assistant/task.spec.js
+++ b/spec/integration/rest/preview/understand/assistant/task.spec.js
@@ -298,7 +298,7 @@ describe('Task', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .tasks.create(opts);
       promise.then(function() {
@@ -311,7 +311,7 @@ describe('Task', function() {
       var assistantSid = 'UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/understand/Assistants/${assistantSid}/Tasks`;
 
-      var values = {UniqueName: 'unique_name', };
+      var values = {'UniqueName': 'unique_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -341,7 +341,7 @@ describe('Task', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .tasks.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/preview/understand/assistant/task/field.spec.js
+++ b/spec/integration/rest/preview/understand/assistant/task/field.spec.js
@@ -278,7 +278,7 @@ describe('Field', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {fieldType: 'field_type', uniqueName: 'unique_name'};
+      var opts = {'fieldType': 'field_type', 'uniqueName': 'unique_name'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .tasks('UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .fields.create(opts);
@@ -293,7 +293,7 @@ describe('Field', function() {
       var taskSid = 'UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/understand/Assistants/${assistantSid}/Tasks/${taskSid}/Fields`;
 
-      var values = {FieldType: 'field_type', UniqueName: 'unique_name', };
+      var values = {'FieldType': 'field_type', 'UniqueName': 'unique_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -317,7 +317,7 @@ describe('Field', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {fieldType: 'field_type', uniqueName: 'unique_name'};
+      var opts = {'fieldType': 'field_type', 'uniqueName': 'unique_name'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .tasks('UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .fields.create(opts);

--- a/spec/integration/rest/preview/understand/assistant/task/sample.spec.js
+++ b/spec/integration/rest/preview/understand/assistant/task/sample.spec.js
@@ -283,7 +283,7 @@ describe('Sample', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {language: 'language', taggedText: 'tagged_text'};
+      var opts = {'language': 'language', 'taggedText': 'tagged_text'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .tasks('UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .samples.create(opts);
@@ -298,7 +298,7 @@ describe('Sample', function() {
       var taskSid = 'UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://preview.twilio.com/understand/Assistants/${assistantSid}/Tasks/${taskSid}/Samples`;
 
-      var values = {Language: 'language', TaggedText: 'tagged_text', };
+      var values = {'Language': 'language', 'TaggedText': 'tagged_text', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -323,7 +323,7 @@ describe('Sample', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {language: 'language', taggedText: 'tagged_text'};
+      var opts = {'language': 'language', 'taggedText': 'tagged_text'};
       var promise = client.preview.understand.assistants('UAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .tasks('UDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                              .samples.create(opts);

--- a/spec/integration/rest/preview/wireless/command.spec.js
+++ b/spec/integration/rest/preview/wireless/command.spec.js
@@ -268,7 +268,7 @@ describe('Command', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {command: 'command'};
+      var opts = {'command': 'command'};
       var promise = client.preview.wireless.commands.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -279,7 +279,7 @@ describe('Command', function() {
 
       var url = 'https://preview.twilio.com/wireless/Commands';
 
-      var values = {Command: 'command', };
+      var values = {'Command': 'command', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -305,7 +305,7 @@ describe('Command', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {command: 'command'};
+      var opts = {'command': 'command'};
       var promise = client.preview.wireless.commands.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/proxy/v1/service.spec.js
+++ b/spec/integration/rest/proxy/v1/service.spec.js
@@ -134,7 +134,7 @@ describe('Service', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.proxy.v1.services.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -145,7 +145,7 @@ describe('Service', function() {
 
       var url = 'https://proxy.twilio.com/v1/Services';
 
-      var values = {UniqueName: 'unique_name', };
+      var values = {'UniqueName': 'unique_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -178,7 +178,7 @@ describe('Service', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.proxy.v1.services.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/proxy/v1/service/session/participant.spec.js
+++ b/spec/integration/rest/proxy/v1/service/session/participant.spec.js
@@ -176,7 +176,7 @@ describe('Participant', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identifier: 'identifier'};
+      var opts = {'identifier': 'identifier'};
       var promise = client.proxy.v1.services('KSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                    .sessions('KCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                    .participants.create(opts);
@@ -191,7 +191,7 @@ describe('Participant', function() {
       var sessionSid = 'KCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://proxy.twilio.com/v1/Services/${serviceSid}/Sessions/${sessionSid}/Participants`;
 
-      var values = {Identifier: 'identifier', };
+      var values = {'Identifier': 'identifier', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -221,7 +221,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identifier: 'identifier'};
+      var opts = {'identifier': 'identifier'};
       var promise = client.proxy.v1.services('KSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                    .sessions('KCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                    .participants.create(opts);
@@ -255,7 +255,7 @@ describe('Participant', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identifier: 'identifier'};
+      var opts = {'identifier': 'identifier'};
       var promise = client.proxy.v1.services('KSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                    .sessions('KCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                    .participants.create(opts);

--- a/spec/integration/rest/proxy/v1/service/shortCode.spec.js
+++ b/spec/integration/rest/proxy/v1/service/shortCode.spec.js
@@ -33,7 +33,7 @@ describe('ShortCode', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {sid: 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'sid': 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.proxy.v1.services('KSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                    .shortCodes.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('ShortCode', function() {
       var serviceSid = 'KSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://proxy.twilio.com/v1/Services/${serviceSid}/ShortCodes`;
 
-      var values = {Sid: 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'Sid': 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -74,7 +74,7 @@ describe('ShortCode', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {sid: 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'sid': 'SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.proxy.v1.services('KSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                    .shortCodes.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/serverless/v1/service.spec.js
+++ b/spec/integration/rest/serverless/v1/service.spec.js
@@ -168,7 +168,7 @@ describe('Service', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {uniqueName: 'unique_name', friendlyName: 'friendly_name'};
+      var opts = {'uniqueName': 'unique_name', 'friendlyName': 'friendly_name'};
       var promise = client.serverless.v1.services.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -179,7 +179,7 @@ describe('Service', function() {
 
       var url = 'https://serverless.twilio.com/v1/Services';
 
-      var values = {UniqueName: 'unique_name', FriendlyName: 'friendly_name', };
+      var values = {'UniqueName': 'unique_name', 'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -210,7 +210,7 @@ describe('Service', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {uniqueName: 'unique_name', friendlyName: 'friendly_name'};
+      var opts = {'uniqueName': 'unique_name', 'friendlyName': 'friendly_name'};
       var promise = client.serverless.v1.services.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/serverless/v1/service/asset.spec.js
+++ b/spec/integration/rest/serverless/v1/service/asset.spec.js
@@ -171,7 +171,7 @@ describe('Asset', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .assets.create(opts);
       promise.then(function() {
@@ -184,7 +184,7 @@ describe('Asset', function() {
       var serviceSid = 'ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://serverless.twilio.com/v1/Services/${serviceSid}/Assets`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -209,7 +209,7 @@ describe('Asset', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .assets.create(opts);
       promise.then(function(response) {
@@ -224,7 +224,7 @@ describe('Asset', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .assets('ZHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -238,7 +238,7 @@ describe('Asset', function() {
       var sid = 'ZHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://serverless.twilio.com/v1/Services/${serviceSid}/Assets/${sid}`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -263,7 +263,7 @@ describe('Asset', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .assets('ZHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/serverless/v1/service/environment.spec.js
+++ b/spec/integration/rest/serverless/v1/service/environment.spec.js
@@ -138,7 +138,7 @@ describe('Environment', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .environments.create(opts);
       promise.then(function() {
@@ -151,7 +151,7 @@ describe('Environment', function() {
       var serviceSid = 'ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://serverless.twilio.com/v1/Services/${serviceSid}/Environments`;
 
-      var values = {UniqueName: 'unique_name', };
+      var values = {'UniqueName': 'unique_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -182,7 +182,7 @@ describe('Environment', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .environments.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/serverless/v1/service/environment/variable.spec.js
+++ b/spec/integration/rest/serverless/v1/service/environment/variable.spec.js
@@ -137,7 +137,7 @@ describe('Variable', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {key: 'key', value: 'value'};
+      var opts = {'key': 'key', 'value': 'value'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .environments('ZEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .variables.create(opts);
@@ -152,7 +152,7 @@ describe('Variable', function() {
       var environmentSid = 'ZEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://serverless.twilio.com/v1/Services/${serviceSid}/Environments/${environmentSid}/Variables`;
 
-      var values = {Key: 'key', Value: 'value', };
+      var values = {'Key': 'key', 'Value': 'value', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -176,7 +176,7 @@ describe('Variable', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {key: 'key', value: 'value'};
+      var opts = {'key': 'key', 'value': 'value'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .environments('ZEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .variables.create(opts);

--- a/spec/integration/rest/serverless/v1/service/function.spec.js
+++ b/spec/integration/rest/serverless/v1/service/function.spec.js
@@ -171,7 +171,7 @@ describe('Function', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .functions.create(opts);
       promise.then(function() {
@@ -184,7 +184,7 @@ describe('Function', function() {
       var serviceSid = 'ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://serverless.twilio.com/v1/Services/${serviceSid}/Functions`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -209,7 +209,7 @@ describe('Function', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .functions.create(opts);
       promise.then(function(response) {
@@ -224,7 +224,7 @@ describe('Function', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .functions('ZHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -238,7 +238,7 @@ describe('Function', function() {
       var sid = 'ZHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://serverless.twilio.com/v1/Services/${serviceSid}/Functions/${sid}`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -263,7 +263,7 @@ describe('Function', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.serverless.v1.services('ZSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .functions('ZHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/studio/v1/flow/engagement.spec.js
+++ b/spec/integration/rest/studio/v1/flow/engagement.spec.js
@@ -136,7 +136,7 @@ describe('Engagement', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {to: '+15558675310', from: '+15017122661'};
+      var opts = {'to': '+15558675310', 'from': '+15017122661'};
       var promise = client.studio.v1.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .engagements.create(opts);
       promise.then(function() {
@@ -149,7 +149,7 @@ describe('Engagement', function() {
       var flowSid = 'FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://studio.twilio.com/v1/Flows/${flowSid}/Engagements`;
 
-      var values = {To: '+15558675310', From: '+15017122661', };
+      var values = {'To': '+15558675310', 'From': '+15017122661', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -178,7 +178,7 @@ describe('Engagement', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310', from: '+15017122661'};
+      var opts = {'to': '+15558675310', 'from': '+15017122661'};
       var promise = client.studio.v1.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .engagements.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/studio/v1/flow/execution.spec.js
+++ b/spec/integration/rest/studio/v1/flow/execution.spec.js
@@ -136,7 +136,7 @@ describe('Execution', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {to: '+15558675310', from: '+15017122661'};
+      var opts = {'to': '+15558675310', 'from': '+15017122661'};
       var promise = client.studio.v1.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .executions.create(opts);
       promise.then(function() {
@@ -149,7 +149,7 @@ describe('Execution', function() {
       var flowSid = 'FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://studio.twilio.com/v1/Flows/${flowSid}/Executions`;
 
-      var values = {To: '+15558675310', From: '+15017122661', };
+      var values = {'To': '+15558675310', 'From': '+15017122661', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -178,7 +178,7 @@ describe('Execution', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310', from: '+15017122661'};
+      var opts = {'to': '+15558675310', 'from': '+15017122661'};
       var promise = client.studio.v1.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .executions.create(opts);
       promise.then(function(response) {
@@ -232,7 +232,7 @@ describe('Execution', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {status: 'active'};
+      var opts = {'status': 'active'};
       var promise = client.studio.v1.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .executions('FNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -246,7 +246,7 @@ describe('Execution', function() {
       var sid = 'FNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://studio.twilio.com/v1/Flows/${flowSid}/Executions/${sid}`;
 
-      var values = {Status: 'active', };
+      var values = {'Status': 'active', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -275,7 +275,7 @@ describe('Execution', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'active'};
+      var opts = {'status': 'active'};
       var promise = client.studio.v1.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .executions('FNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/studio/v2/flow.spec.js
+++ b/spec/integration/rest/studio/v2/flow.spec.js
@@ -35,7 +35,7 @@ describe('Flow', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', status: 'draft', definition: {}};
+      var opts = {'friendlyName': 'friendly_name', 'status': 'draft', 'definition': {}};
       var promise = client.studio.v2.flows.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -46,7 +46,11 @@ describe('Flow', function() {
 
       var url = 'https://studio.twilio.com/v2/Flows';
 
-      var values = {FriendlyName: 'friendly_name', Status: 'draft', Definition: serialize.object({}), };
+      var values = {
+        'FriendlyName': 'friendly_name',
+        'Status': 'draft',
+        'Definition': serialize.object({}),
+      };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -82,7 +86,7 @@ describe('Flow', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', status: 'draft', definition: {}};
+      var opts = {'friendlyName': 'friendly_name', 'status': 'draft', 'definition': {}};
       var promise = client.studio.v2.flows.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -96,7 +100,7 @@ describe('Flow', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {status: 'draft'};
+      var opts = {'status': 'draft'};
       var promise = client.studio.v2.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -108,7 +112,7 @@ describe('Flow', function() {
       var sid = 'FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://studio.twilio.com/v2/Flows/${sid}`;
 
-      var values = {Status: 'draft', };
+      var values = {'Status': 'draft', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -144,7 +148,7 @@ describe('Flow', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'draft'};
+      var opts = {'status': 'draft'};
       var promise = client.studio.v2.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/studio/v2/flow/execution.spec.js
+++ b/spec/integration/rest/studio/v2/flow/execution.spec.js
@@ -135,7 +135,7 @@ describe('Execution', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {to: '+15558675310', from: '+15017122661'};
+      var opts = {'to': '+15558675310', 'from': '+15017122661'};
       var promise = client.studio.v2.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .executions.create(opts);
       promise.then(function() {
@@ -148,7 +148,7 @@ describe('Execution', function() {
       var flowSid = 'FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://studio.twilio.com/v2/Flows/${flowSid}/Executions`;
 
-      var values = {To: '+15558675310', From: '+15017122661', };
+      var values = {'To': '+15558675310', 'From': '+15017122661', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -176,7 +176,7 @@ describe('Execution', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: '+15558675310', from: '+15017122661'};
+      var opts = {'to': '+15558675310', 'from': '+15017122661'};
       var promise = client.studio.v2.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .executions.create(opts);
       promise.then(function(response) {
@@ -230,7 +230,7 @@ describe('Execution', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {status: 'active'};
+      var opts = {'status': 'active'};
       var promise = client.studio.v2.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .executions('FNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -244,7 +244,7 @@ describe('Execution', function() {
       var sid = 'FNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://studio.twilio.com/v2/Flows/${flowSid}/Executions/${sid}`;
 
-      var values = {Status: 'active', };
+      var values = {'Status': 'active', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -272,7 +272,7 @@ describe('Execution', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'active'};
+      var opts = {'status': 'active'};
       var promise = client.studio.v2.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .executions('FNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/studio/v2/flow/testUser.spec.js
+++ b/spec/integration/rest/studio/v2/flow/testUser.spec.js
@@ -80,7 +80,7 @@ describe('FlowTestUser', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {testUsers: ['test_users']};
+      var opts = {'testUsers': ['test_users']};
       var promise = client.studio.v2.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .testUsers().update(opts);
       promise.then(function() {
@@ -93,7 +93,7 @@ describe('FlowTestUser', function() {
       var sid = 'FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://studio.twilio.com/v2/Flows/${sid}/TestUsers`;
 
-      var values = {TestUsers: serialize.map(['test_users'], function(e) { return e; }), };
+      var values = {'TestUsers': serialize.map(['test_users'], function(e) { return e; }), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -114,7 +114,7 @@ describe('FlowTestUser', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {testUsers: ['test_users']};
+      var opts = {'testUsers': ['test_users']};
       var promise = client.studio.v2.flows('FWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .testUsers().update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/studio/v2/flowValidate.spec.js
+++ b/spec/integration/rest/studio/v2/flowValidate.spec.js
@@ -35,7 +35,7 @@ describe('FlowValidate', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', status: 'draft', definition: {}};
+      var opts = {'friendlyName': 'friendly_name', 'status': 'draft', 'definition': {}};
       var promise = client.studio.v2.flowValidate.update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -46,7 +46,11 @@ describe('FlowValidate', function() {
 
       var url = 'https://studio.twilio.com/v2/Flows/Validate';
 
-      var values = {FriendlyName: 'friendly_name', Status: 'draft', Definition: serialize.object({}), };
+      var values = {
+        'FriendlyName': 'friendly_name',
+        'Status': 'draft',
+        'Definition': serialize.object({}),
+      };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -62,7 +66,7 @@ describe('FlowValidate', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {friendlyName: 'friendly_name', status: 'draft', definition: {}};
+      var opts = {'friendlyName': 'friendly_name', 'status': 'draft', 'definition': {}};
       var promise = client.studio.v2.flowValidate.update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/supersim/v1/command.spec.js
+++ b/spec/integration/rest/supersim/v1/command.spec.js
@@ -33,7 +33,7 @@ describe('Command', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {sim: 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', command: 'command'};
+      var opts = {'sim': 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'command': 'command'};
       var promise = client.supersim.v1.commands.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('Command', function() {
 
       var url = 'https://supersim.twilio.com/v1/Commands';
 
-      var values = {Sim: 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', Command: 'command', };
+      var values = {'Sim': 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'Command': 'command', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -68,7 +68,7 @@ describe('Command', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {sim: 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', command: 'command'};
+      var opts = {'sim': 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'command': 'command'};
       var promise = client.supersim.v1.commands.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -94,7 +94,7 @@ describe('Command', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {sim: 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', command: 'command'};
+      var opts = {'sim': 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'command': 'command'};
       var promise = client.supersim.v1.commands.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/supersim/v1/esimProfile.spec.js
+++ b/spec/integration/rest/supersim/v1/esimProfile.spec.js
@@ -33,7 +33,7 @@ describe('EsimProfile', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {eid: 'eid'};
+      var opts = {'eid': 'eid'};
       var promise = client.supersim.v1.esimProfiles.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('EsimProfile', function() {
 
       var url = 'https://supersim.twilio.com/v1/ESimProfiles';
 
-      var values = {Eid: 'eid', };
+      var values = {'Eid': 'eid', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -71,7 +71,7 @@ describe('EsimProfile', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {eid: 'eid'};
+      var opts = {'eid': 'eid'};
       var promise = client.supersim.v1.esimProfiles.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -100,7 +100,7 @@ describe('EsimProfile', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {eid: 'eid'};
+      var opts = {'eid': 'eid'};
       var promise = client.supersim.v1.esimProfiles.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/supersim/v1/fleet.spec.js
+++ b/spec/integration/rest/supersim/v1/fleet.spec.js
@@ -33,7 +33,7 @@ describe('Fleet', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {networkAccessProfile: 'HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'networkAccessProfile': 'HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.supersim.v1.fleets.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('Fleet', function() {
 
       var url = 'https://supersim.twilio.com/v1/Fleets';
 
-      var values = {NetworkAccessProfile: 'HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'NetworkAccessProfile': 'HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -77,7 +77,7 @@ describe('Fleet', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {networkAccessProfile: 'HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'networkAccessProfile': 'HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.supersim.v1.fleets.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/supersim/v1/ipCommand.spec.js
+++ b/spec/integration/rest/supersim/v1/ipCommand.spec.js
@@ -33,7 +33,7 @@ describe('IpCommand', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {sim: 'sim', payload: 'payload', devicePort: 1};
+      var opts = {'sim': 'sim', 'payload': 'payload', 'devicePort': 1};
       var promise = client.supersim.v1.ipCommands.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('IpCommand', function() {
 
       var url = 'https://supersim.twilio.com/v1/IpCommands';
 
-      var values = {Sim: 'sim', Payload: 'payload', DevicePort: 1, };
+      var values = {'Sim': 'sim', 'Payload': 'payload', 'DevicePort': 1, };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -72,7 +72,7 @@ describe('IpCommand', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {sim: 'sim', payload: 'payload', devicePort: 1};
+      var opts = {'sim': 'sim', 'payload': 'payload', 'devicePort': 1};
       var promise = client.supersim.v1.ipCommands.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -102,7 +102,7 @@ describe('IpCommand', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {sim: 'sim', payload: 'payload', devicePort: 1};
+      var opts = {'sim': 'sim', 'payload': 'payload', 'devicePort': 1};
       var promise = client.supersim.v1.ipCommands.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/supersim/v1/networkAccessProfile/networkAccessProfileNetwork.spec.js
+++ b/spec/integration/rest/supersim/v1/networkAccessProfile/networkAccessProfileNetwork.spec.js
@@ -200,7 +200,7 @@ describe('NetworkAccessProfileNetwork', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {network: 'HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'network': 'HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.supersim.v1.networkAccessProfiles('HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .networks.create(opts);
       promise.then(function() {
@@ -213,7 +213,7 @@ describe('NetworkAccessProfileNetwork', function() {
       var networkAccessProfileSid = 'HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://supersim.twilio.com/v1/NetworkAccessProfiles/${networkAccessProfileSid}/Networks`;
 
-      var values = {Network: 'HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'Network': 'HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -239,7 +239,7 @@ describe('NetworkAccessProfileNetwork', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {network: 'HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'network': 'HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.supersim.v1.networkAccessProfiles('HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .networks.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/supersim/v1/sim.spec.js
+++ b/spec/integration/rest/supersim/v1/sim.spec.js
@@ -33,7 +33,7 @@ describe('Sim', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {iccid: 'iccid', registrationCode: 'registration_code'};
+      var opts = {'iccid': 'iccid', 'registrationCode': 'registration_code'};
       var promise = client.supersim.v1.sims.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('Sim', function() {
 
       var url = 'https://supersim.twilio.com/v1/Sims';
 
-      var values = {Iccid: 'iccid', RegistrationCode: 'registration_code', };
+      var values = {'Iccid': 'iccid', 'RegistrationCode': 'registration_code', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -71,7 +71,7 @@ describe('Sim', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {iccid: 'iccid', registrationCode: 'registration_code'};
+      var opts = {'iccid': 'iccid', 'registrationCode': 'registration_code'};
       var promise = client.supersim.v1.sims.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/supersim/v1/smsCommand.spec.js
+++ b/spec/integration/rest/supersim/v1/smsCommand.spec.js
@@ -33,7 +33,7 @@ describe('SmsCommand', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {sim: 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', payload: 'payload'};
+      var opts = {'sim': 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'payload': 'payload'};
       var promise = client.supersim.v1.smsCommands.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('SmsCommand', function() {
 
       var url = 'https://supersim.twilio.com/v1/SmsCommands';
 
-      var values = {Sim: 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', Payload: 'payload', };
+      var values = {'Sim': 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'Payload': 'payload', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -68,7 +68,7 @@ describe('SmsCommand', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {sim: 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', payload: 'payload'};
+      var opts = {'sim': 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'payload': 'payload'};
       var promise = client.supersim.v1.smsCommands.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -94,7 +94,7 @@ describe('SmsCommand', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {sim: 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', payload: 'payload'};
+      var opts = {'sim': 'HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', 'payload': 'payload'};
       var promise = client.supersim.v1.smsCommands.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/sync/v1/service/document.spec.js
+++ b/spec/integration/rest/sync/v1/service/document.spec.js
@@ -385,7 +385,7 @@ describe('Document', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .documents('ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {

--- a/spec/integration/rest/sync/v1/service/document/documentPermission.spec.js
+++ b/spec/integration/rest/sync/v1/service/document/documentPermission.spec.js
@@ -317,7 +317,7 @@ describe('DocumentPermission', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .documents('ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .documentPermissions('identity').update(opts);
@@ -334,9 +334,9 @@ describe('DocumentPermission', function() {
       var url = `https://sync.twilio.com/v1/Services/${serviceSid}/Documents/${documentSid}/Permissions/${identity}`;
 
       var values = {
-        Read: serialize.bool(true),
-        Write: serialize.bool(true),
-        Manage: serialize.bool(true),
+        'Read': serialize.bool(true),
+        'Write': serialize.bool(true),
+        'Manage': serialize.bool(true),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -360,7 +360,7 @@ describe('DocumentPermission', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .documents('ETXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .documentPermissions('identity').update(opts);

--- a/spec/integration/rest/sync/v1/service/syncList/syncListItem.spec.js
+++ b/spec/integration/rest/sync/v1/service/syncList/syncListItem.spec.js
@@ -89,7 +89,7 @@ describe('SyncListItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncListItems(1).remove(opts);
@@ -134,7 +134,7 @@ describe('SyncListItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {data: {}};
+      var opts = {'data': {}};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncListItems.create(opts);
@@ -149,7 +149,7 @@ describe('SyncListItem', function() {
       var listSid = 'ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://sync.twilio.com/v1/Services/${serviceSid}/Lists/${listSid}/Items`;
 
-      var values = {Data: serialize.object({}), };
+      var values = {'Data': serialize.object({}), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -175,7 +175,7 @@ describe('SyncListItem', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {data: {}};
+      var opts = {'data': {}};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncListItems.create(opts);
@@ -392,7 +392,7 @@ describe('SyncListItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncListItems(1).update(opts);

--- a/spec/integration/rest/sync/v1/service/syncList/syncListPermission.spec.js
+++ b/spec/integration/rest/sync/v1/service/syncList/syncListPermission.spec.js
@@ -317,7 +317,7 @@ describe('SyncListPermission', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncListPermissions('identity').update(opts);
@@ -334,9 +334,9 @@ describe('SyncListPermission', function() {
       var url = `https://sync.twilio.com/v1/Services/${serviceSid}/Lists/${listSid}/Permissions/${identity}`;
 
       var values = {
-        Read: serialize.bool(true),
-        Write: serialize.bool(true),
-        Manage: serialize.bool(true),
+        'Read': serialize.bool(true),
+        'Write': serialize.bool(true),
+        'Manage': serialize.bool(true),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -360,7 +360,7 @@ describe('SyncListPermission', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncLists('ESXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncListPermissions('identity').update(opts);

--- a/spec/integration/rest/sync/v1/service/syncMap/syncMapItem.spec.js
+++ b/spec/integration/rest/sync/v1/service/syncMap/syncMapItem.spec.js
@@ -89,7 +89,7 @@ describe('SyncMapItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMapItems('key').remove(opts);
@@ -134,7 +134,7 @@ describe('SyncMapItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {key: 'key', data: {}};
+      var opts = {'key': 'key', 'data': {}};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMapItems.create(opts);
@@ -149,7 +149,7 @@ describe('SyncMapItem', function() {
       var mapSid = 'MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://sync.twilio.com/v1/Services/${serviceSid}/Maps/${mapSid}/Items`;
 
-      var values = {Key: 'key', Data: serialize.object({}), };
+      var values = {'Key': 'key', 'Data': serialize.object({}), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -175,7 +175,7 @@ describe('SyncMapItem', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {key: 'key', data: {}};
+      var opts = {'key': 'key', 'data': {}};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMapItems.create(opts);
@@ -392,7 +392,7 @@ describe('SyncMapItem', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMapItems('key').update(opts);

--- a/spec/integration/rest/sync/v1/service/syncMap/syncMapPermission.spec.js
+++ b/spec/integration/rest/sync/v1/service/syncMap/syncMapPermission.spec.js
@@ -317,7 +317,7 @@ describe('SyncMapPermission', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMapPermissions('identity').update(opts);
@@ -334,9 +334,9 @@ describe('SyncMapPermission', function() {
       var url = `https://sync.twilio.com/v1/Services/${serviceSid}/Maps/${mapSid}/Permissions/${identity}`;
 
       var values = {
-        Read: serialize.bool(true),
-        Write: serialize.bool(true),
-        Manage: serialize.bool(true),
+        'Read': serialize.bool(true),
+        'Write': serialize.bool(true),
+        'Manage': serialize.bool(true),
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -360,7 +360,7 @@ describe('SyncMapPermission', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {read: true, write: true, manage: true};
+      var opts = {'read': true, 'write': true, 'manage': true};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMaps('MPXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncMapPermissions('identity').update(opts);

--- a/spec/integration/rest/sync/v1/service/syncStream/streamMessage.spec.js
+++ b/spec/integration/rest/sync/v1/service/syncStream/streamMessage.spec.js
@@ -35,7 +35,7 @@ describe('StreamMessage', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {data: {}};
+      var opts = {'data': {}};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncStreams('TOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .streamMessages.create(opts);
@@ -50,7 +50,7 @@ describe('StreamMessage', function() {
       var streamSid = 'TOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://sync.twilio.com/v1/Services/${serviceSid}/Streams/${streamSid}/Messages`;
 
-      var values = {Data: serialize.object({}), };
+      var values = {'Data': serialize.object({}), };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -67,7 +67,7 @@ describe('StreamMessage', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {data: {}};
+      var opts = {'data': {}};
       var promise = client.sync.v1.services('ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .syncStreams('TOXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                   .streamMessages.create(opts);

--- a/spec/integration/rest/taskrouter/v1/workspace.spec.js
+++ b/spec/integration/rest/taskrouter/v1/workspace.spec.js
@@ -406,7 +406,7 @@ describe('Workspace', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.taskrouter.v1.workspaces.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -417,7 +417,7 @@ describe('Workspace', function() {
 
       var url = 'https://taskrouter.twilio.com/v1/Workspaces';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -458,7 +458,7 @@ describe('Workspace', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.taskrouter.v1.workspaces.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/taskrouter/v1/workspace/activity.spec.js
+++ b/spec/integration/rest/taskrouter/v1/workspace/activity.spec.js
@@ -368,7 +368,7 @@ describe('Activity', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .activities.create(opts);
       promise.then(function() {
@@ -381,7 +381,7 @@ describe('Activity', function() {
       var workspaceSid = 'WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://taskrouter.twilio.com/v1/Workspaces/${workspaceSid}/Activities`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -407,7 +407,7 @@ describe('Activity', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .activities.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/taskrouter/v1/workspace/task.spec.js
+++ b/spec/integration/rest/taskrouter/v1/workspace/task.spec.js
@@ -99,7 +99,7 @@ describe('Task', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .tasks('WTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -168,7 +168,7 @@ describe('Task', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .tasks('WTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
       promise.then(function() {

--- a/spec/integration/rest/taskrouter/v1/workspace/task/reservation.spec.js
+++ b/spec/integration/rest/taskrouter/v1/workspace/task/reservation.spec.js
@@ -308,7 +308,7 @@ describe('Reservation', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .tasks('WTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .reservations('WRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/taskrouter/v1/workspace/taskChannel.spec.js
+++ b/spec/integration/rest/taskrouter/v1/workspace/taskChannel.spec.js
@@ -448,7 +448,7 @@ describe('TaskChannel', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', uniqueName: 'unique_name'};
+      var opts = {'friendlyName': 'friendly_name', 'uniqueName': 'unique_name'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .taskChannels.create(opts);
       promise.then(function() {
@@ -461,7 +461,7 @@ describe('TaskChannel', function() {
       var workspaceSid = 'WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://taskrouter.twilio.com/v1/Workspaces/${workspaceSid}/TaskChannels`;
 
-      var values = {FriendlyName: 'friendly_name', UniqueName: 'unique_name', };
+      var values = {'FriendlyName': 'friendly_name', 'UniqueName': 'unique_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -488,7 +488,7 @@ describe('TaskChannel', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', uniqueName: 'unique_name'};
+      var opts = {'friendlyName': 'friendly_name', 'uniqueName': 'unique_name'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .taskChannels.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/taskrouter/v1/workspace/taskQueue.spec.js
+++ b/spec/integration/rest/taskrouter/v1/workspace/taskQueue.spec.js
@@ -401,7 +401,7 @@ describe('TaskQueue', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .taskQueues.create(opts);
       promise.then(function() {
@@ -414,7 +414,7 @@ describe('TaskQueue', function() {
       var workspaceSid = 'WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://taskrouter.twilio.com/v1/Workspaces/${workspaceSid}/TaskQueues`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -452,7 +452,7 @@ describe('TaskQueue', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .taskQueues.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/taskrouter/v1/workspace/worker.spec.js
+++ b/spec/integration/rest/taskrouter/v1/workspace/worker.spec.js
@@ -275,7 +275,7 @@ describe('Worker', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .workers.create(opts);
       promise.then(function() {
@@ -288,7 +288,7 @@ describe('Worker', function() {
       var workspaceSid = 'WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://taskrouter.twilio.com/v1/Workspaces/${workspaceSid}/Workers`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -326,7 +326,7 @@ describe('Worker', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .workers.create(opts);
       promise.then(function(response) {
@@ -404,7 +404,7 @@ describe('Worker', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .workers('WKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
@@ -470,7 +470,7 @@ describe('Worker', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .workers('WKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').remove(opts);
       promise.then(function() {

--- a/spec/integration/rest/taskrouter/v1/workspace/worker/reservation.spec.js
+++ b/spec/integration/rest/taskrouter/v1/workspace/worker/reservation.spec.js
@@ -308,7 +308,7 @@ describe('Reservation', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ifMatch: 'if_match'};
+      var opts = {'ifMatch': 'if_match'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .workers('WKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .reservations('WRXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);

--- a/spec/integration/rest/taskrouter/v1/workspace/workflow.spec.js
+++ b/spec/integration/rest/taskrouter/v1/workspace/workflow.spec.js
@@ -404,7 +404,7 @@ describe('Workflow', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', configuration: 'configuration'};
+      var opts = {'friendlyName': 'friendly_name', 'configuration': 'configuration'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .workflows.create(opts);
       promise.then(function() {
@@ -417,7 +417,7 @@ describe('Workflow', function() {
       var workspaceSid = 'WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://taskrouter.twilio.com/v1/Workspaces/${workspaceSid}/Workflows`;
 
-      var values = {FriendlyName: 'friendly_name', Configuration: 'configuration', };
+      var values = {'FriendlyName': 'friendly_name', 'Configuration': 'configuration', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -449,7 +449,7 @@ describe('Workflow', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', configuration: 'configuration'};
+      var opts = {'friendlyName': 'friendly_name', 'configuration': 'configuration'};
       var promise = client.taskrouter.v1.workspaces('WSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                         .workflows.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/trunking/v1/trunk/credentialList.spec.js
+++ b/spec/integration/rest/trunking/v1/trunk/credentialList.spec.js
@@ -119,7 +119,7 @@ describe('CredentialList', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {credentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'credentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trunking.v1.trunks('TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .credentialsLists.create(opts);
       promise.then(function() {
@@ -132,7 +132,7 @@ describe('CredentialList', function() {
       var trunkSid = 'TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://trunking.twilio.com/v1/Trunks/${trunkSid}/CredentialLists`;
 
-      var values = {CredentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'CredentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -154,7 +154,7 @@ describe('CredentialList', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {credentialListSid: 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'credentialListSid': 'CLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trunking.v1.trunks('TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .credentialsLists.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/trunking/v1/trunk/ipAccessControlList.spec.js
+++ b/spec/integration/rest/trunking/v1/trunk/ipAccessControlList.spec.js
@@ -119,7 +119,7 @@ describe('IpAccessControlList', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ipAccessControlListSid: 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'ipAccessControlListSid': 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trunking.v1.trunks('TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .ipAccessControlLists.create(opts);
       promise.then(function() {
@@ -132,7 +132,7 @@ describe('IpAccessControlList', function() {
       var trunkSid = 'TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://trunking.twilio.com/v1/Trunks/${trunkSid}/IpAccessControlLists`;
 
-      var values = {IpAccessControlListSid: 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'IpAccessControlListSid': 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -154,7 +154,7 @@ describe('IpAccessControlList', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {ipAccessControlListSid: 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'ipAccessControlListSid': 'ALXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trunking.v1.trunks('TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .ipAccessControlLists.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/trunking/v1/trunk/originationUrl.spec.js
+++ b/spec/integration/rest/trunking/v1/trunk/originationUrl.spec.js
@@ -126,11 +126,11 @@ describe('OriginationUrl', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        weight: 1,
-        priority: 1,
-        enabled: true,
-        friendlyName: 'friendly_name',
-        sipUrl: 'https://example.com'
+        'weight': 1,
+        'priority': 1,
+        'enabled': true,
+        'friendlyName': 'friendly_name',
+        'sipUrl': 'https://example.com'
       };
       var promise = client.trunking.v1.trunks('TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .originationUrls.create(opts);
@@ -145,11 +145,11 @@ describe('OriginationUrl', function() {
       var url = `https://trunking.twilio.com/v1/Trunks/${trunkSid}/OriginationUrls`;
 
       var values = {
-        Weight: 1,
-        Priority: 1,
-        Enabled: serialize.bool(true),
-        FriendlyName: 'friendly_name',
-        SipUrl: 'https://example.com',
+        'Weight': 1,
+        'Priority': 1,
+        'Enabled': serialize.bool(true),
+        'FriendlyName': 'friendly_name',
+        'SipUrl': 'https://example.com',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -177,11 +177,11 @@ describe('OriginationUrl', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        weight: 1,
-        priority: 1,
-        enabled: true,
-        friendlyName: 'friendly_name',
-        sipUrl: 'https://example.com'
+        'weight': 1,
+        'priority': 1,
+        'enabled': true,
+        'friendlyName': 'friendly_name',
+        'sipUrl': 'https://example.com'
       };
       var promise = client.trunking.v1.trunks('TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .originationUrls.create(opts);

--- a/spec/integration/rest/trunking/v1/trunk/phoneNumber.spec.js
+++ b/spec/integration/rest/trunking/v1/trunk/phoneNumber.spec.js
@@ -144,7 +144,7 @@ describe('PhoneNumber', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {phoneNumberSid: 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'phoneNumberSid': 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trunking.v1.trunks('TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .phoneNumbers.create(opts);
       promise.then(function() {
@@ -157,7 +157,7 @@ describe('PhoneNumber', function() {
       var trunkSid = 'TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://trunking.twilio.com/v1/Trunks/${trunkSid}/PhoneNumbers`;
 
-      var values = {PhoneNumberSid: 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'PhoneNumberSid': 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -204,7 +204,7 @@ describe('PhoneNumber', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {phoneNumberSid: 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'phoneNumberSid': 'PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trunking.v1.trunks('TKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .phoneNumbers.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/trusthub/v1/customerProfiles.spec.js
+++ b/spec/integration/rest/trusthub/v1/customerProfiles.spec.js
@@ -34,9 +34,9 @@ describe('CustomerProfiles', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        friendlyName: 'friendly_name',
-        email: 'email',
-        policySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'friendlyName': 'friendly_name',
+        'email': 'email',
+        'policySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.trusthub.v1.customerProfiles.create(opts);
       promise.then(function() {
@@ -49,9 +49,9 @@ describe('CustomerProfiles', function() {
       var url = 'https://trusthub.twilio.com/v1/CustomerProfiles';
 
       var values = {
-        FriendlyName: 'friendly_name',
-        Email: 'email',
-        PolicySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'FriendlyName': 'friendly_name',
+        'Email': 'email',
+        'PolicySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -84,9 +84,9 @@ describe('CustomerProfiles', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        friendlyName: 'friendly_name',
-        email: 'email',
-        policySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'friendlyName': 'friendly_name',
+        'email': 'email',
+        'policySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.trusthub.v1.customerProfiles.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/trusthub/v1/customerProfiles/customerProfilesChannelEndpointAssignment.spec.js
+++ b/spec/integration/rest/trusthub/v1/customerProfiles/customerProfilesChannelEndpointAssignment.spec.js
@@ -34,8 +34,8 @@ describe('CustomerProfilesChannelEndpointAssignment', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        channelEndpointType: 'channel_endpoint_type',
-        channelEndpointSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'channelEndpointType': 'channel_endpoint_type',
+        'channelEndpointSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.trusthub.v1.customerProfiles('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .customerProfilesChannelEndpointAssignment.create(opts);
@@ -50,8 +50,8 @@ describe('CustomerProfilesChannelEndpointAssignment', function() {
       var url = `https://trusthub.twilio.com/v1/CustomerProfiles/${customerProfileSid}/ChannelEndpointAssignments`;
 
       var values = {
-        ChannelEndpointType: 'channel_endpoint_type',
-        ChannelEndpointSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'ChannelEndpointType': 'channel_endpoint_type',
+        'ChannelEndpointSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -75,8 +75,8 @@ describe('CustomerProfilesChannelEndpointAssignment', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        channelEndpointType: 'channel_endpoint_type',
-        channelEndpointSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'channelEndpointType': 'channel_endpoint_type',
+        'channelEndpointSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.trusthub.v1.customerProfiles('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .customerProfilesChannelEndpointAssignment.create(opts);

--- a/spec/integration/rest/trusthub/v1/customerProfiles/customerProfilesEntityAssignments.spec.js
+++ b/spec/integration/rest/trusthub/v1/customerProfiles/customerProfilesEntityAssignments.spec.js
@@ -33,7 +33,7 @@ describe('CustomerProfilesEntityAssignments', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {objectSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'objectSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trusthub.v1.customerProfiles('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .customerProfilesEntityAssignments.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('CustomerProfilesEntityAssignments', function() {
       var customerProfileSid = 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://trusthub.twilio.com/v1/CustomerProfiles/${customerProfileSid}/EntityAssignments`;
 
-      var values = {ObjectSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'ObjectSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -67,7 +67,7 @@ describe('CustomerProfilesEntityAssignments', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {objectSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'objectSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trusthub.v1.customerProfiles('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .customerProfilesEntityAssignments.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/trusthub/v1/customerProfiles/customerProfilesEvaluations.spec.js
+++ b/spec/integration/rest/trusthub/v1/customerProfiles/customerProfilesEvaluations.spec.js
@@ -33,7 +33,7 @@ describe('CustomerProfilesEvaluations', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {policySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'policySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trusthub.v1.customerProfiles('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .customerProfilesEvaluations.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('CustomerProfilesEvaluations', function() {
       var customerProfileSid = 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://trusthub.twilio.com/v1/CustomerProfiles/${customerProfileSid}/Evaluations`;
 
-      var values = {PolicySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'PolicySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -219,7 +219,7 @@ describe('CustomerProfilesEvaluations', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {policySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'policySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trusthub.v1.customerProfiles('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .customerProfilesEvaluations.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/trusthub/v1/endUser.spec.js
+++ b/spec/integration/rest/trusthub/v1/endUser.spec.js
@@ -33,7 +33,7 @@ describe('EndUser', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', type: 'type'};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'type'};
       var promise = client.trusthub.v1.endUsers.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('EndUser', function() {
 
       var url = 'https://trusthub.twilio.com/v1/EndUsers';
 
-      var values = {FriendlyName: 'friendly_name', Type: 'type', };
+      var values = {'FriendlyName': 'friendly_name', 'Type': 'type', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -74,7 +74,7 @@ describe('EndUser', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', type: 'type'};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'type'};
       var promise = client.trusthub.v1.endUsers.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/trusthub/v1/supportingDocument.spec.js
+++ b/spec/integration/rest/trusthub/v1/supportingDocument.spec.js
@@ -33,7 +33,7 @@ describe('SupportingDocument', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', type: 'type'};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'type'};
       var promise = client.trusthub.v1.supportingDocuments.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('SupportingDocument', function() {
 
       var url = 'https://trusthub.twilio.com/v1/SupportingDocuments';
 
-      var values = {FriendlyName: 'friendly_name', Type: 'type', };
+      var values = {'FriendlyName': 'friendly_name', 'Type': 'type', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -71,7 +71,7 @@ describe('SupportingDocument', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', type: 'type'};
+      var opts = {'friendlyName': 'friendly_name', 'type': 'type'};
       var promise = client.trusthub.v1.supportingDocuments.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/trusthub/v1/trustProducts.spec.js
+++ b/spec/integration/rest/trusthub/v1/trustProducts.spec.js
@@ -34,9 +34,9 @@ describe('TrustProducts', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        friendlyName: 'friendly_name',
-        email: 'email',
-        policySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'friendlyName': 'friendly_name',
+        'email': 'email',
+        'policySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.trusthub.v1.trustProducts.create(opts);
       promise.then(function() {
@@ -49,9 +49,9 @@ describe('TrustProducts', function() {
       var url = 'https://trusthub.twilio.com/v1/TrustProducts';
 
       var values = {
-        FriendlyName: 'friendly_name',
-        Email: 'email',
-        PolicySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'FriendlyName': 'friendly_name',
+        'Email': 'email',
+        'PolicySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -84,9 +84,9 @@ describe('TrustProducts', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        friendlyName: 'friendly_name',
-        email: 'email',
-        policySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'friendlyName': 'friendly_name',
+        'email': 'email',
+        'policySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.trusthub.v1.trustProducts.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/trusthub/v1/trustProducts/trustProductsChannelEndpointAssignment.spec.js
+++ b/spec/integration/rest/trusthub/v1/trustProducts/trustProductsChannelEndpointAssignment.spec.js
@@ -34,8 +34,8 @@ describe('TrustProductsChannelEndpointAssignment', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        channelEndpointType: 'channel_endpoint_type',
-        channelEndpointSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'channelEndpointType': 'channel_endpoint_type',
+        'channelEndpointSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.trusthub.v1.trustProducts('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .trustProductsChannelEndpointAssignment.create(opts);
@@ -50,8 +50,8 @@ describe('TrustProductsChannelEndpointAssignment', function() {
       var url = `https://trusthub.twilio.com/v1/TrustProducts/${trustProductSid}/ChannelEndpointAssignments`;
 
       var values = {
-        ChannelEndpointType: 'channel_endpoint_type',
-        ChannelEndpointSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'ChannelEndpointType': 'channel_endpoint_type',
+        'ChannelEndpointSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -75,8 +75,8 @@ describe('TrustProductsChannelEndpointAssignment', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        channelEndpointType: 'channel_endpoint_type',
-        channelEndpointSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'channelEndpointType': 'channel_endpoint_type',
+        'channelEndpointSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.trusthub.v1.trustProducts('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .trustProductsChannelEndpointAssignment.create(opts);

--- a/spec/integration/rest/trusthub/v1/trustProducts/trustProductsEntityAssignments.spec.js
+++ b/spec/integration/rest/trusthub/v1/trustProducts/trustProductsEntityAssignments.spec.js
@@ -33,7 +33,7 @@ describe('TrustProductsEntityAssignments', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {objectSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'objectSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trusthub.v1.trustProducts('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .trustProductsEntityAssignments.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('TrustProductsEntityAssignments', function() {
       var trustProductSid = 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://trusthub.twilio.com/v1/TrustProducts/${trustProductSid}/EntityAssignments`;
 
-      var values = {ObjectSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'ObjectSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -67,7 +67,7 @@ describe('TrustProductsEntityAssignments', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {objectSid: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'objectSid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trusthub.v1.trustProducts('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .trustProductsEntityAssignments.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/trusthub/v1/trustProducts/trustProductsEvaluations.spec.js
+++ b/spec/integration/rest/trusthub/v1/trustProducts/trustProductsEvaluations.spec.js
@@ -33,7 +33,7 @@ describe('TrustProductsEvaluations', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {policySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'policySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trusthub.v1.trustProducts('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .trustProductsEvaluations.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('TrustProductsEvaluations', function() {
       var trustProductSid = 'BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://trusthub.twilio.com/v1/TrustProducts/${trustProductSid}/Evaluations`;
 
-      var values = {PolicySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'PolicySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -219,7 +219,7 @@ describe('TrustProductsEvaluations', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {policySid: 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'policySid': 'RNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.trusthub.v1.trustProducts('BUXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                       .trustProductsEvaluations.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/verify/v2/service.spec.js
+++ b/spec/integration/rest/verify/v2/service.spec.js
@@ -33,7 +33,7 @@ describe('Service', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.verify.v2.services.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('Service', function() {
 
       var url = 'https://verify.twilio.com/v2/Services';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -95,7 +95,7 @@ describe('Service', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.verify.v2.services.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/verify/v2/service/accessToken.spec.js
+++ b/spec/integration/rest/verify/v2/service/accessToken.spec.js
@@ -33,7 +33,7 @@ describe('AccessToken', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity', factorType: 'push'};
+      var opts = {'identity': 'identity', 'factorType': 'push'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .accessTokens.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('AccessToken', function() {
       var serviceSid = 'VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/AccessTokens`;
 
-      var values = {Identity: 'identity', FactorType: 'push', };
+      var values = {'Identity': 'identity', 'FactorType': 'push', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -69,7 +69,7 @@ describe('AccessToken', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity', factorType: 'push'};
+      var opts = {'identity': 'identity', 'factorType': 'push'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .accessTokens.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/verify/v2/service/entity.spec.js
+++ b/spec/integration/rest/verify/v2/service/entity.spec.js
@@ -33,7 +33,7 @@ describe('Entity', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .entities.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('Entity', function() {
       var serviceSid = 'VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/Entities`;
 
-      var values = {Identity: 'identity', };
+      var values = {'Identity': 'identity', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -73,7 +73,7 @@ describe('Entity', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {identity: 'identity'};
+      var opts = {'identity': 'identity'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .entities.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/verify/v2/service/entity/challenge.spec.js
+++ b/spec/integration/rest/verify/v2/service/entity/challenge.spec.js
@@ -33,7 +33,7 @@ describe('Challenge', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {factorSid: 'YFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'factorSid': 'YFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .entities('identity')
                                     .challenges.create(opts);
@@ -48,7 +48,7 @@ describe('Challenge', function() {
       var identity = 'identity';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/Entities/${identity}/Challenges`;
 
-      var values = {FactorSid: 'YFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'FactorSid': 'YFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -93,7 +93,7 @@ describe('Challenge', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {factorSid: 'YFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'factorSid': 'YFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .entities('identity')
                                     .challenges.create(opts);
@@ -142,7 +142,7 @@ describe('Challenge', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {factorSid: 'YFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'factorSid': 'YFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .entities('identity')
                                     .challenges.create(opts);
@@ -191,7 +191,7 @@ describe('Challenge', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {factorSid: 'YFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'factorSid': 'YFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .entities('identity')
                                     .challenges.create(opts);

--- a/spec/integration/rest/verify/v2/service/entity/newFactor.spec.js
+++ b/spec/integration/rest/verify/v2/service/entity/newFactor.spec.js
@@ -33,7 +33,7 @@ describe('NewFactor', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', factorType: 'push'};
+      var opts = {'friendlyName': 'friendly_name', 'factorType': 'push'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .entities('identity')
                                     .newFactors.create(opts);
@@ -48,7 +48,7 @@ describe('NewFactor', function() {
       var identity = 'identity';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/Entities/${identity}/Factors`;
 
-      var values = {FriendlyName: 'friendly_name', FactorType: 'push', };
+      var values = {'FriendlyName': 'friendly_name', 'FactorType': 'push', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -84,7 +84,7 @@ describe('NewFactor', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', factorType: 'push'};
+      var opts = {'friendlyName': 'friendly_name', 'factorType': 'push'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .entities('identity')
                                     .newFactors.create(opts);
@@ -124,7 +124,7 @@ describe('NewFactor', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', factorType: 'push'};
+      var opts = {'friendlyName': 'friendly_name', 'factorType': 'push'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .entities('identity')
                                     .newFactors.create(opts);

--- a/spec/integration/rest/verify/v2/service/messagingConfiguration.spec.js
+++ b/spec/integration/rest/verify/v2/service/messagingConfiguration.spec.js
@@ -33,7 +33,7 @@ describe('MessagingConfiguration', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {country: 'country', messagingServiceSid: 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'country': 'country', 'messagingServiceSid': 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messagingConfigurations.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('MessagingConfiguration', function() {
       var serviceSid = 'VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/MessagingConfigurations`;
 
-      var values = {Country: 'country', MessagingServiceSid: 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'Country': 'country', 'MessagingServiceSid': 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -68,7 +68,7 @@ describe('MessagingConfiguration', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {country: 'country', messagingServiceSid: 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'country': 'country', 'messagingServiceSid': 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messagingConfigurations.create(opts);
       promise.then(function(response) {
@@ -83,7 +83,7 @@ describe('MessagingConfiguration', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {messagingServiceSid: 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'messagingServiceSid': 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messagingConfigurations('country').update(opts);
       promise.then(function() {
@@ -97,7 +97,7 @@ describe('MessagingConfiguration', function() {
       var country = 'country';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/MessagingConfigurations/${country}`;
 
-      var values = {MessagingServiceSid: 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'MessagingServiceSid': 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -119,7 +119,7 @@ describe('MessagingConfiguration', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {messagingServiceSid: 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'messagingServiceSid': 'MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .messagingConfigurations('country').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/verify/v2/service/rateLimit.spec.js
+++ b/spec/integration/rest/verify/v2/service/rateLimit.spec.js
@@ -33,7 +33,7 @@ describe('RateLimit', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .rateLimits.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('RateLimit', function() {
       var serviceSid = 'VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/RateLimits`;
 
-      var values = {UniqueName: 'unique_name', };
+      var values = {'UniqueName': 'unique_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -72,7 +72,7 @@ describe('RateLimit', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {uniqueName: 'unique_name'};
+      var opts = {'uniqueName': 'unique_name'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .rateLimits.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/verify/v2/service/rateLimit/bucket.spec.js
+++ b/spec/integration/rest/verify/v2/service/rateLimit/bucket.spec.js
@@ -33,7 +33,7 @@ describe('Bucket', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {max: 1, interval: 1};
+      var opts = {'max': 1, 'interval': 1};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .rateLimits('RKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .buckets.create(opts);
@@ -48,7 +48,7 @@ describe('Bucket', function() {
       var rateLimitSid = 'RKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/RateLimits/${rateLimitSid}/Buckets`;
 
-      var values = {Max: 1, Interval: 1, };
+      var values = {'Max': 1, 'Interval': 1, };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -72,7 +72,7 @@ describe('Bucket', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {max: 1, interval: 1};
+      var opts = {'max': 1, 'interval': 1};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .rateLimits('RKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .buckets.create(opts);

--- a/spec/integration/rest/verify/v2/service/verification.spec.js
+++ b/spec/integration/rest/verify/v2/service/verification.spec.js
@@ -33,7 +33,7 @@ describe('Verification', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {to: 'to', channel: 'channel'};
+      var opts = {'to': 'to', 'channel': 'channel'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verifications.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('Verification', function() {
       var serviceSid = 'VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/Verifications`;
 
-      var values = {To: 'to', Channel: 'channel', };
+      var values = {'To': 'to', 'Channel': 'channel', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -89,7 +89,7 @@ describe('Verification', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: 'to', channel: 'channel'};
+      var opts = {'to': 'to', 'channel': 'channel'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verifications.create(opts);
       promise.then(function(response) {
@@ -135,7 +135,7 @@ describe('Verification', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: 'to', channel: 'channel'};
+      var opts = {'to': 'to', 'channel': 'channel'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verifications.create(opts);
       promise.then(function(response) {
@@ -181,7 +181,7 @@ describe('Verification', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: 'to', channel: 'channel'};
+      var opts = {'to': 'to', 'channel': 'channel'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verifications.create(opts);
       promise.then(function(response) {
@@ -227,7 +227,7 @@ describe('Verification', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {to: 'to', channel: 'channel'};
+      var opts = {'to': 'to', 'channel': 'channel'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verifications.create(opts);
       promise.then(function(response) {
@@ -242,7 +242,7 @@ describe('Verification', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {status: 'canceled'};
+      var opts = {'status': 'canceled'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verifications('sid').update(opts);
       promise.then(function() {
@@ -256,7 +256,7 @@ describe('Verification', function() {
       var sid = 'sid';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/Verifications/${sid}`;
 
-      var values = {Status: 'canceled', };
+      var values = {'Status': 'canceled', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -299,7 +299,7 @@ describe('Verification', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'canceled'};
+      var opts = {'status': 'canceled'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verifications('sid').update(opts);
       promise.then(function(response) {
@@ -345,7 +345,7 @@ describe('Verification', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'canceled'};
+      var opts = {'status': 'canceled'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verifications('sid').update(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/verify/v2/service/verificationCheck.spec.js
+++ b/spec/integration/rest/verify/v2/service/verificationCheck.spec.js
@@ -33,7 +33,7 @@ describe('VerificationCheck', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {code: 'code'};
+      var opts = {'code': 'code'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verificationChecks.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('VerificationCheck', function() {
       var serviceSid = 'VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/VerificationCheck`;
 
-      var values = {Code: 'code', };
+      var values = {'Code': 'code', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -72,7 +72,7 @@ describe('VerificationCheck', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {code: 'code'};
+      var opts = {'code': 'code'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verificationChecks.create(opts);
       promise.then(function(response) {
@@ -101,7 +101,7 @@ describe('VerificationCheck', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {code: 'code'};
+      var opts = {'code': 'code'};
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .verificationChecks.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/verify/v2/service/webhook.spec.js
+++ b/spec/integration/rest/verify/v2/service/webhook.spec.js
@@ -35,7 +35,11 @@ describe('Webhook', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name', eventTypes: ['event_types'], webhookUrl: 'webhook_url'};
+      var opts = {
+        'friendlyName': 'friendly_name',
+        'eventTypes': ['event_types'],
+        'webhookUrl': 'webhook_url'
+      };
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .webhooks.create(opts);
       promise.then(function() {
@@ -49,9 +53,9 @@ describe('Webhook', function() {
       var url = `https://verify.twilio.com/v2/Services/${serviceSid}/Webhooks`;
 
       var values = {
-        FriendlyName: 'friendly_name',
-        EventTypes: serialize.map(['event_types'], function(e) { return e; }),
-        WebhookUrl: 'webhook_url',
+        'FriendlyName': 'friendly_name',
+        'EventTypes': serialize.map(['event_types'], function(e) { return e; }),
+        'WebhookUrl': 'webhook_url',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -82,7 +86,11 @@ describe('Webhook', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name', eventTypes: ['event_types'], webhookUrl: 'webhook_url'};
+      var opts = {
+        'friendlyName': 'friendly_name',
+        'eventTypes': ['event_types'],
+        'webhookUrl': 'webhook_url'
+      };
       var promise = client.verify.v2.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                     .webhooks.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/video/v1/composition.spec.js
+++ b/spec/integration/rest/video/v1/composition.spec.js
@@ -559,7 +559,7 @@ describe('Composition', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {roomSid: 'RMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'roomSid': 'RMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.video.v1.compositions.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -570,7 +570,7 @@ describe('Composition', function() {
 
       var url = 'https://video.twilio.com/v1/Compositions';
 
-      var values = {RoomSid: 'RMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'RoomSid': 'RMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -633,7 +633,7 @@ describe('Composition', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {roomSid: 'RMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'roomSid': 'RMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.video.v1.compositions.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/video/v1/compositionHook.spec.js
+++ b/spec/integration/rest/video/v1/compositionHook.spec.js
@@ -501,7 +501,7 @@ describe('CompositionHook', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.video.v1.compositionHooks.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -512,7 +512,7 @@ describe('CompositionHook', function() {
 
       var url = 'https://video.twilio.com/v1/CompositionHooks';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -568,7 +568,7 @@ describe('CompositionHook', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.video.v1.compositionHooks.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -582,7 +582,7 @@ describe('CompositionHook', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.video.v1.compositionHooks('HKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -594,7 +594,7 @@ describe('CompositionHook', function() {
       var sid = 'HKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://video.twilio.com/v1/CompositionHooks/${sid}`;
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -650,7 +650,7 @@ describe('CompositionHook', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.video.v1.compositionHooks('HKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -687,7 +687,7 @@ describe('CompositionHook', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.video.v1.compositionHooks('HKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/video/v1/compositionSettings.spec.js
+++ b/spec/integration/rest/video/v1/compositionSettings.spec.js
@@ -77,7 +77,7 @@ describe('CompositionSettings', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.video.v1.compositionSettings().create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -88,7 +88,7 @@ describe('CompositionSettings', function() {
 
       var url = 'https://video.twilio.com/v1/CompositionSettings/Default';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -111,7 +111,7 @@ describe('CompositionSettings', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.video.v1.compositionSettings().create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/video/v1/recordingSettings.spec.js
+++ b/spec/integration/rest/video/v1/recordingSettings.spec.js
@@ -77,7 +77,7 @@ describe('RecordingSettings', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.video.v1.recordingSettings().create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -88,7 +88,7 @@ describe('RecordingSettings', function() {
 
       var url = 'https://video.twilio.com/v1/RecordingSettings/Default';
 
-      var values = {FriendlyName: 'friendly_name', };
+      var values = {'FriendlyName': 'friendly_name', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -111,7 +111,7 @@ describe('RecordingSettings', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {friendlyName: 'friendly_name'};
+      var opts = {'friendlyName': 'friendly_name'};
       var promise = client.video.v1.recordingSettings().create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/video/v1/room.spec.js
+++ b/spec/integration/rest/video/v1/room.spec.js
@@ -689,7 +689,7 @@ describe('Room', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {status: 'in-progress'};
+      var opts = {'status': 'in-progress'};
       var promise = client.video.v1.rooms('RMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -701,7 +701,7 @@ describe('Room', function() {
       var sid = 'RMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://video.twilio.com/v1/Rooms/${sid}`;
 
-      var values = {Status: 'in-progress', };
+      var values = {'Status': 'in-progress', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -745,7 +745,7 @@ describe('Room', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {status: 'in-progress'};
+      var opts = {'status': 'in-progress'};
       var promise = client.video.v1.rooms('RMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/voice/v1/connectionPolicy/connectionPolicyTarget.spec.js
+++ b/spec/integration/rest/voice/v1/connectionPolicy/connectionPolicyTarget.spec.js
@@ -33,7 +33,7 @@ describe('ConnectionPolicyTarget', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {target: 'https://example.com'};
+      var opts = {'target': 'https://example.com'};
       var promise = client.voice.v1.connectionPolicies('NYXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                    .targets.create(opts);
       promise.then(function() {
@@ -46,7 +46,7 @@ describe('ConnectionPolicyTarget', function() {
       var connectionPolicySid = 'NYXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://voice.twilio.com/v1/ConnectionPolicies/${connectionPolicySid}/Targets`;
 
-      var values = {Target: 'https://example.com', };
+      var values = {'Target': 'https://example.com', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -72,7 +72,7 @@ describe('ConnectionPolicyTarget', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {target: 'https://example.com'};
+      var opts = {'target': 'https://example.com'};
       var promise = client.voice.v1.connectionPolicies('NYXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
                                    .targets.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/voice/v1/dialingPermissions/bulkCountryUpdate.spec.js
+++ b/spec/integration/rest/voice/v1/dialingPermissions/bulkCountryUpdate.spec.js
@@ -33,7 +33,7 @@ describe('BulkCountryUpdate', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {updateRequest: 'update_request'};
+      var opts = {'updateRequest': 'update_request'};
       var promise = client.voice.v1.dialingPermissions
                                    .bulkCountryUpdates.create(opts);
       promise.then(function() {
@@ -45,7 +45,7 @@ describe('BulkCountryUpdate', function() {
 
       var url = 'https://voice.twilio.com/v1/DialingPermissions/BulkCountryUpdates';
 
-      var values = {UpdateRequest: 'update_request', };
+      var values = {'UpdateRequest': 'update_request', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -62,7 +62,7 @@ describe('BulkCountryUpdate', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {updateRequest: 'update_request'};
+      var opts = {'updateRequest': 'update_request'};
       var promise = client.voice.v1.dialingPermissions
                                    .bulkCountryUpdates.create(opts);
       promise.then(function(response) {

--- a/spec/integration/rest/voice/v1/ipRecord.spec.js
+++ b/spec/integration/rest/voice/v1/ipRecord.spec.js
@@ -33,7 +33,7 @@ describe('IpRecord', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {ipAddress: 'ip_address'};
+      var opts = {'ipAddress': 'ip_address'};
       var promise = client.voice.v1.ipRecords.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -44,7 +44,7 @@ describe('IpRecord', function() {
 
       var url = 'https://voice.twilio.com/v1/IpRecords';
 
-      var values = {IpAddress: 'ip_address', };
+      var values = {'IpAddress': 'ip_address', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -67,7 +67,7 @@ describe('IpRecord', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {ipAddress: 'ip_address'};
+      var opts = {'ipAddress': 'ip_address'};
       var promise = client.voice.v1.ipRecords.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/voice/v1/sourceIpMapping.spec.js
+++ b/spec/integration/rest/voice/v1/sourceIpMapping.spec.js
@@ -34,8 +34,8 @@ describe('SourceIpMapping', function() {
       holodeck.mock(new Response(500, {}));
 
       var opts = {
-        ipRecordSid: 'ILXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        sipDomainSid: 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'ipRecordSid': 'ILXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'sipDomainSid': 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.voice.v1.sourceIpMappings.create(opts);
       promise.then(function() {
@@ -48,8 +48,8 @@ describe('SourceIpMapping', function() {
       var url = 'https://voice.twilio.com/v1/SourceIpMappings';
 
       var values = {
-        IpRecordSid: 'ILXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        SipDomainSid: 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'IpRecordSid': 'ILXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'SipDomainSid': 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
       };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
@@ -72,8 +72,8 @@ describe('SourceIpMapping', function() {
       holodeck.mock(new Response(201, body));
 
       var opts = {
-        ipRecordSid: 'ILXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-        sipDomainSid: 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+        'ipRecordSid': 'ILXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'sipDomainSid': 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
       };
       var promise = client.voice.v1.sourceIpMappings.create(opts);
       promise.then(function(response) {
@@ -298,7 +298,7 @@ describe('SourceIpMapping', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {sipDomainSid: 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'sipDomainSid': 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.voice.v1.sourceIpMappings('IBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -310,7 +310,7 @@ describe('SourceIpMapping', function() {
       var sid = 'IBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
       var url = `https://voice.twilio.com/v1/SourceIpMappings/${sid}`;
 
-      var values = {SipDomainSid: 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
+      var values = {'SipDomainSid': 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -331,7 +331,7 @@ describe('SourceIpMapping', function() {
 
       holodeck.mock(new Response(200, body));
 
-      var opts = {sipDomainSid: 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
+      var opts = {'sipDomainSid': 'SDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'};
       var promise = client.voice.v1.sourceIpMappings('IBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').update(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();

--- a/spec/integration/rest/wireless/v1/command.spec.js
+++ b/spec/integration/rest/wireless/v1/command.spec.js
@@ -342,7 +342,7 @@ describe('Command', function() {
     function(done) {
       holodeck.mock(new Response(500, {}));
 
-      var opts = {command: 'command'};
+      var opts = {'command': 'command'};
       var promise = client.wireless.v1.commands.create(opts);
       promise.then(function() {
         throw new Error('failed');
@@ -353,7 +353,7 @@ describe('Command', function() {
 
       var url = 'https://wireless.twilio.com/v1/Commands';
 
-      var values = {Command: 'command', };
+      var values = {'Command': 'command', };
       holodeck.assertHasRequest(new Request({
           method: 'POST',
           url: url,
@@ -380,7 +380,7 @@ describe('Command', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {command: 'command'};
+      var opts = {'command': 'command'};
       var promise = client.wireless.v1.commands.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();
@@ -409,7 +409,7 @@ describe('Command', function() {
 
       holodeck.mock(new Response(201, body));
 
-      var opts = {command: 'command'};
+      var opts = {'command': 'command'};
       var promise = client.wireless.v1.commands.create(opts);
       promise.then(function(response) {
         expect(response).toBeDefined();


### PR DESCRIPTION
Adds support for using names containing periods in required resource properties. Updates undefined checks for those required properties using bracket notation instead of dot notation to avoid the interpreter from attempting to reference nested object properties when encountering property names containing periods.

Changes:
- Undefined check statements for required resource properties (options) now use bracket notation over dot notation
- Updates integration tests to support property names containing periods by wrapping property names in quotes
- Disables jshint error recommending dot notation over bracket notation object property references

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
