### PR TITLE
fix: Using version instead of resourceVersion where applicable

### DIFF
--- a/lib/rest/events/v1/schema/version.d.ts
+++ b/lib/rest/events/v1/schema/version.d.ts
@@ -60,9 +60,9 @@ interface SchemaVersionListInstance {
   /**
    * Constructs a schema_version
    *
-   * @param resourceVersion - The version of the schema
+   * @param version - The version of the schema
    */
-  get(resourceVersion: string): SchemaVersionContext;
+  get(version: string): SchemaVersionContext;
   /**
    * Retrieve a single target page of SchemaVersionInstance records from the API.
    *

--- a/lib/rest/events/v1/schema/version.d.ts
+++ b/lib/rest/events/v1/schema/version.d.ts
@@ -60,9 +60,9 @@ interface SchemaVersionListInstance {
   /**
    * Constructs a schema_version
    *
-   * @param schemaVersion - The version of the schema
+   * @param resourceVersion - The version of the schema
    */
-  get(schemaVersion: string): SchemaVersionContext;
+  get(resourceVersion: string): SchemaVersionContext;
   /**
    * Retrieve a single target page of SchemaVersionInstance records from the API.
    *
@@ -198,8 +198,8 @@ interface SchemaVersionResource {
   date_created: Date;
   id: string;
   raw: string;
-  schema_version: number;
   url: string;
+  version: number;
 }
 
 interface SchemaVersionSolution {
@@ -216,9 +216,9 @@ declare class SchemaVersionContext {
    *
    * @param version - Version of the resource
    * @param id - The unique identifier of the schema.
-   * @param schemaVersion - The version of the schema
+   * @param resourceVersion - The version of the schema
    */
-  constructor(version: V1, id: string, schemaVersion: number);
+  constructor(version: V1, id: string, resourceVersion: number);
 
   /**
    * fetch a SchemaVersionInstance
@@ -243,9 +243,9 @@ declare class SchemaVersionInstance extends SerializableClass {
    * @param version - Version of the resource
    * @param payload - The instance payload
    * @param id - The unique identifier of the schema.
-   * @param schemaVersion - The version of the schema
+   * @param resourceVersion - The version of the schema
    */
-  constructor(version: V1, payload: SchemaVersionPayload, id: string, schemaVersion: number);
+  constructor(version: V1, payload: SchemaVersionPayload, id: string, resourceVersion: number);
 
   private _proxy: SchemaVersionContext;
   dateCreated: Date;
@@ -257,12 +257,12 @@ declare class SchemaVersionInstance extends SerializableClass {
   fetch(callback?: (error: Error | null, items: SchemaVersionInstance) => any): Promise<SchemaVersionInstance>;
   id: string;
   raw: string;
-  schemaVersion: number;
   /**
    * Provide a user-friendly representation
    */
   toJSON(): any;
   url: string;
+  version: number;
 }
 
 

--- a/lib/rest/events/v1/schema/version.js
+++ b/lib/rest/events/v1/schema/version.js
@@ -305,13 +305,13 @@ SchemaVersionList = function SchemaVersionList(version, id) {
    * @function get
    * @memberof Twilio.Events.V1.SchemaContext.SchemaVersionList#
    *
-   * @param {string} resourceVersion - The version of the schema
+   * @param {string} version - The version of the schema
    *
    * @returns {Twilio.Events.V1.SchemaContext.SchemaVersionContext}
    */
   /* jshint ignore:end */
-  SchemaVersionListInstance.get = function get(resourceVersion) {
-    return new SchemaVersionContext(this._version, this._solution.id, resourceVersion);
+  SchemaVersionListInstance.get = function get(version) {
+    return new SchemaVersionContext(this._version, this._solution.id, version);
   };
 
   /* jshint ignore:start */
@@ -446,11 +446,7 @@ Object.defineProperty(SchemaVersionInstance.prototype,
   '_proxy', {
     get: function() {
       if (!this._context) {
-        this._context = new SchemaVersionContext(
-          this._version,
-          this._solution.id,
-          this._solution.resourceVersion
-        );
+        this._context = new SchemaVersionContext(this._version, this._solution.id, this._solution.version);
       }
 
       return this._context;
@@ -518,7 +514,7 @@ SchemaVersionContext = function SchemaVersionContext(version, id,
   this._version = version;
 
   // Path Solution
-  this._solution = {id: id, resourceVersion: resourceVersion, };
+  this._solution = {id: id, version: resourceVersion, };
   this._uri = `/Schemas/${id}/Versions/${resourceVersion}`;
 };
 
@@ -543,7 +539,7 @@ SchemaVersionContext.prototype.fetch = function fetch(callback) {
       this._version,
       payload,
       this._solution.id,
-      this._solution.resourceVersion
+      this._solution.version
     ));
   }.bind(this));
 

--- a/lib/rest/events/v1/schema/version.js
+++ b/lib/rest/events/v1/schema/version.js
@@ -305,13 +305,13 @@ SchemaVersionList = function SchemaVersionList(version, id) {
    * @function get
    * @memberof Twilio.Events.V1.SchemaContext.SchemaVersionList#
    *
-   * @param {string} schemaVersion - The version of the schema
+   * @param {string} resourceVersion - The version of the schema
    *
    * @returns {Twilio.Events.V1.SchemaContext.SchemaVersionContext}
    */
   /* jshint ignore:end */
-  SchemaVersionListInstance.get = function get(schemaVersion) {
-    return new SchemaVersionContext(this._version, this._solution.id, schemaVersion);
+  SchemaVersionListInstance.get = function get(resourceVersion) {
+    return new SchemaVersionContext(this._version, this._solution.id, resourceVersion);
   };
 
   /* jshint ignore:start */
@@ -415,7 +415,7 @@ SchemaVersionPage.prototype[util.inspect.custom] = function inspect(depth,
  * @constructor Twilio.Events.V1.SchemaContext.SchemaVersionInstance
  *
  * @property {string} id - The unique identifier of the schema.
- * @property {number} schemaVersion - The version of this schema.
+ * @property {number} version - The version of this schema.
  * @property {Date} dateCreated - The date the schema version was created.
  * @property {string} url - The URL of this resource.
  * @property {string} raw - The raw
@@ -423,23 +423,23 @@ SchemaVersionPage.prototype[util.inspect.custom] = function inspect(depth,
  * @param {V1} version - Version of the resource
  * @param {SchemaVersionPayload} payload - The instance payload
  * @param {string} id - The unique identifier of the schema.
- * @param {integer} schemaVersion - The version of the schema
+ * @param {integer} resourceVersion - The version of the schema
  */
 /* jshint ignore:end */
 SchemaVersionInstance = function SchemaVersionInstance(version, payload, id,
-                                                        schemaVersion) {
+                                                        resourceVersion) {
   this._version = version;
 
   // Marshaled Properties
   this.id = payload.id; // jshint ignore:line
-  this.schemaVersion = deserialize.integer(payload.schema_version); // jshint ignore:line
+  this.version = deserialize.integer(payload.version); // jshint ignore:line
   this.dateCreated = deserialize.iso8601DateTime(payload.date_created); // jshint ignore:line
   this.url = payload.url; // jshint ignore:line
   this.raw = payload.raw; // jshint ignore:line
 
   // Context
   this._context = undefined;
-  this._solution = {id: id, schemaVersion: schemaVersion || this.schemaVersion, };
+  this._solution = {id: id, resourceVersion: resourceVersion || this.resourceVersion, };
 };
 
 Object.defineProperty(SchemaVersionInstance.prototype,
@@ -449,7 +449,7 @@ Object.defineProperty(SchemaVersionInstance.prototype,
         this._context = new SchemaVersionContext(
           this._version,
           this._solution.id,
-          this._solution.schemaVersion
+          this._solution.resourceVersion
         );
       }
 
@@ -510,16 +510,16 @@ SchemaVersionInstance.prototype[util.inspect.custom] = function inspect(depth,
  *
  * @param {V1} version - Version of the resource
  * @param {string} id - The unique identifier of the schema.
- * @param {integer} schemaVersion - The version of the schema
+ * @param {integer} resourceVersion - The version of the schema
  */
 /* jshint ignore:end */
-SchemaVersionContext = function SchemaVersionContext(version, id, schemaVersion)
-                                                      {
+SchemaVersionContext = function SchemaVersionContext(version, id,
+                                                      resourceVersion) {
   this._version = version;
 
   // Path Solution
-  this._solution = {id: id, schemaVersion: schemaVersion, };
-  this._uri = `/Schemas/${id}/Versions/${schemaVersion}`;
+  this._solution = {id: id, resourceVersion: resourceVersion, };
+  this._uri = `/Schemas/${id}/Versions/${resourceVersion}`;
 };
 
 /* jshint ignore:start */
@@ -543,7 +543,7 @@ SchemaVersionContext.prototype.fetch = function fetch(callback) {
       this._version,
       payload,
       this._solution.id,
-      this._solution.schemaVersion
+      this._solution.resourceVersion
     ));
   }.bind(this));
 

--- a/lib/rest/events/v1/schema/version.js
+++ b/lib/rest/events/v1/schema/version.js
@@ -439,7 +439,7 @@ SchemaVersionInstance = function SchemaVersionInstance(version, payload, id,
 
   // Context
   this._context = undefined;
-  this._solution = {id: id, resourceVersion: resourceVersion || this.resourceVersion, };
+  this._solution = {id: id, resourceVersion: resourceVersion || this.version, };
 };
 
 Object.defineProperty(SchemaVersionInstance.prototype,

--- a/spec/integration/rest/events/v1/schema/version.spec.js
+++ b/spec/integration/rest/events/v1/schema/version.spec.js
@@ -35,7 +35,7 @@ describe('SchemaVersion', function() {
           'schema_versions': [
               {
                   'id': 'Messaging.MessageStatus',
-                  'schema_version': 1,
+                  'version': 1,
                   'public': true,
                   'date_created': '2015-07-30T20:00:00Z',
                   'url': 'https://events.twilio.com/v1/Schemas/Messaging.MessageStatus/Versions/1',
@@ -43,7 +43,7 @@ describe('SchemaVersion', function() {
               },
               {
                   'id': 'Messaging.MessageStatus',
-                  'schema_version': 2,
+                  'version': 2,
                   'public': true,
                   'date_created': '2015-07-30T20:00:00Z',
                   'url': 'https://events.twilio.com/v1/Schemas/Messaging.MessageStatus/Versions/2',
@@ -71,7 +71,7 @@ describe('SchemaVersion', function() {
           'schema_versions': [
               {
                   'id': 'Messaging.MessageStatus',
-                  'schema_version': 1,
+                  'version': 1,
                   'public': true,
                   'date_created': '2015-07-30T20:00:00Z',
                   'url': 'https://events.twilio.com/v1/Schemas/Messaging.MessageStatus/Versions/1',
@@ -79,7 +79,7 @@ describe('SchemaVersion', function() {
               },
               {
                   'id': 'Messaging.MessageStatus',
-                  'schema_version': 2,
+                  'version': 2,
                   'public': true,
                   'date_created': '2015-07-30T20:00:00Z',
                   'url': 'https://events.twilio.com/v1/Schemas/Messaging.MessageStatus/Versions/2',
@@ -112,7 +112,7 @@ describe('SchemaVersion', function() {
           'schema_versions': [
               {
                   'id': 'Messaging.MessageStatus',
-                  'schema_version': 1,
+                  'version': 1,
                   'public': true,
                   'date_created': '2015-07-30T20:00:00Z',
                   'url': 'https://events.twilio.com/v1/Schemas/Messaging.MessageStatus/Versions/1',
@@ -120,7 +120,7 @@ describe('SchemaVersion', function() {
               },
               {
                   'id': 'Messaging.MessageStatus',
-                  'schema_version': 2,
+                  'version': 2,
                   'public': true,
                   'date_created': '2015-07-30T20:00:00Z',
                   'url': 'https://events.twilio.com/v1/Schemas/Messaging.MessageStatus/Versions/2',
@@ -197,7 +197,7 @@ describe('SchemaVersion', function() {
           'schema_versions': [
               {
                   'id': 'Messaging.MessageStatus',
-                  'schema_version': 1,
+                  'version': 1,
                   'public': true,
                   'date_created': '2015-07-30T20:00:00Z',
                   'url': 'https://events.twilio.com/v1/Schemas/Messaging.MessageStatus/Versions/1',
@@ -205,7 +205,7 @@ describe('SchemaVersion', function() {
               },
               {
                   'id': 'Messaging.MessageStatus',
-                  'schema_version': 2,
+                  'version': 2,
                   'public': true,
                   'date_created': '2015-07-30T20:00:00Z',
                   'url': 'https://events.twilio.com/v1/Schemas/Messaging.MessageStatus/Versions/2',
@@ -249,8 +249,8 @@ describe('SchemaVersion', function() {
       }).done();
 
       var id = 'id';
-      var schemaVersion = 1;
-      var url = `https://events.twilio.com/v1/Schemas/${id}/Versions/${schemaVersion}`;
+      var resourceVersion = 1;
+      var url = `https://events.twilio.com/v1/Schemas/${id}/Versions/${resourceVersion}`;
 
       holodeck.assertHasRequest(new Request({
         method: 'GET',
@@ -262,7 +262,7 @@ describe('SchemaVersion', function() {
     function(done) {
       var body = {
           'id': 'Messaging.MessageStatus',
-          'schema_version': 1,
+          'version': 1,
           'public': true,
           'date_created': '2015-07-30T20:00:00Z',
           'url': 'https://events.twilio.com/v1/Schemas/Messaging.MessageStatus/Versions/1',


### PR DESCRIPTION
Currently we use `schemaVersion` to refer to a path parameter used by the schema resources of the event streams api.

We want to call it `version' whenever possible and rename it to `resourceVersion` when there is a need in the constructor, i.e. when the high level `version` is already defined.

[Internal Reference](https://code.hq.twilio.com/twilio/yoyodyne/pull/528)

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
