### PR TITLE
docs!: a full stop  is added in one sentence in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ client.logLevel = 'debug';
 ```
 
 ## Using webhook validation
-See [example](examples/express.js) for a code sample for incoming Twilio request validation
+See [example](examples/express.js) for a code sample for incoming Twilio request validation.
 
 ## Handling Exceptions
 


### PR DESCRIPTION


# Fixes #762 

a full stop  is added in one sentence in README.md file

# Closes #762 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
