### PR TITLE
feat: add a timeout options to RequestClient that creates a custom https agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ npm test
 To run just one specific test file instead of the whole suite, provide a JavaScript regular expression that will match your spec file's name, like:
 
 ```bash
-npm run test -- -m .\*client.\*
+npm run test:javascript -- -m .\*client.\*
 ```
 
 [apidocs]: https://www.twilio.com/docs/api

--- a/lib/base/RequestClient.d.ts
+++ b/lib/base/RequestClient.d.ts
@@ -1,13 +1,15 @@
-import { HttpMethod } from '../interfaces';
-import Response = require('../http/response');
+import { HttpMethod } from "../interfaces";
+import Response = require("../http/response");
 
 declare class RequestClient {
-  constructor();
+  constructor(opts?: RequestClient.RequestClientOptions);
   /**
    * Make an HTTP request
    * @param opts The request options
    */
-  request<TData>(opts: RequestClient.RequestOptions<TData>): Promise<Response<TData>>;
+  request<TData>(
+    opts: RequestClient.RequestOptions<TData>
+  ): Promise<Response<TData>>;
 }
 
 declare namespace RequestClient {
@@ -52,6 +54,14 @@ declare namespace RequestClient {
      * Set to true to use the forever-agent
      */
     forever?: boolean;
+  }
+
+  export interface RequestClientOptions {
+    /**
+     * A timeout in milliseconds. This will be used as the HTTPS agent's socket
+     * timeout, and as the default request timeout.
+     */
+    timeout?: number;
   }
 
   export interface Headers {

--- a/lib/base/RequestClient.js
+++ b/lib/base/RequestClient.js
@@ -6,12 +6,42 @@ var fs = require('fs');
 var HttpsProxyAgent = require('https-proxy-agent');
 var Q = require('q');
 var qs = require('qs');
+var url = require('url');
+var https = require('https');
 var Response = require('../http/response');
 var Request = require('../http/request');
 
-axios.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';
+const DEFAULT_CONTENT_TYPE = 'application/x-www-form-urlencoded';
+const DEFAULT_TIMEOUT = 30000;
 
-var RequestClient = function () { };
+/**
+ * Make http request
+ * @param {object} opts - The options argument
+ * @param {string} opts.timeout - A custom timeout to use. This will be used as the socket timeout, and as the default request timeout.
+ */
+var RequestClient = function (opts) {
+  opts = opts || {};
+  this.defaultTimeout = opts.timeout || DEFAULT_TIMEOUT;
+
+  // construct an https agent
+  let agentOpts = {
+    timeout: this.defaultTimeout,
+  };
+
+  let agent;
+  if (process.env.HTTP_PROXY) {
+    // Note: if process.env.HTTP_PROXY is set, we're not able to apply the given
+    // socket timeout. See: https://github.com/TooTallNate/node-https-proxy-agent/pull/96
+    agent = new HttpsProxyAgent(process.env.HTTP_PROXY);
+  } else {
+    agent = new https.Agent(agentOpts);
+  }
+
+  // construct an axios instance
+  this.axios = axios.create();
+  this.axios.defaults.headers.post['Content-Type'] = DEFAULT_CONTENT_TYPE;
+  this.axios.defaults.httpsAgent = agent;
+};
 
 /**
  * Make http request
@@ -53,7 +83,7 @@ RequestClient.prototype.request = function (opts) {
   }
 
   var options = {
-    timeout: opts.timeout || 30000,
+    timeout: opts.timeout || this.defaultTimeout,
     maxRedirects: opts.allowRedirects ? 10 : 0, // Same number of allowed redirects as request module default
     url: opts.uri,
     method: opts.method,
@@ -99,7 +129,7 @@ RequestClient.prototype.request = function (opts) {
   this.lastResponse = undefined;
   this.lastRequest = new Request(optionsRequest);
 
-  axios(options).then((response) => {
+  this.axios(options).then((response) => {
     if (opts.logLevel === 'debug') {
       console.log(`response.statusCode: ${response.status}`)
       console.log(`response.headers: ${JSON.stringify(response.headers)}`)
@@ -122,7 +152,7 @@ RequestClient.prototype.filterLoggingHeaders = function (headers){
   return Object.keys(headers).filter((header) => {
     return !'authorization'.includes(header.toLowerCase());
   });
-}
+};
 
 RequestClient.prototype.logRequest = function (options){
   console.log('-- BEGIN Twilio API Request --');
@@ -140,6 +170,6 @@ RequestClient.prototype.logRequest = function (options){
   }
 
   console.log('-- END Twilio API Request --');
-}
+};
 
 module.exports = RequestClient;

--- a/lib/base/RequestClient.js
+++ b/lib/base/RequestClient.js
@@ -88,7 +88,6 @@ RequestClient.prototype.request = function (opts) {
     url: opts.uri,
     method: opts.method,
     headers: opts.headers,
-    httpsAgent: process.env.HTTP_PROXY ? new HttpsProxyAgent(process.env.HTTP_PROXY) : undefined,
     proxy: false,
     validateStatus: status => status >= 100 && status < 600,
   };


### PR DESCRIPTION
# Fixes #

This PR improves handling of timeouts and axios options in RequestClient. It:
- Accepts a new `timeout` option to the RequestClient constructor
- Constructs a custom https Agent with the timeout applied. This ensures that timeouts are applied both at the socket level, and at the request/response level. See: https://github.com/axios/axios/issues/1739
- Moves construction of the HttpsProxyAgent to the constructor to avoid creating a new agent for each request
- Creates an axios instance rather than mutating axios defaults

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
