### PR TITLE
fix:Add TS definition to allow parameter-less constructor call

### DIFF
--- a/lib/rest/Twilio.d.ts
+++ b/lib/rest/Twilio.d.ts
@@ -48,7 +48,12 @@ declare class Twilio {
    * @param opts - The options argument
    */
   constructor(username: string, password: string, opts?: Twilio.TwilioClientOptions);
-  constructor();
+  /**
+   * Twilio Client to interact with the Rest API
+   *
+   * @param opts - The options argument
+   */
+  constructor(opts?: Twilio.TwilioClientOptions);
 
   accounts: Accounts;
   addresses: (typeof Api.prototype.account.addresses);

--- a/lib/rest/Twilio.d.ts
+++ b/lib/rest/Twilio.d.ts
@@ -48,6 +48,7 @@ declare class Twilio {
    * @param opts - The options argument
    */
   constructor(username: string, password: string, opts?: Twilio.TwilioClientOptions);
+  constructor();
 
   accounts: Accounts;
   addresses: (typeof Api.prototype.account.addresses);


### PR DESCRIPTION
So far, the TS definition only allowed these constructor calls:
```
import { Twilio } from "twilio";
const client =  new Twilio(accountSid, authToken);
```
Now, the parameter can be omitted and retrieved from the environment variable:
```
import { Twilio } from "twilio";
const client =  new Twilio();
```

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works -> NA
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file -> NA
- [ ] I have added inline documentation to the code I modified -> NA

