### PR TITLE
misc: remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "dayjs": "^1.8.29",
     "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "^8.5.1",
-    "q": "2.0.x",
     "qs": "^6.9.4",
-    "rootpath": "^0.1.2",
     "scmp": "^2.1.0",
     "url-parse": "^1.5.9",
     "xmlbuilder": "^13.0.2"


### PR DESCRIPTION
Removes `q` as a saved dependency as all handcrafted and auto-generated code now no longer uses it in-favor of native promises. Removes unused `rootpath` dependency.