### PR TITLE
fix: properly generate response models when there are no instance operations

### DIFF
--- a/lib/rest/api/v2010/account/address/dependentPhoneNumber.ts
+++ b/lib/rest/api/v2010/account/address/dependentPhoneNumber.ts
@@ -19,106 +19,13 @@ import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
 
-export class ApiV2010AccountAddressDependentPhoneNumber {
-  /**
-   * The unique string that identifies the resource
-   */
-  "sid"?: string | null;
-  /**
-   * The SID of the Account that created the resource
-   */
-  "accountSid"?: string | null;
-  /**
-   * The string that you assigned to describe the resource
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The URL we call when the phone number receives a call
-   */
-  "voiceUrl"?: string | null;
-  /**
-   * The HTTP method used with the voice_url
-   */
-  "voiceMethod"?: ApiV2010AccountAddressDependentPhoneNumber.VoiceMethodEnum;
-  /**
-   * The HTTP method used with voice_fallback_url
-   */
-  "voiceFallbackMethod"?: ApiV2010AccountAddressDependentPhoneNumber.VoiceFallbackMethodEnum;
-  /**
-   * The URL we call when an error occurs in TwiML
-   */
-  "voiceFallbackUrl"?: string | null;
-  /**
-   * Whether to lookup the caller\'s name
-   */
-  "voiceCallerIdLookup"?: boolean | null;
-  /**
-   * The RFC 2822 date and time in GMT that the resource was created
-   */
-  "dateCreated"?: string | null;
-  /**
-   * The RFC 2822 date and time in GMT that the resource was last updated
-   */
-  "dateUpdated"?: string | null;
-  /**
-   * The HTTP method used with sms_fallback_url
-   */
-  "smsFallbackMethod"?: ApiV2010AccountAddressDependentPhoneNumber.SmsFallbackMethodEnum;
-  /**
-   * The URL that we call when an error occurs while retrieving or executing the TwiML
-   */
-  "smsFallbackUrl"?: string | null;
-  /**
-   * The HTTP method to use with sms_url
-   */
-  "smsMethod"?: ApiV2010AccountAddressDependentPhoneNumber.SmsMethodEnum;
-  /**
-   * The URL we call when the phone number receives an incoming SMS message
-   */
-  "smsUrl"?: string | null;
-  "addressRequirements"?: DependentPhoneNumberEnumAddressRequirement;
-  /**
-   * Indicate if a phone can receive calls or messages
-   */
-  "capabilities"?: any | null;
-  /**
-   * The URL to send status information to your application
-   */
-  "statusCallback"?: string | null;
-  /**
-   * The HTTP method we use to call status_callback
-   */
-  "statusCallbackMethod"?: ApiV2010AccountAddressDependentPhoneNumber.StatusCallbackMethodEnum;
-  /**
-   * The API version used to start a new TwiML session
-   */
-  "apiVersion"?: string | null;
-  /**
-   * The SID of the application that handles SMS messages sent to the phone number
-   */
-  "smsApplicationSid"?: string | null;
-  /**
-   * The SID of the application that handles calls to the phone number
-   */
-  "voiceApplicationSid"?: string | null;
-  /**
-   * The SID of the Trunk that handles calls to the phone number
-   */
-  "trunkSid"?: string | null;
-  "emergencyStatus"?: DependentPhoneNumberEnumEmergencyStatus;
-  /**
-   * The emergency address configuration to use for emergency calling
-   */
-  "emergencyAddressSid"?: string | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-}
+type DependentPhoneNumberAddressRequirement =
+  | "none"
+  | "any"
+  | "local"
+  | "foreign";
+
+type DependentPhoneNumberEmergencyStatus = "Active" | "Inactive";
 
 /**
  * Options to pass to each
@@ -412,21 +319,73 @@ export function DependentPhoneNumberListInstance(
 
   return instance;
 }
+export type DependentPhoneNumberVoiceMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type DependentPhoneNumberVoiceFallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type DependentPhoneNumberSmsFallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type DependentPhoneNumberSmsMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type DependentPhoneNumberStatusCallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
 
 interface DependentPhoneNumberPayload
   extends DependentPhoneNumberResource,
     Page.TwilioResponsePayload {}
 
 interface DependentPhoneNumberResource {
-  dependent_phone_numbers?: Array<ApiV2010AccountAddressDependentPhoneNumber>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  sid?: string | null;
+  account_sid?: string | null;
+  friendly_name?: string | null;
+  phone_number?: string | null;
+  voice_url?: string | null;
+  voice_method?: DependentPhoneNumberVoiceMethod;
+  voice_fallback_method?: DependentPhoneNumberVoiceFallbackMethod;
+  voice_fallback_url?: string | null;
+  voice_caller_id_lookup?: boolean | null;
+  date_created?: string | null;
+  date_updated?: string | null;
+  sms_fallback_method?: DependentPhoneNumberSmsFallbackMethod;
+  sms_fallback_url?: string | null;
+  sms_method?: DependentPhoneNumberSmsMethod;
+  sms_url?: string | null;
+  address_requirements?: DependentPhoneNumberAddressRequirement;
+  capabilities?: any | null;
+  status_callback?: string | null;
+  status_callback_method?: DependentPhoneNumberStatusCallbackMethod;
+  api_version?: string | null;
+  sms_application_sid?: string | null;
+  voice_application_sid?: string | null;
+  trunk_sid?: string | null;
+  emergency_status?: DependentPhoneNumberEmergencyStatus;
+  emergency_address_sid?: string | null;
+  uri?: string | null;
 }
 
 export class DependentPhoneNumberInstance {
@@ -436,26 +395,132 @@ export class DependentPhoneNumberInstance {
     accountSid: string,
     addressSid?: string
   ) {
-    this.dependentPhoneNumbers = payload.dependent_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.sid = payload.sid;
+    this.accountSid = payload.account_sid;
+    this.friendlyName = payload.friendly_name;
+    this.phoneNumber = payload.phone_number;
+    this.voiceUrl = payload.voice_url;
+    this.voiceMethod = payload.voice_method;
+    this.voiceFallbackMethod = payload.voice_fallback_method;
+    this.voiceFallbackUrl = payload.voice_fallback_url;
+    this.voiceCallerIdLookup = payload.voice_caller_id_lookup;
+    this.dateCreated = deserialize.rfc2822DateTime(payload.date_created);
+    this.dateUpdated = deserialize.rfc2822DateTime(payload.date_updated);
+    this.smsFallbackMethod = payload.sms_fallback_method;
+    this.smsFallbackUrl = payload.sms_fallback_url;
+    this.smsMethod = payload.sms_method;
+    this.smsUrl = payload.sms_url;
+    this.addressRequirements = payload.address_requirements;
+    this.capabilities = payload.capabilities;
+    this.statusCallback = payload.status_callback;
+    this.statusCallbackMethod = payload.status_callback_method;
+    this.apiVersion = payload.api_version;
+    this.smsApplicationSid = payload.sms_application_sid;
+    this.voiceApplicationSid = payload.voice_application_sid;
+    this.trunkSid = payload.trunk_sid;
+    this.emergencyStatus = payload.emergency_status;
+    this.emergencyAddressSid = payload.emergency_address_sid;
     this.uri = payload.uri;
   }
 
-  dependentPhoneNumbers?: Array<ApiV2010AccountAddressDependentPhoneNumber>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The unique string that identifies the resource
+   */
+  sid?: string | null;
+  /**
+   * The SID of the Account that created the resource
+   */
+  accountSid?: string | null;
+  /**
+   * The string that you assigned to describe the resource
+   */
+  friendlyName?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The URL we call when the phone number receives a call
+   */
+  voiceUrl?: string | null;
+  /**
+   * The HTTP method used with the voice_url
+   */
+  voiceMethod?: DependentPhoneNumberVoiceMethod;
+  /**
+   * The HTTP method used with voice_fallback_url
+   */
+  voiceFallbackMethod?: DependentPhoneNumberVoiceFallbackMethod;
+  /**
+   * The URL we call when an error occurs in TwiML
+   */
+  voiceFallbackUrl?: string | null;
+  /**
+   * Whether to lookup the caller\'s name
+   */
+  voiceCallerIdLookup?: boolean | null;
+  /**
+   * The RFC 2822 date and time in GMT that the resource was created
+   */
+  dateCreated?: string | null;
+  /**
+   * The RFC 2822 date and time in GMT that the resource was last updated
+   */
+  dateUpdated?: string | null;
+  /**
+   * The HTTP method used with sms_fallback_url
+   */
+  smsFallbackMethod?: DependentPhoneNumberSmsFallbackMethod;
+  /**
+   * The URL that we call when an error occurs while retrieving or executing the TwiML
+   */
+  smsFallbackUrl?: string | null;
+  /**
+   * The HTTP method to use with sms_url
+   */
+  smsMethod?: DependentPhoneNumberSmsMethod;
+  /**
+   * The URL we call when the phone number receives an incoming SMS message
+   */
+  smsUrl?: string | null;
+  addressRequirements?: DependentPhoneNumberAddressRequirement;
+  /**
+   * Indicate if a phone can receive calls or messages
+   */
+  capabilities?: any | null;
+  /**
+   * The URL to send status information to your application
+   */
+  statusCallback?: string | null;
+  /**
+   * The HTTP method we use to call status_callback
+   */
+  statusCallbackMethod?: DependentPhoneNumberStatusCallbackMethod;
+  /**
+   * The API version used to start a new TwiML session
+   */
+  apiVersion?: string | null;
+  /**
+   * The SID of the application that handles SMS messages sent to the phone number
+   */
+  smsApplicationSid?: string | null;
+  /**
+   * The SID of the application that handles calls to the phone number
+   */
+  voiceApplicationSid?: string | null;
+  /**
+   * The SID of the Trunk that handles calls to the phone number
+   */
+  trunkSid?: string | null;
+  emergencyStatus?: DependentPhoneNumberEmergencyStatus;
+  /**
+   * The emergency address configuration to use for emergency calling
+   */
+  emergencyAddressSid?: string | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -464,14 +529,31 @@ export class DependentPhoneNumberInstance {
    */
   toJSON() {
     return {
-      dependentPhoneNumbers: this.dependentPhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      sid: this.sid,
+      accountSid: this.accountSid,
+      friendlyName: this.friendlyName,
+      phoneNumber: this.phoneNumber,
+      voiceUrl: this.voiceUrl,
+      voiceMethod: this.voiceMethod,
+      voiceFallbackMethod: this.voiceFallbackMethod,
+      voiceFallbackUrl: this.voiceFallbackUrl,
+      voiceCallerIdLookup: this.voiceCallerIdLookup,
+      dateCreated: this.dateCreated,
+      dateUpdated: this.dateUpdated,
+      smsFallbackMethod: this.smsFallbackMethod,
+      smsFallbackUrl: this.smsFallbackUrl,
+      smsMethod: this.smsMethod,
+      smsUrl: this.smsUrl,
+      addressRequirements: this.addressRequirements,
+      capabilities: this.capabilities,
+      statusCallback: this.statusCallback,
+      statusCallbackMethod: this.statusCallbackMethod,
+      apiVersion: this.apiVersion,
+      smsApplicationSid: this.smsApplicationSid,
+      voiceApplicationSid: this.voiceApplicationSid,
+      trunkSid: this.trunkSid,
+      emergencyStatus: this.emergencyStatus,
+      emergencyAddressSid: this.emergencyAddressSid,
       uri: this.uri,
     };
   }

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/local.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/local.ts
@@ -18,58 +18,7 @@ import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
-
-export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocal {
-  /**
-   * A formatted version of the phone number
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The LATA of this phone number
-   */
-  "lata"?: string | null;
-  /**
-   * The locality or city of this phone number\'s location
-   */
-  "locality"?: string | null;
-  /**
-   * The rate center of this phone number
-   */
-  "rateCenter"?: string | null;
-  /**
-   * The latitude of this phone number\'s location
-   */
-  "latitude"?: number | null;
-  /**
-   * The longitude of this phone number\'s location
-   */
-  "longitude"?: number | null;
-  /**
-   * The two-letter state or province abbreviation of this phone number\'s location
-   */
-  "region"?: string | null;
-  /**
-   * The postal or ZIP code of this phone number\'s location
-   */
-  "postalCode"?: string | null;
-  /**
-   * The ISO country code of this phone number
-   */
-  "isoCountry"?: string | null;
-  /**
-   * The type of Address resource the phone number requires
-   */
-  "addressRequirements"?: string | null;
-  /**
-   * Whether the phone number is new to the Twilio platform
-   */
-  "beta"?: boolean | null;
-  "capabilities"?: ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocalCapabilities | null;
-}
+import { PhoneNumberCapabilities } from "../../../../../interfaces";
 
 /**
  * Whether a phone number can receive calls or messages
@@ -502,15 +451,19 @@ export function LocalListInstance(
 interface LocalPayload extends LocalResource, Page.TwilioResponsePayload {}
 
 interface LocalResource {
-  available_phone_numbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocal>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  friendly_name?: string | null;
+  phone_number?: string | null;
+  lata?: string | null;
+  locality?: string | null;
+  rate_center?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  region?: string | null;
+  postal_code?: string | null;
+  iso_country?: string | null;
+  address_requirements?: string | null;
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 }
 
 export class LocalInstance {
@@ -520,26 +473,70 @@ export class LocalInstance {
     accountSid: string,
     countryCode?: string
   ) {
-    this.availablePhoneNumbers = payload.available_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
-    this.uri = payload.uri;
+    this.friendlyName = payload.friendly_name;
+    this.phoneNumber = payload.phone_number;
+    this.lata = payload.lata;
+    this.locality = payload.locality;
+    this.rateCenter = payload.rate_center;
+    this.latitude = payload.latitude;
+    this.longitude = payload.longitude;
+    this.region = payload.region;
+    this.postalCode = payload.postal_code;
+    this.isoCountry = payload.iso_country;
+    this.addressRequirements = payload.address_requirements;
+    this.beta = payload.beta;
+    this.capabilities = payload.capabilities;
   }
 
-  availablePhoneNumbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocal>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * A formatted version of the phone number
+   */
+  friendlyName?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The LATA of this phone number
+   */
+  lata?: string | null;
+  /**
+   * The locality or city of this phone number\'s location
+   */
+  locality?: string | null;
+  /**
+   * The rate center of this phone number
+   */
+  rateCenter?: string | null;
+  /**
+   * The latitude of this phone number\'s location
+   */
+  latitude?: number | null;
+  /**
+   * The longitude of this phone number\'s location
+   */
+  longitude?: number | null;
+  /**
+   * The two-letter state or province abbreviation of this phone number\'s location
+   */
+  region?: string | null;
+  /**
+   * The postal or ZIP code of this phone number\'s location
+   */
+  postalCode?: string | null;
+  /**
+   * The ISO country code of this phone number
+   */
+  isoCountry?: string | null;
+  /**
+   * The type of Address resource the phone number requires
+   */
+  addressRequirements?: string | null;
+  /**
+   * Whether the phone number is new to the Twilio platform
+   */
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 
   /**
    * Provide a user-friendly representation
@@ -548,15 +545,19 @@ export class LocalInstance {
    */
   toJSON() {
     return {
-      availablePhoneNumbers: this.availablePhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
-      uri: this.uri,
+      friendlyName: this.friendlyName,
+      phoneNumber: this.phoneNumber,
+      lata: this.lata,
+      locality: this.locality,
+      rateCenter: this.rateCenter,
+      latitude: this.latitude,
+      longitude: this.longitude,
+      region: this.region,
+      postalCode: this.postalCode,
+      isoCountry: this.isoCountry,
+      addressRequirements: this.addressRequirements,
+      beta: this.beta,
+      capabilities: this.capabilities,
     };
   }
 

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/machineToMachine.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/machineToMachine.ts
@@ -18,6 +18,7 @@ import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
+import { PhoneNumberCapabilities } from "../../../../../interfaces";
 
 /**
  * Whether a phone number can receive calls or messages
@@ -27,58 +28,6 @@ export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocal
   "sms"?: boolean;
   "voice"?: boolean;
   "fax"?: boolean;
-}
-
-export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberMachineToMachine {
-  /**
-   * A formatted version of the phone number
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The LATA of this phone number
-   */
-  "lata"?: string | null;
-  /**
-   * The locality or city of this phone number\'s location
-   */
-  "locality"?: string | null;
-  /**
-   * The rate center of this phone number
-   */
-  "rateCenter"?: string | null;
-  /**
-   * The latitude of this phone number\'s location
-   */
-  "latitude"?: number | null;
-  /**
-   * The longitude of this phone number\'s location
-   */
-  "longitude"?: number | null;
-  /**
-   * The two-letter state or province abbreviation of this phone number\'s location
-   */
-  "region"?: string | null;
-  /**
-   * The postal or ZIP code of this phone number\'s location
-   */
-  "postalCode"?: string | null;
-  /**
-   * The ISO country code of this phone number
-   */
-  "isoCountry"?: string | null;
-  /**
-   * The type of Address resource the phone number requires
-   */
-  "addressRequirements"?: string | null;
-  /**
-   * Whether the phone number is new to the Twilio platform
-   */
-  "beta"?: boolean | null;
-  "capabilities"?: ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocalCapabilities | null;
 }
 
 /**
@@ -516,15 +465,19 @@ interface MachineToMachinePayload
     Page.TwilioResponsePayload {}
 
 interface MachineToMachineResource {
-  available_phone_numbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberMachineToMachine>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  friendly_name?: string | null;
+  phone_number?: string | null;
+  lata?: string | null;
+  locality?: string | null;
+  rate_center?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  region?: string | null;
+  postal_code?: string | null;
+  iso_country?: string | null;
+  address_requirements?: string | null;
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 }
 
 export class MachineToMachineInstance {
@@ -534,26 +487,70 @@ export class MachineToMachineInstance {
     accountSid: string,
     countryCode?: string
   ) {
-    this.availablePhoneNumbers = payload.available_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
-    this.uri = payload.uri;
+    this.friendlyName = payload.friendly_name;
+    this.phoneNumber = payload.phone_number;
+    this.lata = payload.lata;
+    this.locality = payload.locality;
+    this.rateCenter = payload.rate_center;
+    this.latitude = payload.latitude;
+    this.longitude = payload.longitude;
+    this.region = payload.region;
+    this.postalCode = payload.postal_code;
+    this.isoCountry = payload.iso_country;
+    this.addressRequirements = payload.address_requirements;
+    this.beta = payload.beta;
+    this.capabilities = payload.capabilities;
   }
 
-  availablePhoneNumbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberMachineToMachine>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * A formatted version of the phone number
+   */
+  friendlyName?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The LATA of this phone number
+   */
+  lata?: string | null;
+  /**
+   * The locality or city of this phone number\'s location
+   */
+  locality?: string | null;
+  /**
+   * The rate center of this phone number
+   */
+  rateCenter?: string | null;
+  /**
+   * The latitude of this phone number\'s location
+   */
+  latitude?: number | null;
+  /**
+   * The longitude of this phone number\'s location
+   */
+  longitude?: number | null;
+  /**
+   * The two-letter state or province abbreviation of this phone number\'s location
+   */
+  region?: string | null;
+  /**
+   * The postal or ZIP code of this phone number\'s location
+   */
+  postalCode?: string | null;
+  /**
+   * The ISO country code of this phone number
+   */
+  isoCountry?: string | null;
+  /**
+   * The type of Address resource the phone number requires
+   */
+  addressRequirements?: string | null;
+  /**
+   * Whether the phone number is new to the Twilio platform
+   */
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 
   /**
    * Provide a user-friendly representation
@@ -562,15 +559,19 @@ export class MachineToMachineInstance {
    */
   toJSON() {
     return {
-      availablePhoneNumbers: this.availablePhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
-      uri: this.uri,
+      friendlyName: this.friendlyName,
+      phoneNumber: this.phoneNumber,
+      lata: this.lata,
+      locality: this.locality,
+      rateCenter: this.rateCenter,
+      latitude: this.latitude,
+      longitude: this.longitude,
+      region: this.region,
+      postalCode: this.postalCode,
+      isoCountry: this.isoCountry,
+      addressRequirements: this.addressRequirements,
+      beta: this.beta,
+      capabilities: this.capabilities,
     };
   }
 

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/mobile.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/mobile.ts
@@ -18,6 +18,7 @@ import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
+import { PhoneNumberCapabilities } from "../../../../../interfaces";
 
 /**
  * Whether a phone number can receive calls or messages
@@ -27,58 +28,6 @@ export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocal
   "sms"?: boolean;
   "voice"?: boolean;
   "fax"?: boolean;
-}
-
-export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberMobile {
-  /**
-   * A formatted version of the phone number
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The LATA of this phone number
-   */
-  "lata"?: string | null;
-  /**
-   * The locality or city of this phone number\'s location
-   */
-  "locality"?: string | null;
-  /**
-   * The rate center of this phone number
-   */
-  "rateCenter"?: string | null;
-  /**
-   * The latitude of this phone number\'s location
-   */
-  "latitude"?: number | null;
-  /**
-   * The longitude of this phone number\'s location
-   */
-  "longitude"?: number | null;
-  /**
-   * The two-letter state or province abbreviation of this phone number\'s location
-   */
-  "region"?: string | null;
-  /**
-   * The postal or ZIP code of this phone number\'s location
-   */
-  "postalCode"?: string | null;
-  /**
-   * The ISO country code of this phone number
-   */
-  "isoCountry"?: string | null;
-  /**
-   * The type of Address resource the phone number requires
-   */
-  "addressRequirements"?: string | null;
-  /**
-   * Whether the phone number is new to the Twilio platform
-   */
-  "beta"?: boolean | null;
-  "capabilities"?: ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocalCapabilities | null;
 }
 
 /**
@@ -502,15 +451,19 @@ export function MobileListInstance(
 interface MobilePayload extends MobileResource, Page.TwilioResponsePayload {}
 
 interface MobileResource {
-  available_phone_numbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberMobile>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  friendly_name?: string | null;
+  phone_number?: string | null;
+  lata?: string | null;
+  locality?: string | null;
+  rate_center?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  region?: string | null;
+  postal_code?: string | null;
+  iso_country?: string | null;
+  address_requirements?: string | null;
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 }
 
 export class MobileInstance {
@@ -520,26 +473,70 @@ export class MobileInstance {
     accountSid: string,
     countryCode?: string
   ) {
-    this.availablePhoneNumbers = payload.available_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
-    this.uri = payload.uri;
+    this.friendlyName = payload.friendly_name;
+    this.phoneNumber = payload.phone_number;
+    this.lata = payload.lata;
+    this.locality = payload.locality;
+    this.rateCenter = payload.rate_center;
+    this.latitude = payload.latitude;
+    this.longitude = payload.longitude;
+    this.region = payload.region;
+    this.postalCode = payload.postal_code;
+    this.isoCountry = payload.iso_country;
+    this.addressRequirements = payload.address_requirements;
+    this.beta = payload.beta;
+    this.capabilities = payload.capabilities;
   }
 
-  availablePhoneNumbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberMobile>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * A formatted version of the phone number
+   */
+  friendlyName?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The LATA of this phone number
+   */
+  lata?: string | null;
+  /**
+   * The locality or city of this phone number\'s location
+   */
+  locality?: string | null;
+  /**
+   * The rate center of this phone number
+   */
+  rateCenter?: string | null;
+  /**
+   * The latitude of this phone number\'s location
+   */
+  latitude?: number | null;
+  /**
+   * The longitude of this phone number\'s location
+   */
+  longitude?: number | null;
+  /**
+   * The two-letter state or province abbreviation of this phone number\'s location
+   */
+  region?: string | null;
+  /**
+   * The postal or ZIP code of this phone number\'s location
+   */
+  postalCode?: string | null;
+  /**
+   * The ISO country code of this phone number
+   */
+  isoCountry?: string | null;
+  /**
+   * The type of Address resource the phone number requires
+   */
+  addressRequirements?: string | null;
+  /**
+   * Whether the phone number is new to the Twilio platform
+   */
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 
   /**
    * Provide a user-friendly representation
@@ -548,15 +545,19 @@ export class MobileInstance {
    */
   toJSON() {
     return {
-      availablePhoneNumbers: this.availablePhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
-      uri: this.uri,
+      friendlyName: this.friendlyName,
+      phoneNumber: this.phoneNumber,
+      lata: this.lata,
+      locality: this.locality,
+      rateCenter: this.rateCenter,
+      latitude: this.latitude,
+      longitude: this.longitude,
+      region: this.region,
+      postalCode: this.postalCode,
+      isoCountry: this.isoCountry,
+      addressRequirements: this.addressRequirements,
+      beta: this.beta,
+      capabilities: this.capabilities,
     };
   }
 

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/national.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/national.ts
@@ -18,6 +18,7 @@ import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
+import { PhoneNumberCapabilities } from "../../../../../interfaces";
 
 /**
  * Whether a phone number can receive calls or messages
@@ -27,58 +28,6 @@ export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocal
   "sms"?: boolean;
   "voice"?: boolean;
   "fax"?: boolean;
-}
-
-export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberNational {
-  /**
-   * A formatted version of the phone number
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The LATA of this phone number
-   */
-  "lata"?: string | null;
-  /**
-   * The locality or city of this phone number\'s location
-   */
-  "locality"?: string | null;
-  /**
-   * The rate center of this phone number
-   */
-  "rateCenter"?: string | null;
-  /**
-   * The latitude of this phone number\'s location
-   */
-  "latitude"?: number | null;
-  /**
-   * The longitude of this phone number\'s location
-   */
-  "longitude"?: number | null;
-  /**
-   * The two-letter state or province abbreviation of this phone number\'s location
-   */
-  "region"?: string | null;
-  /**
-   * The postal or ZIP code of this phone number\'s location
-   */
-  "postalCode"?: string | null;
-  /**
-   * The ISO country code of this phone number
-   */
-  "isoCountry"?: string | null;
-  /**
-   * The type of Address resource the phone number requires
-   */
-  "addressRequirements"?: string | null;
-  /**
-   * Whether the phone number is new to the Twilio platform
-   */
-  "beta"?: boolean | null;
-  "capabilities"?: ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocalCapabilities | null;
 }
 
 /**
@@ -504,15 +453,19 @@ interface NationalPayload
     Page.TwilioResponsePayload {}
 
 interface NationalResource {
-  available_phone_numbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberNational>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  friendly_name?: string | null;
+  phone_number?: string | null;
+  lata?: string | null;
+  locality?: string | null;
+  rate_center?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  region?: string | null;
+  postal_code?: string | null;
+  iso_country?: string | null;
+  address_requirements?: string | null;
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 }
 
 export class NationalInstance {
@@ -522,26 +475,70 @@ export class NationalInstance {
     accountSid: string,
     countryCode?: string
   ) {
-    this.availablePhoneNumbers = payload.available_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
-    this.uri = payload.uri;
+    this.friendlyName = payload.friendly_name;
+    this.phoneNumber = payload.phone_number;
+    this.lata = payload.lata;
+    this.locality = payload.locality;
+    this.rateCenter = payload.rate_center;
+    this.latitude = payload.latitude;
+    this.longitude = payload.longitude;
+    this.region = payload.region;
+    this.postalCode = payload.postal_code;
+    this.isoCountry = payload.iso_country;
+    this.addressRequirements = payload.address_requirements;
+    this.beta = payload.beta;
+    this.capabilities = payload.capabilities;
   }
 
-  availablePhoneNumbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberNational>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * A formatted version of the phone number
+   */
+  friendlyName?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The LATA of this phone number
+   */
+  lata?: string | null;
+  /**
+   * The locality or city of this phone number\'s location
+   */
+  locality?: string | null;
+  /**
+   * The rate center of this phone number
+   */
+  rateCenter?: string | null;
+  /**
+   * The latitude of this phone number\'s location
+   */
+  latitude?: number | null;
+  /**
+   * The longitude of this phone number\'s location
+   */
+  longitude?: number | null;
+  /**
+   * The two-letter state or province abbreviation of this phone number\'s location
+   */
+  region?: string | null;
+  /**
+   * The postal or ZIP code of this phone number\'s location
+   */
+  postalCode?: string | null;
+  /**
+   * The ISO country code of this phone number
+   */
+  isoCountry?: string | null;
+  /**
+   * The type of Address resource the phone number requires
+   */
+  addressRequirements?: string | null;
+  /**
+   * Whether the phone number is new to the Twilio platform
+   */
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 
   /**
    * Provide a user-friendly representation
@@ -550,15 +547,19 @@ export class NationalInstance {
    */
   toJSON() {
     return {
-      availablePhoneNumbers: this.availablePhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
-      uri: this.uri,
+      friendlyName: this.friendlyName,
+      phoneNumber: this.phoneNumber,
+      lata: this.lata,
+      locality: this.locality,
+      rateCenter: this.rateCenter,
+      latitude: this.latitude,
+      longitude: this.longitude,
+      region: this.region,
+      postalCode: this.postalCode,
+      isoCountry: this.isoCountry,
+      addressRequirements: this.addressRequirements,
+      beta: this.beta,
+      capabilities: this.capabilities,
     };
   }
 

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/sharedCost.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/sharedCost.ts
@@ -18,6 +18,7 @@ import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
+import { PhoneNumberCapabilities } from "../../../../../interfaces";
 
 /**
  * Whether a phone number can receive calls or messages
@@ -27,58 +28,6 @@ export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocal
   "sms"?: boolean;
   "voice"?: boolean;
   "fax"?: boolean;
-}
-
-export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberSharedCost {
-  /**
-   * A formatted version of the phone number
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The LATA of this phone number
-   */
-  "lata"?: string | null;
-  /**
-   * The locality or city of this phone number\'s location
-   */
-  "locality"?: string | null;
-  /**
-   * The rate center of this phone number
-   */
-  "rateCenter"?: string | null;
-  /**
-   * The latitude of this phone number\'s location
-   */
-  "latitude"?: number | null;
-  /**
-   * The longitude of this phone number\'s location
-   */
-  "longitude"?: number | null;
-  /**
-   * The two-letter state or province abbreviation of this phone number\'s location
-   */
-  "region"?: string | null;
-  /**
-   * The postal or ZIP code of this phone number\'s location
-   */
-  "postalCode"?: string | null;
-  /**
-   * The ISO country code of this phone number
-   */
-  "isoCountry"?: string | null;
-  /**
-   * The type of Address resource the phone number requires
-   */
-  "addressRequirements"?: string | null;
-  /**
-   * Whether the phone number is new to the Twilio platform
-   */
-  "beta"?: boolean | null;
-  "capabilities"?: ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocalCapabilities | null;
 }
 
 /**
@@ -504,15 +453,19 @@ interface SharedCostPayload
     Page.TwilioResponsePayload {}
 
 interface SharedCostResource {
-  available_phone_numbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberSharedCost>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  friendly_name?: string | null;
+  phone_number?: string | null;
+  lata?: string | null;
+  locality?: string | null;
+  rate_center?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  region?: string | null;
+  postal_code?: string | null;
+  iso_country?: string | null;
+  address_requirements?: string | null;
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 }
 
 export class SharedCostInstance {
@@ -522,26 +475,70 @@ export class SharedCostInstance {
     accountSid: string,
     countryCode?: string
   ) {
-    this.availablePhoneNumbers = payload.available_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
-    this.uri = payload.uri;
+    this.friendlyName = payload.friendly_name;
+    this.phoneNumber = payload.phone_number;
+    this.lata = payload.lata;
+    this.locality = payload.locality;
+    this.rateCenter = payload.rate_center;
+    this.latitude = payload.latitude;
+    this.longitude = payload.longitude;
+    this.region = payload.region;
+    this.postalCode = payload.postal_code;
+    this.isoCountry = payload.iso_country;
+    this.addressRequirements = payload.address_requirements;
+    this.beta = payload.beta;
+    this.capabilities = payload.capabilities;
   }
 
-  availablePhoneNumbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberSharedCost>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * A formatted version of the phone number
+   */
+  friendlyName?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The LATA of this phone number
+   */
+  lata?: string | null;
+  /**
+   * The locality or city of this phone number\'s location
+   */
+  locality?: string | null;
+  /**
+   * The rate center of this phone number
+   */
+  rateCenter?: string | null;
+  /**
+   * The latitude of this phone number\'s location
+   */
+  latitude?: number | null;
+  /**
+   * The longitude of this phone number\'s location
+   */
+  longitude?: number | null;
+  /**
+   * The two-letter state or province abbreviation of this phone number\'s location
+   */
+  region?: string | null;
+  /**
+   * The postal or ZIP code of this phone number\'s location
+   */
+  postalCode?: string | null;
+  /**
+   * The ISO country code of this phone number
+   */
+  isoCountry?: string | null;
+  /**
+   * The type of Address resource the phone number requires
+   */
+  addressRequirements?: string | null;
+  /**
+   * Whether the phone number is new to the Twilio platform
+   */
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 
   /**
    * Provide a user-friendly representation
@@ -550,15 +547,19 @@ export class SharedCostInstance {
    */
   toJSON() {
     return {
-      availablePhoneNumbers: this.availablePhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
-      uri: this.uri,
+      friendlyName: this.friendlyName,
+      phoneNumber: this.phoneNumber,
+      lata: this.lata,
+      locality: this.locality,
+      rateCenter: this.rateCenter,
+      latitude: this.latitude,
+      longitude: this.longitude,
+      region: this.region,
+      postalCode: this.postalCode,
+      isoCountry: this.isoCountry,
+      addressRequirements: this.addressRequirements,
+      beta: this.beta,
+      capabilities: this.capabilities,
     };
   }
 

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/tollFree.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/tollFree.ts
@@ -18,6 +18,7 @@ import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
+import { PhoneNumberCapabilities } from "../../../../../interfaces";
 
 /**
  * Whether a phone number can receive calls or messages
@@ -27,58 +28,6 @@ export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocal
   "sms"?: boolean;
   "voice"?: boolean;
   "fax"?: boolean;
-}
-
-export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberTollFree {
-  /**
-   * A formatted version of the phone number
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The LATA of this phone number
-   */
-  "lata"?: string | null;
-  /**
-   * The locality or city of this phone number\'s location
-   */
-  "locality"?: string | null;
-  /**
-   * The rate center of this phone number
-   */
-  "rateCenter"?: string | null;
-  /**
-   * The latitude of this phone number\'s location
-   */
-  "latitude"?: number | null;
-  /**
-   * The longitude of this phone number\'s location
-   */
-  "longitude"?: number | null;
-  /**
-   * The two-letter state or province abbreviation of this phone number\'s location
-   */
-  "region"?: string | null;
-  /**
-   * The postal or ZIP code of this phone number\'s location
-   */
-  "postalCode"?: string | null;
-  /**
-   * The ISO country code of this phone number
-   */
-  "isoCountry"?: string | null;
-  /**
-   * The type of Address resource the phone number requires
-   */
-  "addressRequirements"?: string | null;
-  /**
-   * Whether the phone number is new to the Twilio platform
-   */
-  "beta"?: boolean | null;
-  "capabilities"?: ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocalCapabilities | null;
 }
 
 /**
@@ -504,15 +453,19 @@ interface TollFreePayload
     Page.TwilioResponsePayload {}
 
 interface TollFreeResource {
-  available_phone_numbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberTollFree>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  friendly_name?: string | null;
+  phone_number?: string | null;
+  lata?: string | null;
+  locality?: string | null;
+  rate_center?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  region?: string | null;
+  postal_code?: string | null;
+  iso_country?: string | null;
+  address_requirements?: string | null;
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 }
 
 export class TollFreeInstance {
@@ -522,26 +475,70 @@ export class TollFreeInstance {
     accountSid: string,
     countryCode?: string
   ) {
-    this.availablePhoneNumbers = payload.available_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
-    this.uri = payload.uri;
+    this.friendlyName = payload.friendly_name;
+    this.phoneNumber = payload.phone_number;
+    this.lata = payload.lata;
+    this.locality = payload.locality;
+    this.rateCenter = payload.rate_center;
+    this.latitude = payload.latitude;
+    this.longitude = payload.longitude;
+    this.region = payload.region;
+    this.postalCode = payload.postal_code;
+    this.isoCountry = payload.iso_country;
+    this.addressRequirements = payload.address_requirements;
+    this.beta = payload.beta;
+    this.capabilities = payload.capabilities;
   }
 
-  availablePhoneNumbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberTollFree>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * A formatted version of the phone number
+   */
+  friendlyName?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The LATA of this phone number
+   */
+  lata?: string | null;
+  /**
+   * The locality or city of this phone number\'s location
+   */
+  locality?: string | null;
+  /**
+   * The rate center of this phone number
+   */
+  rateCenter?: string | null;
+  /**
+   * The latitude of this phone number\'s location
+   */
+  latitude?: number | null;
+  /**
+   * The longitude of this phone number\'s location
+   */
+  longitude?: number | null;
+  /**
+   * The two-letter state or province abbreviation of this phone number\'s location
+   */
+  region?: string | null;
+  /**
+   * The postal or ZIP code of this phone number\'s location
+   */
+  postalCode?: string | null;
+  /**
+   * The ISO country code of this phone number
+   */
+  isoCountry?: string | null;
+  /**
+   * The type of Address resource the phone number requires
+   */
+  addressRequirements?: string | null;
+  /**
+   * Whether the phone number is new to the Twilio platform
+   */
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 
   /**
    * Provide a user-friendly representation
@@ -550,15 +547,19 @@ export class TollFreeInstance {
    */
   toJSON() {
     return {
-      availablePhoneNumbers: this.availablePhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
-      uri: this.uri,
+      friendlyName: this.friendlyName,
+      phoneNumber: this.phoneNumber,
+      lata: this.lata,
+      locality: this.locality,
+      rateCenter: this.rateCenter,
+      latitude: this.latitude,
+      longitude: this.longitude,
+      region: this.region,
+      postalCode: this.postalCode,
+      isoCountry: this.isoCountry,
+      addressRequirements: this.addressRequirements,
+      beta: this.beta,
+      capabilities: this.capabilities,
     };
   }
 

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/voip.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/voip.ts
@@ -18,6 +18,7 @@ import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
+import { PhoneNumberCapabilities } from "../../../../../interfaces";
 
 /**
  * Whether a phone number can receive calls or messages
@@ -27,58 +28,6 @@ export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocal
   "sms"?: boolean;
   "voice"?: boolean;
   "fax"?: boolean;
-}
-
-export class ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberVoip {
-  /**
-   * A formatted version of the phone number
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The LATA of this phone number
-   */
-  "lata"?: string | null;
-  /**
-   * The locality or city of this phone number\'s location
-   */
-  "locality"?: string | null;
-  /**
-   * The rate center of this phone number
-   */
-  "rateCenter"?: string | null;
-  /**
-   * The latitude of this phone number\'s location
-   */
-  "latitude"?: number | null;
-  /**
-   * The longitude of this phone number\'s location
-   */
-  "longitude"?: number | null;
-  /**
-   * The two-letter state or province abbreviation of this phone number\'s location
-   */
-  "region"?: string | null;
-  /**
-   * The postal or ZIP code of this phone number\'s location
-   */
-  "postalCode"?: string | null;
-  /**
-   * The ISO country code of this phone number
-   */
-  "isoCountry"?: string | null;
-  /**
-   * The type of Address resource the phone number requires
-   */
-  "addressRequirements"?: string | null;
-  /**
-   * Whether the phone number is new to the Twilio platform
-   */
-  "beta"?: boolean | null;
-  "capabilities"?: ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberLocalCapabilities | null;
 }
 
 /**
@@ -502,15 +451,19 @@ export function VoipListInstance(
 interface VoipPayload extends VoipResource, Page.TwilioResponsePayload {}
 
 interface VoipResource {
-  available_phone_numbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberVoip>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  friendly_name?: string | null;
+  phone_number?: string | null;
+  lata?: string | null;
+  locality?: string | null;
+  rate_center?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  region?: string | null;
+  postal_code?: string | null;
+  iso_country?: string | null;
+  address_requirements?: string | null;
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 }
 
 export class VoipInstance {
@@ -520,26 +473,70 @@ export class VoipInstance {
     accountSid: string,
     countryCode?: string
   ) {
-    this.availablePhoneNumbers = payload.available_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
-    this.uri = payload.uri;
+    this.friendlyName = payload.friendly_name;
+    this.phoneNumber = payload.phone_number;
+    this.lata = payload.lata;
+    this.locality = payload.locality;
+    this.rateCenter = payload.rate_center;
+    this.latitude = payload.latitude;
+    this.longitude = payload.longitude;
+    this.region = payload.region;
+    this.postalCode = payload.postal_code;
+    this.isoCountry = payload.iso_country;
+    this.addressRequirements = payload.address_requirements;
+    this.beta = payload.beta;
+    this.capabilities = payload.capabilities;
   }
 
-  availablePhoneNumbers?: Array<ApiV2010AccountAvailablePhoneNumberCountryAvailablePhoneNumberVoip>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * A formatted version of the phone number
+   */
+  friendlyName?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The LATA of this phone number
+   */
+  lata?: string | null;
+  /**
+   * The locality or city of this phone number\'s location
+   */
+  locality?: string | null;
+  /**
+   * The rate center of this phone number
+   */
+  rateCenter?: string | null;
+  /**
+   * The latitude of this phone number\'s location
+   */
+  latitude?: number | null;
+  /**
+   * The longitude of this phone number\'s location
+   */
+  longitude?: number | null;
+  /**
+   * The two-letter state or province abbreviation of this phone number\'s location
+   */
+  region?: string | null;
+  /**
+   * The postal or ZIP code of this phone number\'s location
+   */
+  postalCode?: string | null;
+  /**
+   * The ISO country code of this phone number
+   */
+  isoCountry?: string | null;
+  /**
+   * The type of Address resource the phone number requires
+   */
+  addressRequirements?: string | null;
+  /**
+   * Whether the phone number is new to the Twilio platform
+   */
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
 
   /**
    * Provide a user-friendly representation
@@ -548,15 +545,19 @@ export class VoipInstance {
    */
   toJSON() {
     return {
-      availablePhoneNumbers: this.availablePhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
-      uri: this.uri,
+      friendlyName: this.friendlyName,
+      phoneNumber: this.phoneNumber,
+      lata: this.lata,
+      locality: this.locality,
+      rateCenter: this.rateCenter,
+      latitude: this.latitude,
+      longitude: this.longitude,
+      region: this.region,
+      postalCode: this.postalCode,
+      isoCountry: this.isoCountry,
+      addressRequirements: this.addressRequirements,
+      beta: this.beta,
+      capabilities: this.capabilities,
     };
   }
 

--- a/lib/rest/api/v2010/account/call/event.ts
+++ b/lib/rest/api/v2010/account/call/event.ts
@@ -19,17 +19,6 @@ import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
 
-export class ApiV2010AccountCallCallEvent {
-  /**
-   * Call Request.
-   */
-  "request"?: any | null;
-  /**
-   * Call Response with Events.
-   */
-  "response"?: any | null;
-}
-
 /**
  * Options to pass to each
  *
@@ -306,15 +295,8 @@ export function EventListInstance(
 interface EventPayload extends EventResource, Page.TwilioResponsePayload {}
 
 interface EventResource {
-  events?: Array<ApiV2010AccountCallCallEvent>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  request?: any | null;
+  response?: any | null;
 }
 
 export class EventInstance {
@@ -324,26 +306,18 @@ export class EventInstance {
     accountSid: string,
     callSid?: string
   ) {
-    this.events = payload.events;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
-    this.uri = payload.uri;
+    this.request = payload.request;
+    this.response = payload.response;
   }
 
-  events?: Array<ApiV2010AccountCallCallEvent>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * Call Request.
+   */
+  request?: any | null;
+  /**
+   * Call Response with Events.
+   */
+  response?: any | null;
 
   /**
    * Provide a user-friendly representation
@@ -352,15 +326,8 @@ export class EventInstance {
    */
   toJSON() {
     return {
-      events: this.events,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
-      uri: this.uri,
+      request: this.request,
+      response: this.response,
     };
   }
 

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/local.ts
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/local.ts
@@ -18,6 +18,7 @@ import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
+import { PhoneNumberCapabilities } from "../../../../../interfaces";
 
 /**
  * Indicate if a phone can receive calls or messages
@@ -27,127 +28,6 @@ export class ApiV2010AccountIncomingPhoneNumberCapabilities {
   "sms"?: boolean;
   "voice"?: boolean;
   "fax"?: boolean;
-}
-
-export class ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberLocal {
-  /**
-   * The SID of the Account that created the resource
-   */
-  "accountSid"?: string | null;
-  /**
-   * The SID of the Address resource associated with the phone number
-   */
-  "addressSid"?: string | null;
-  "addressRequirements"?: IncomingPhoneNumberLocalAddressRequirement;
-  /**
-   * The API version used to start a new TwiML session
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Whether the phone number is new to the Twilio platform
-   */
-  "beta"?: boolean | null;
-  "capabilities"?: PhoneNumberCapabilities | null;
-  /**
-   * The RFC 2822 date and time in GMT that the resource was created
-   */
-  "dateCreated"?: string | null;
-  /**
-   * The RFC 2822 date and time in GMT that the resource was last updated
-   */
-  "dateUpdated"?: string | null;
-  /**
-   * The string that you assigned to describe the resource
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The SID of the Identity resource associated with number
-   */
-  "identitySid"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The phone number\'s origin. Can be twilio or hosted.
-   */
-  "origin"?: string | null;
-  /**
-   * The unique string that identifies the resource
-   */
-  "sid"?: string | null;
-  /**
-   * The SID of the Application resource to handle SMS messages
-   */
-  "smsApplicationSid"?: string | null;
-  /**
-   * The HTTP method used with sms_fallback_url
-   */
-  "smsFallbackMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberLocal.SmsFallbackMethodEnum;
-  /**
-   * The URL that we call when an error occurs while retrieving or executing the TwiML
-   */
-  "smsFallbackUrl"?: string | null;
-  /**
-   * The HTTP method to use with sms_url
-   */
-  "smsMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberLocal.SmsMethodEnum;
-  /**
-   * The URL we call when the phone number receives an incoming SMS message
-   */
-  "smsUrl"?: string | null;
-  /**
-   * The URL to send status information to your application
-   */
-  "statusCallback"?: string | null;
-  /**
-   * The HTTP method we use to call status_callback
-   */
-  "statusCallbackMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberLocal.StatusCallbackMethodEnum;
-  /**
-   * The SID of the Trunk that handles calls to the phone number
-   */
-  "trunkSid"?: string | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  "voiceReceiveMode"?: IncomingPhoneNumberLocalVoiceReceiveMode;
-  /**
-   * The SID of the application that handles calls to the phone number
-   */
-  "voiceApplicationSid"?: string | null;
-  /**
-   * Whether to lookup the caller\'s name
-   */
-  "voiceCallerIdLookup"?: boolean | null;
-  /**
-   * The HTTP method used with voice_fallback_url
-   */
-  "voiceFallbackMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberLocal.VoiceFallbackMethodEnum;
-  /**
-   * The URL we call when an error occurs in TwiML
-   */
-  "voiceFallbackUrl"?: string | null;
-  /**
-   * The HTTP method used with the voice_url
-   */
-  "voiceMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberLocal.VoiceMethodEnum;
-  /**
-   * The URL we call when this phone number receives a call
-   */
-  "voiceUrl"?: string | null;
-  "emergencyStatus"?: IncomingPhoneNumberLocalEmergencyStatus;
-  /**
-   * The emergency address configuration to use for emergency calling
-   */
-  "emergencyAddressSid"?: string | null;
-  "emergencyAddressStatus"?: IncomingPhoneNumberLocalEmergencyAddressStatus;
-  /**
-   * The SID of the Bundle resource associated with number
-   */
-  "bundleSid"?: string | null;
-  "status"?: string | null;
 }
 
 type IncomingPhoneNumberLocalAddressRequirement =
@@ -617,19 +497,79 @@ export function LocalListInstance(
 
   return instance;
 }
+export type LocalSmsFallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type LocalSmsMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type LocalStatusCallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type LocalVoiceFallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type LocalVoiceMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
 
 interface LocalPayload extends LocalResource, Page.TwilioResponsePayload {}
 
 interface LocalResource {
-  incoming_phone_numbers?: Array<ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberLocal>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  address_sid?: string | null;
+  address_requirements?: IncomingPhoneNumberLocalAddressRequirement;
+  api_version?: string | null;
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
+  date_created?: string | null;
+  date_updated?: string | null;
+  friendly_name?: string | null;
+  identity_sid?: string | null;
+  phone_number?: string | null;
+  origin?: string | null;
+  sid?: string | null;
+  sms_application_sid?: string | null;
+  sms_fallback_method?: LocalSmsFallbackMethod;
+  sms_fallback_url?: string | null;
+  sms_method?: LocalSmsMethod;
+  sms_url?: string | null;
+  status_callback?: string | null;
+  status_callback_method?: LocalStatusCallbackMethod;
+  trunk_sid?: string | null;
+  uri?: string | null;
+  voice_receive_mode?: IncomingPhoneNumberLocalVoiceReceiveMode;
+  voice_application_sid?: string | null;
+  voice_caller_id_lookup?: boolean | null;
+  voice_fallback_method?: LocalVoiceFallbackMethod;
+  voice_fallback_url?: string | null;
+  voice_method?: LocalVoiceMethod;
+  voice_url?: string | null;
+  emergency_status?: IncomingPhoneNumberLocalEmergencyStatus;
+  emergency_address_sid?: string | null;
+  emergency_address_status?: IncomingPhoneNumberLocalEmergencyAddressStatus;
+  bundle_sid?: string | null;
+  status?: string | null;
 }
 
 export class LocalInstance {
@@ -638,26 +578,160 @@ export class LocalInstance {
     payload: LocalPayload,
     accountSid?: string
   ) {
-    this.incomingPhoneNumbers = payload.incoming_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.addressSid = payload.address_sid;
+    this.addressRequirements = payload.address_requirements;
+    this.apiVersion = payload.api_version;
+    this.beta = payload.beta;
+    this.capabilities = payload.capabilities;
+    this.dateCreated = deserialize.rfc2822DateTime(payload.date_created);
+    this.dateUpdated = deserialize.rfc2822DateTime(payload.date_updated);
+    this.friendlyName = payload.friendly_name;
+    this.identitySid = payload.identity_sid;
+    this.phoneNumber = payload.phone_number;
+    this.origin = payload.origin;
+    this.sid = payload.sid;
+    this.smsApplicationSid = payload.sms_application_sid;
+    this.smsFallbackMethod = payload.sms_fallback_method;
+    this.smsFallbackUrl = payload.sms_fallback_url;
+    this.smsMethod = payload.sms_method;
+    this.smsUrl = payload.sms_url;
+    this.statusCallback = payload.status_callback;
+    this.statusCallbackMethod = payload.status_callback_method;
+    this.trunkSid = payload.trunk_sid;
     this.uri = payload.uri;
+    this.voiceReceiveMode = payload.voice_receive_mode;
+    this.voiceApplicationSid = payload.voice_application_sid;
+    this.voiceCallerIdLookup = payload.voice_caller_id_lookup;
+    this.voiceFallbackMethod = payload.voice_fallback_method;
+    this.voiceFallbackUrl = payload.voice_fallback_url;
+    this.voiceMethod = payload.voice_method;
+    this.voiceUrl = payload.voice_url;
+    this.emergencyStatus = payload.emergency_status;
+    this.emergencyAddressSid = payload.emergency_address_sid;
+    this.emergencyAddressStatus = payload.emergency_address_status;
+    this.bundleSid = payload.bundle_sid;
+    this.status = payload.status;
   }
 
-  incomingPhoneNumbers?: Array<ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberLocal>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account that created the resource
+   */
+  accountSid?: string | null;
+  /**
+   * The SID of the Address resource associated with the phone number
+   */
+  addressSid?: string | null;
+  addressRequirements?: IncomingPhoneNumberLocalAddressRequirement;
+  /**
+   * The API version used to start a new TwiML session
+   */
+  apiVersion?: string | null;
+  /**
+   * Whether the phone number is new to the Twilio platform
+   */
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
+  /**
+   * The RFC 2822 date and time in GMT that the resource was created
+   */
+  dateCreated?: string | null;
+  /**
+   * The RFC 2822 date and time in GMT that the resource was last updated
+   */
+  dateUpdated?: string | null;
+  /**
+   * The string that you assigned to describe the resource
+   */
+  friendlyName?: string | null;
+  /**
+   * The SID of the Identity resource associated with number
+   */
+  identitySid?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The phone number\'s origin. Can be twilio or hosted.
+   */
+  origin?: string | null;
+  /**
+   * The unique string that identifies the resource
+   */
+  sid?: string | null;
+  /**
+   * The SID of the Application resource to handle SMS messages
+   */
+  smsApplicationSid?: string | null;
+  /**
+   * The HTTP method used with sms_fallback_url
+   */
+  smsFallbackMethod?: LocalSmsFallbackMethod;
+  /**
+   * The URL that we call when an error occurs while retrieving or executing the TwiML
+   */
+  smsFallbackUrl?: string | null;
+  /**
+   * The HTTP method to use with sms_url
+   */
+  smsMethod?: LocalSmsMethod;
+  /**
+   * The URL we call when the phone number receives an incoming SMS message
+   */
+  smsUrl?: string | null;
+  /**
+   * The URL to send status information to your application
+   */
+  statusCallback?: string | null;
+  /**
+   * The HTTP method we use to call status_callback
+   */
+  statusCallbackMethod?: LocalStatusCallbackMethod;
+  /**
+   * The SID of the Trunk that handles calls to the phone number
+   */
+  trunkSid?: string | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  voiceReceiveMode?: IncomingPhoneNumberLocalVoiceReceiveMode;
+  /**
+   * The SID of the application that handles calls to the phone number
+   */
+  voiceApplicationSid?: string | null;
+  /**
+   * Whether to lookup the caller\'s name
+   */
+  voiceCallerIdLookup?: boolean | null;
+  /**
+   * The HTTP method used with voice_fallback_url
+   */
+  voiceFallbackMethod?: LocalVoiceFallbackMethod;
+  /**
+   * The URL we call when an error occurs in TwiML
+   */
+  voiceFallbackUrl?: string | null;
+  /**
+   * The HTTP method used with the voice_url
+   */
+  voiceMethod?: LocalVoiceMethod;
+  /**
+   * The URL we call when this phone number receives a call
+   */
+  voiceUrl?: string | null;
+  emergencyStatus?: IncomingPhoneNumberLocalEmergencyStatus;
+  /**
+   * The emergency address configuration to use for emergency calling
+   */
+  emergencyAddressSid?: string | null;
+  emergencyAddressStatus?: IncomingPhoneNumberLocalEmergencyAddressStatus;
+  /**
+   * The SID of the Bundle resource associated with number
+   */
+  bundleSid?: string | null;
+  status?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -666,15 +740,40 @@ export class LocalInstance {
    */
   toJSON() {
     return {
-      incomingPhoneNumbers: this.incomingPhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      addressSid: this.addressSid,
+      addressRequirements: this.addressRequirements,
+      apiVersion: this.apiVersion,
+      beta: this.beta,
+      capabilities: this.capabilities,
+      dateCreated: this.dateCreated,
+      dateUpdated: this.dateUpdated,
+      friendlyName: this.friendlyName,
+      identitySid: this.identitySid,
+      phoneNumber: this.phoneNumber,
+      origin: this.origin,
+      sid: this.sid,
+      smsApplicationSid: this.smsApplicationSid,
+      smsFallbackMethod: this.smsFallbackMethod,
+      smsFallbackUrl: this.smsFallbackUrl,
+      smsMethod: this.smsMethod,
+      smsUrl: this.smsUrl,
+      statusCallback: this.statusCallback,
+      statusCallbackMethod: this.statusCallbackMethod,
+      trunkSid: this.trunkSid,
       uri: this.uri,
+      voiceReceiveMode: this.voiceReceiveMode,
+      voiceApplicationSid: this.voiceApplicationSid,
+      voiceCallerIdLookup: this.voiceCallerIdLookup,
+      voiceFallbackMethod: this.voiceFallbackMethod,
+      voiceFallbackUrl: this.voiceFallbackUrl,
+      voiceMethod: this.voiceMethod,
+      voiceUrl: this.voiceUrl,
+      emergencyStatus: this.emergencyStatus,
+      emergencyAddressSid: this.emergencyAddressSid,
+      emergencyAddressStatus: this.emergencyAddressStatus,
+      bundleSid: this.bundleSid,
+      status: this.status,
     };
   }
 

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/mobile.ts
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/mobile.ts
@@ -18,6 +18,7 @@ import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
+import { PhoneNumberCapabilities } from "../../../../../interfaces";
 
 /**
  * Indicate if a phone can receive calls or messages
@@ -27,127 +28,6 @@ export class ApiV2010AccountIncomingPhoneNumberCapabilities {
   "sms"?: boolean;
   "voice"?: boolean;
   "fax"?: boolean;
-}
-
-export class ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberMobile {
-  /**
-   * The SID of the Account that created the resource
-   */
-  "accountSid"?: string | null;
-  /**
-   * The SID of the Address resource associated with the phone number
-   */
-  "addressSid"?: string | null;
-  "addressRequirements"?: IncomingPhoneNumberMobileAddressRequirement;
-  /**
-   * The API version used to start a new TwiML session
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Whether the phone number is new to the Twilio platform
-   */
-  "beta"?: boolean | null;
-  "capabilities"?: PhoneNumberCapabilities | null;
-  /**
-   * The RFC 2822 date and time in GMT that the resource was created
-   */
-  "dateCreated"?: string | null;
-  /**
-   * The RFC 2822 date and time in GMT that the resource was last updated
-   */
-  "dateUpdated"?: string | null;
-  /**
-   * The string that you assigned to describe the resource
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The SID of the Identity resource associated with number
-   */
-  "identitySid"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The phone number\'s origin. Can be twilio or hosted.
-   */
-  "origin"?: string | null;
-  /**
-   * The unique string that identifies the resource
-   */
-  "sid"?: string | null;
-  /**
-   * The SID of the application that handles SMS messages sent to the phone number
-   */
-  "smsApplicationSid"?: string | null;
-  /**
-   * The HTTP method used with sms_fallback_url
-   */
-  "smsFallbackMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberMobile.SmsFallbackMethodEnum;
-  /**
-   * The URL that we call when an error occurs while retrieving or executing the TwiML
-   */
-  "smsFallbackUrl"?: string | null;
-  /**
-   * The HTTP method to use with sms_url
-   */
-  "smsMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberMobile.SmsMethodEnum;
-  /**
-   * The URL we call when the phone number receives an incoming SMS message
-   */
-  "smsUrl"?: string | null;
-  /**
-   * The URL to send status information to your application
-   */
-  "statusCallback"?: string | null;
-  /**
-   * The HTTP method we use to call status_callback
-   */
-  "statusCallbackMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberMobile.StatusCallbackMethodEnum;
-  /**
-   * The SID of the Trunk that handles calls to the phone number
-   */
-  "trunkSid"?: string | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  "voiceReceiveMode"?: IncomingPhoneNumberMobileVoiceReceiveMode;
-  /**
-   * The SID of the application that handles calls to the phone number
-   */
-  "voiceApplicationSid"?: string | null;
-  /**
-   * Whether to lookup the caller\'s name
-   */
-  "voiceCallerIdLookup"?: boolean | null;
-  /**
-   * The HTTP method used with voice_fallback_url
-   */
-  "voiceFallbackMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberMobile.VoiceFallbackMethodEnum;
-  /**
-   * The URL we call when an error occurs in TwiML
-   */
-  "voiceFallbackUrl"?: string | null;
-  /**
-   * The HTTP method used with the voice_url
-   */
-  "voiceMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberMobile.VoiceMethodEnum;
-  /**
-   * The URL we call when the phone number receives a call
-   */
-  "voiceUrl"?: string | null;
-  "emergencyStatus"?: IncomingPhoneNumberMobileEmergencyStatus;
-  /**
-   * The emergency address configuration to use for emergency calling
-   */
-  "emergencyAddressSid"?: string | null;
-  "emergencyAddressStatus"?: IncomingPhoneNumberMobileEmergencyAddressStatus;
-  /**
-   * The SID of the Bundle resource associated with number
-   */
-  "bundleSid"?: string | null;
-  "status"?: string | null;
 }
 
 type IncomingPhoneNumberMobileAddressRequirement =
@@ -617,19 +497,79 @@ export function MobileListInstance(
 
   return instance;
 }
+export type MobileSmsFallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type MobileSmsMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type MobileStatusCallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type MobileVoiceFallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type MobileVoiceMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
 
 interface MobilePayload extends MobileResource, Page.TwilioResponsePayload {}
 
 interface MobileResource {
-  incoming_phone_numbers?: Array<ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberMobile>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  address_sid?: string | null;
+  address_requirements?: IncomingPhoneNumberMobileAddressRequirement;
+  api_version?: string | null;
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
+  date_created?: string | null;
+  date_updated?: string | null;
+  friendly_name?: string | null;
+  identity_sid?: string | null;
+  phone_number?: string | null;
+  origin?: string | null;
+  sid?: string | null;
+  sms_application_sid?: string | null;
+  sms_fallback_method?: MobileSmsFallbackMethod;
+  sms_fallback_url?: string | null;
+  sms_method?: MobileSmsMethod;
+  sms_url?: string | null;
+  status_callback?: string | null;
+  status_callback_method?: MobileStatusCallbackMethod;
+  trunk_sid?: string | null;
+  uri?: string | null;
+  voice_receive_mode?: IncomingPhoneNumberMobileVoiceReceiveMode;
+  voice_application_sid?: string | null;
+  voice_caller_id_lookup?: boolean | null;
+  voice_fallback_method?: MobileVoiceFallbackMethod;
+  voice_fallback_url?: string | null;
+  voice_method?: MobileVoiceMethod;
+  voice_url?: string | null;
+  emergency_status?: IncomingPhoneNumberMobileEmergencyStatus;
+  emergency_address_sid?: string | null;
+  emergency_address_status?: IncomingPhoneNumberMobileEmergencyAddressStatus;
+  bundle_sid?: string | null;
+  status?: string | null;
 }
 
 export class MobileInstance {
@@ -638,26 +578,160 @@ export class MobileInstance {
     payload: MobilePayload,
     accountSid?: string
   ) {
-    this.incomingPhoneNumbers = payload.incoming_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.addressSid = payload.address_sid;
+    this.addressRequirements = payload.address_requirements;
+    this.apiVersion = payload.api_version;
+    this.beta = payload.beta;
+    this.capabilities = payload.capabilities;
+    this.dateCreated = deserialize.rfc2822DateTime(payload.date_created);
+    this.dateUpdated = deserialize.rfc2822DateTime(payload.date_updated);
+    this.friendlyName = payload.friendly_name;
+    this.identitySid = payload.identity_sid;
+    this.phoneNumber = payload.phone_number;
+    this.origin = payload.origin;
+    this.sid = payload.sid;
+    this.smsApplicationSid = payload.sms_application_sid;
+    this.smsFallbackMethod = payload.sms_fallback_method;
+    this.smsFallbackUrl = payload.sms_fallback_url;
+    this.smsMethod = payload.sms_method;
+    this.smsUrl = payload.sms_url;
+    this.statusCallback = payload.status_callback;
+    this.statusCallbackMethod = payload.status_callback_method;
+    this.trunkSid = payload.trunk_sid;
     this.uri = payload.uri;
+    this.voiceReceiveMode = payload.voice_receive_mode;
+    this.voiceApplicationSid = payload.voice_application_sid;
+    this.voiceCallerIdLookup = payload.voice_caller_id_lookup;
+    this.voiceFallbackMethod = payload.voice_fallback_method;
+    this.voiceFallbackUrl = payload.voice_fallback_url;
+    this.voiceMethod = payload.voice_method;
+    this.voiceUrl = payload.voice_url;
+    this.emergencyStatus = payload.emergency_status;
+    this.emergencyAddressSid = payload.emergency_address_sid;
+    this.emergencyAddressStatus = payload.emergency_address_status;
+    this.bundleSid = payload.bundle_sid;
+    this.status = payload.status;
   }
 
-  incomingPhoneNumbers?: Array<ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberMobile>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account that created the resource
+   */
+  accountSid?: string | null;
+  /**
+   * The SID of the Address resource associated with the phone number
+   */
+  addressSid?: string | null;
+  addressRequirements?: IncomingPhoneNumberMobileAddressRequirement;
+  /**
+   * The API version used to start a new TwiML session
+   */
+  apiVersion?: string | null;
+  /**
+   * Whether the phone number is new to the Twilio platform
+   */
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
+  /**
+   * The RFC 2822 date and time in GMT that the resource was created
+   */
+  dateCreated?: string | null;
+  /**
+   * The RFC 2822 date and time in GMT that the resource was last updated
+   */
+  dateUpdated?: string | null;
+  /**
+   * The string that you assigned to describe the resource
+   */
+  friendlyName?: string | null;
+  /**
+   * The SID of the Identity resource associated with number
+   */
+  identitySid?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The phone number\'s origin. Can be twilio or hosted.
+   */
+  origin?: string | null;
+  /**
+   * The unique string that identifies the resource
+   */
+  sid?: string | null;
+  /**
+   * The SID of the application that handles SMS messages sent to the phone number
+   */
+  smsApplicationSid?: string | null;
+  /**
+   * The HTTP method used with sms_fallback_url
+   */
+  smsFallbackMethod?: MobileSmsFallbackMethod;
+  /**
+   * The URL that we call when an error occurs while retrieving or executing the TwiML
+   */
+  smsFallbackUrl?: string | null;
+  /**
+   * The HTTP method to use with sms_url
+   */
+  smsMethod?: MobileSmsMethod;
+  /**
+   * The URL we call when the phone number receives an incoming SMS message
+   */
+  smsUrl?: string | null;
+  /**
+   * The URL to send status information to your application
+   */
+  statusCallback?: string | null;
+  /**
+   * The HTTP method we use to call status_callback
+   */
+  statusCallbackMethod?: MobileStatusCallbackMethod;
+  /**
+   * The SID of the Trunk that handles calls to the phone number
+   */
+  trunkSid?: string | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  voiceReceiveMode?: IncomingPhoneNumberMobileVoiceReceiveMode;
+  /**
+   * The SID of the application that handles calls to the phone number
+   */
+  voiceApplicationSid?: string | null;
+  /**
+   * Whether to lookup the caller\'s name
+   */
+  voiceCallerIdLookup?: boolean | null;
+  /**
+   * The HTTP method used with voice_fallback_url
+   */
+  voiceFallbackMethod?: MobileVoiceFallbackMethod;
+  /**
+   * The URL we call when an error occurs in TwiML
+   */
+  voiceFallbackUrl?: string | null;
+  /**
+   * The HTTP method used with the voice_url
+   */
+  voiceMethod?: MobileVoiceMethod;
+  /**
+   * The URL we call when the phone number receives a call
+   */
+  voiceUrl?: string | null;
+  emergencyStatus?: IncomingPhoneNumberMobileEmergencyStatus;
+  /**
+   * The emergency address configuration to use for emergency calling
+   */
+  emergencyAddressSid?: string | null;
+  emergencyAddressStatus?: IncomingPhoneNumberMobileEmergencyAddressStatus;
+  /**
+   * The SID of the Bundle resource associated with number
+   */
+  bundleSid?: string | null;
+  status?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -666,15 +740,40 @@ export class MobileInstance {
    */
   toJSON() {
     return {
-      incomingPhoneNumbers: this.incomingPhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      addressSid: this.addressSid,
+      addressRequirements: this.addressRequirements,
+      apiVersion: this.apiVersion,
+      beta: this.beta,
+      capabilities: this.capabilities,
+      dateCreated: this.dateCreated,
+      dateUpdated: this.dateUpdated,
+      friendlyName: this.friendlyName,
+      identitySid: this.identitySid,
+      phoneNumber: this.phoneNumber,
+      origin: this.origin,
+      sid: this.sid,
+      smsApplicationSid: this.smsApplicationSid,
+      smsFallbackMethod: this.smsFallbackMethod,
+      smsFallbackUrl: this.smsFallbackUrl,
+      smsMethod: this.smsMethod,
+      smsUrl: this.smsUrl,
+      statusCallback: this.statusCallback,
+      statusCallbackMethod: this.statusCallbackMethod,
+      trunkSid: this.trunkSid,
       uri: this.uri,
+      voiceReceiveMode: this.voiceReceiveMode,
+      voiceApplicationSid: this.voiceApplicationSid,
+      voiceCallerIdLookup: this.voiceCallerIdLookup,
+      voiceFallbackMethod: this.voiceFallbackMethod,
+      voiceFallbackUrl: this.voiceFallbackUrl,
+      voiceMethod: this.voiceMethod,
+      voiceUrl: this.voiceUrl,
+      emergencyStatus: this.emergencyStatus,
+      emergencyAddressSid: this.emergencyAddressSid,
+      emergencyAddressStatus: this.emergencyAddressStatus,
+      bundleSid: this.bundleSid,
+      status: this.status,
     };
   }
 

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/tollFree.ts
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/tollFree.ts
@@ -18,6 +18,7 @@ import Response from "../../../../../http/response";
 import V2010 from "../../../V2010";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
+import { PhoneNumberCapabilities } from "../../../../../interfaces";
 
 /**
  * Indicate if a phone can receive calls or messages
@@ -27,127 +28,6 @@ export class ApiV2010AccountIncomingPhoneNumberCapabilities {
   "sms"?: boolean;
   "voice"?: boolean;
   "fax"?: boolean;
-}
-
-export class ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberTollFree {
-  /**
-   * The SID of the Account that created the resource
-   */
-  "accountSid"?: string | null;
-  /**
-   * The SID of the Address resource associated with the phone number
-   */
-  "addressSid"?: string | null;
-  "addressRequirements"?: IncomingPhoneNumberTollFreeAddressRequirement;
-  /**
-   * The API version used to start a new TwiML session
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Whether the phone number is new to the Twilio platform
-   */
-  "beta"?: boolean | null;
-  "capabilities"?: PhoneNumberCapabilities | null;
-  /**
-   * The RFC 2822 date and time in GMT that the resource was created
-   */
-  "dateCreated"?: string | null;
-  /**
-   * The RFC 2822 date and time in GMT that the resource was last updated
-   */
-  "dateUpdated"?: string | null;
-  /**
-   * The string that you assigned to describe the resource
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The SID of the Identity resource associated with number
-   */
-  "identitySid"?: string | null;
-  /**
-   * The phone number in E.164 format
-   */
-  "phoneNumber"?: string | null;
-  /**
-   * The phone number\'s origin. Can be twilio or hosted.
-   */
-  "origin"?: string | null;
-  /**
-   * The unique string that identifies the resource
-   */
-  "sid"?: string | null;
-  /**
-   * The SID of the application that handles SMS messages sent to the phone number
-   */
-  "smsApplicationSid"?: string | null;
-  /**
-   * The HTTP method used with sms_fallback_url
-   */
-  "smsFallbackMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberTollFree.SmsFallbackMethodEnum;
-  /**
-   * The URL that we call when an error occurs while retrieving or executing the TwiML
-   */
-  "smsFallbackUrl"?: string | null;
-  /**
-   * The HTTP method to use with sms_url
-   */
-  "smsMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberTollFree.SmsMethodEnum;
-  /**
-   * The URL we call when the phone number receives an incoming SMS message
-   */
-  "smsUrl"?: string | null;
-  /**
-   * The URL to send status information to your application
-   */
-  "statusCallback"?: string | null;
-  /**
-   * The HTTP method we use to call status_callback
-   */
-  "statusCallbackMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberTollFree.StatusCallbackMethodEnum;
-  /**
-   * The SID of the Trunk that handles calls to the phone number
-   */
-  "trunkSid"?: string | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  "voiceReceiveMode"?: IncomingPhoneNumberTollFreeVoiceReceiveMode;
-  /**
-   * The SID of the application that handles calls to the phone number
-   */
-  "voiceApplicationSid"?: string | null;
-  /**
-   * Whether to lookup the caller\'s name
-   */
-  "voiceCallerIdLookup"?: boolean | null;
-  /**
-   * The HTTP method used with voice_fallback_url
-   */
-  "voiceFallbackMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberTollFree.VoiceFallbackMethodEnum;
-  /**
-   * The URL we call when an error occurs in TwiML
-   */
-  "voiceFallbackUrl"?: string | null;
-  /**
-   * The HTTP method used with the voice_url
-   */
-  "voiceMethod"?: ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberTollFree.VoiceMethodEnum;
-  /**
-   * The URL we call when the phone number receives a call
-   */
-  "voiceUrl"?: string | null;
-  "emergencyStatus"?: IncomingPhoneNumberTollFreeEmergencyStatus;
-  /**
-   * The emergency address configuration to use for emergency calling
-   */
-  "emergencyAddressSid"?: string | null;
-  "emergencyAddressStatus"?: IncomingPhoneNumberTollFreeEmergencyAddressStatus;
-  /**
-   * The SID of the Bundle resource associated with number
-   */
-  "bundleSid"?: string | null;
-  "status"?: string | null;
 }
 
 type IncomingPhoneNumberTollFreeAddressRequirement =
@@ -621,21 +501,81 @@ export function TollFreeListInstance(
 
   return instance;
 }
+export type TollFreeSmsFallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type TollFreeSmsMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type TollFreeStatusCallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type TollFreeVoiceFallbackMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
+export type TollFreeVoiceMethod =
+  | "HEAD"
+  | "GET"
+  | "POST"
+  | "PATCH"
+  | "PUT"
+  | "DELETE";
 
 interface TollFreePayload
   extends TollFreeResource,
     Page.TwilioResponsePayload {}
 
 interface TollFreeResource {
-  incoming_phone_numbers?: Array<ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberTollFree>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  address_sid?: string | null;
+  address_requirements?: IncomingPhoneNumberTollFreeAddressRequirement;
+  api_version?: string | null;
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
+  date_created?: string | null;
+  date_updated?: string | null;
+  friendly_name?: string | null;
+  identity_sid?: string | null;
+  phone_number?: string | null;
+  origin?: string | null;
+  sid?: string | null;
+  sms_application_sid?: string | null;
+  sms_fallback_method?: TollFreeSmsFallbackMethod;
+  sms_fallback_url?: string | null;
+  sms_method?: TollFreeSmsMethod;
+  sms_url?: string | null;
+  status_callback?: string | null;
+  status_callback_method?: TollFreeStatusCallbackMethod;
+  trunk_sid?: string | null;
+  uri?: string | null;
+  voice_receive_mode?: IncomingPhoneNumberTollFreeVoiceReceiveMode;
+  voice_application_sid?: string | null;
+  voice_caller_id_lookup?: boolean | null;
+  voice_fallback_method?: TollFreeVoiceFallbackMethod;
+  voice_fallback_url?: string | null;
+  voice_method?: TollFreeVoiceMethod;
+  voice_url?: string | null;
+  emergency_status?: IncomingPhoneNumberTollFreeEmergencyStatus;
+  emergency_address_sid?: string | null;
+  emergency_address_status?: IncomingPhoneNumberTollFreeEmergencyAddressStatus;
+  bundle_sid?: string | null;
+  status?: string | null;
 }
 
 export class TollFreeInstance {
@@ -644,26 +584,160 @@ export class TollFreeInstance {
     payload: TollFreePayload,
     accountSid?: string
   ) {
-    this.incomingPhoneNumbers = payload.incoming_phone_numbers;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.addressSid = payload.address_sid;
+    this.addressRequirements = payload.address_requirements;
+    this.apiVersion = payload.api_version;
+    this.beta = payload.beta;
+    this.capabilities = payload.capabilities;
+    this.dateCreated = deserialize.rfc2822DateTime(payload.date_created);
+    this.dateUpdated = deserialize.rfc2822DateTime(payload.date_updated);
+    this.friendlyName = payload.friendly_name;
+    this.identitySid = payload.identity_sid;
+    this.phoneNumber = payload.phone_number;
+    this.origin = payload.origin;
+    this.sid = payload.sid;
+    this.smsApplicationSid = payload.sms_application_sid;
+    this.smsFallbackMethod = payload.sms_fallback_method;
+    this.smsFallbackUrl = payload.sms_fallback_url;
+    this.smsMethod = payload.sms_method;
+    this.smsUrl = payload.sms_url;
+    this.statusCallback = payload.status_callback;
+    this.statusCallbackMethod = payload.status_callback_method;
+    this.trunkSid = payload.trunk_sid;
     this.uri = payload.uri;
+    this.voiceReceiveMode = payload.voice_receive_mode;
+    this.voiceApplicationSid = payload.voice_application_sid;
+    this.voiceCallerIdLookup = payload.voice_caller_id_lookup;
+    this.voiceFallbackMethod = payload.voice_fallback_method;
+    this.voiceFallbackUrl = payload.voice_fallback_url;
+    this.voiceMethod = payload.voice_method;
+    this.voiceUrl = payload.voice_url;
+    this.emergencyStatus = payload.emergency_status;
+    this.emergencyAddressSid = payload.emergency_address_sid;
+    this.emergencyAddressStatus = payload.emergency_address_status;
+    this.bundleSid = payload.bundle_sid;
+    this.status = payload.status;
   }
 
-  incomingPhoneNumbers?: Array<ApiV2010AccountIncomingPhoneNumberIncomingPhoneNumberTollFree>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account that created the resource
+   */
+  accountSid?: string | null;
+  /**
+   * The SID of the Address resource associated with the phone number
+   */
+  addressSid?: string | null;
+  addressRequirements?: IncomingPhoneNumberTollFreeAddressRequirement;
+  /**
+   * The API version used to start a new TwiML session
+   */
+  apiVersion?: string | null;
+  /**
+   * Whether the phone number is new to the Twilio platform
+   */
+  beta?: boolean | null;
+  capabilities?: PhoneNumberCapabilities | null;
+  /**
+   * The RFC 2822 date and time in GMT that the resource was created
+   */
+  dateCreated?: string | null;
+  /**
+   * The RFC 2822 date and time in GMT that the resource was last updated
+   */
+  dateUpdated?: string | null;
+  /**
+   * The string that you assigned to describe the resource
+   */
+  friendlyName?: string | null;
+  /**
+   * The SID of the Identity resource associated with number
+   */
+  identitySid?: string | null;
+  /**
+   * The phone number in E.164 format
+   */
+  phoneNumber?: string | null;
+  /**
+   * The phone number\'s origin. Can be twilio or hosted.
+   */
+  origin?: string | null;
+  /**
+   * The unique string that identifies the resource
+   */
+  sid?: string | null;
+  /**
+   * The SID of the application that handles SMS messages sent to the phone number
+   */
+  smsApplicationSid?: string | null;
+  /**
+   * The HTTP method used with sms_fallback_url
+   */
+  smsFallbackMethod?: TollFreeSmsFallbackMethod;
+  /**
+   * The URL that we call when an error occurs while retrieving or executing the TwiML
+   */
+  smsFallbackUrl?: string | null;
+  /**
+   * The HTTP method to use with sms_url
+   */
+  smsMethod?: TollFreeSmsMethod;
+  /**
+   * The URL we call when the phone number receives an incoming SMS message
+   */
+  smsUrl?: string | null;
+  /**
+   * The URL to send status information to your application
+   */
+  statusCallback?: string | null;
+  /**
+   * The HTTP method we use to call status_callback
+   */
+  statusCallbackMethod?: TollFreeStatusCallbackMethod;
+  /**
+   * The SID of the Trunk that handles calls to the phone number
+   */
+  trunkSid?: string | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  voiceReceiveMode?: IncomingPhoneNumberTollFreeVoiceReceiveMode;
+  /**
+   * The SID of the application that handles calls to the phone number
+   */
+  voiceApplicationSid?: string | null;
+  /**
+   * Whether to lookup the caller\'s name
+   */
+  voiceCallerIdLookup?: boolean | null;
+  /**
+   * The HTTP method used with voice_fallback_url
+   */
+  voiceFallbackMethod?: TollFreeVoiceFallbackMethod;
+  /**
+   * The URL we call when an error occurs in TwiML
+   */
+  voiceFallbackUrl?: string | null;
+  /**
+   * The HTTP method used with the voice_url
+   */
+  voiceMethod?: TollFreeVoiceMethod;
+  /**
+   * The URL we call when the phone number receives a call
+   */
+  voiceUrl?: string | null;
+  emergencyStatus?: IncomingPhoneNumberTollFreeEmergencyStatus;
+  /**
+   * The emergency address configuration to use for emergency calling
+   */
+  emergencyAddressSid?: string | null;
+  emergencyAddressStatus?: IncomingPhoneNumberTollFreeEmergencyAddressStatus;
+  /**
+   * The SID of the Bundle resource associated with number
+   */
+  bundleSid?: string | null;
+  status?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -672,15 +746,40 @@ export class TollFreeInstance {
    */
   toJSON() {
     return {
-      incomingPhoneNumbers: this.incomingPhoneNumbers,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      addressSid: this.addressSid,
+      addressRequirements: this.addressRequirements,
+      apiVersion: this.apiVersion,
+      beta: this.beta,
+      capabilities: this.capabilities,
+      dateCreated: this.dateCreated,
+      dateUpdated: this.dateUpdated,
+      friendlyName: this.friendlyName,
+      identitySid: this.identitySid,
+      phoneNumber: this.phoneNumber,
+      origin: this.origin,
+      sid: this.sid,
+      smsApplicationSid: this.smsApplicationSid,
+      smsFallbackMethod: this.smsFallbackMethod,
+      smsFallbackUrl: this.smsFallbackUrl,
+      smsMethod: this.smsMethod,
+      smsUrl: this.smsUrl,
+      statusCallback: this.statusCallback,
+      statusCallbackMethod: this.statusCallbackMethod,
+      trunkSid: this.trunkSid,
       uri: this.uri,
+      voiceReceiveMode: this.voiceReceiveMode,
+      voiceApplicationSid: this.voiceApplicationSid,
+      voiceCallerIdLookup: this.voiceCallerIdLookup,
+      voiceFallbackMethod: this.voiceFallbackMethod,
+      voiceFallbackUrl: this.voiceFallbackUrl,
+      voiceMethod: this.voiceMethod,
+      voiceUrl: this.voiceUrl,
+      emergencyStatus: this.emergencyStatus,
+      emergencyAddressSid: this.emergencyAddressSid,
+      emergencyAddressStatus: this.emergencyAddressStatus,
+      bundleSid: this.bundleSid,
+      status: this.status,
     };
   }
 

--- a/lib/rest/api/v2010/account/usage/record.ts
+++ b/lib/rest/api/v2010/account/usage/record.ts
@@ -27,66 +27,6 @@ import { TodayListInstance } from "./record/today";
 import { YearlyListInstance } from "./record/yearly";
 import { YesterdayListInstance } from "./record/yesterday";
 
-export class ApiV2010AccountUsageUsageRecord {
-  /**
-   * The SID of the Account accrued the usage
-   */
-  "accountSid"?: string | null;
-  /**
-   * The API version used to create the resource
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Usage records up to date as of this timestamp
-   */
-  "asOf"?: string | null;
-  "category"?: UsageRecordEnumCategory;
-  /**
-   * The number of usage events
-   */
-  "count"?: string | null;
-  /**
-   * The units in which count is measured
-   */
-  "countUnit"?: string | null;
-  /**
-   * A plain-language description of the usage category
-   */
-  "description"?: string | null;
-  /**
-   * The last date for which usage is included in the UsageRecord
-   */
-  "endDate"?: string | null;
-  /**
-   * The total price of the usage
-   */
-  "price"?: number | null;
-  /**
-   * The currency in which `price` is measured
-   */
-  "priceUnit"?: string | null;
-  /**
-   * The first date for which usage is included in this UsageRecord
-   */
-  "startDate"?: string | null;
-  /**
-   * A list of related resources identified by their relative URIs
-   */
-  "subresourceUris"?: object | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  /**
-   * The amount of usage
-   */
-  "usage"?: string | null;
-  /**
-   * The units in which usage is measured
-   */
-  "usageUnit"?: string | null;
-}
-
 type UsageRecordCategory =
   | "a2p-registration-fees"
   | "agent-conference"
@@ -753,15 +693,21 @@ export function RecordListInstance(
 interface RecordPayload extends RecordResource, Page.TwilioResponsePayload {}
 
 interface RecordResource {
-  usage_records?: Array<ApiV2010AccountUsageUsageRecord>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  api_version?: string | null;
+  as_of?: string | null;
+  category?: UsageRecordCategory;
+  count?: string | null;
+  count_unit?: string | null;
+  description?: string | null;
+  end_date?: Date | null;
+  price?: number | null;
+  price_unit?: string | null;
+  start_date?: Date | null;
+  subresource_uris?: object | null;
+  uri?: string | null;
+  usage?: string | null;
+  usage_unit?: string | null;
 }
 
 export class RecordInstance {
@@ -770,26 +716,80 @@ export class RecordInstance {
     payload: RecordPayload,
     accountSid?: string
   ) {
-    this.usageRecords = payload.usage_records;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.apiVersion = payload.api_version;
+    this.asOf = payload.as_of;
+    this.category = payload.category;
+    this.count = payload.count;
+    this.countUnit = payload.count_unit;
+    this.description = payload.description;
+    this.endDate = deserialize.iso8601Date(payload.end_date);
+    this.price = payload.price;
+    this.priceUnit = payload.price_unit;
+    this.startDate = deserialize.iso8601Date(payload.start_date);
+    this.subresourceUris = payload.subresource_uris;
     this.uri = payload.uri;
+    this.usage = payload.usage;
+    this.usageUnit = payload.usage_unit;
   }
 
-  usageRecords?: Array<ApiV2010AccountUsageUsageRecord>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account accrued the usage
+   */
+  accountSid?: string | null;
+  /**
+   * The API version used to create the resource
+   */
+  apiVersion?: string | null;
+  /**
+   * Usage records up to date as of this timestamp
+   */
+  asOf?: string | null;
+  category?: UsageRecordCategory;
+  /**
+   * The number of usage events
+   */
+  count?: string | null;
+  /**
+   * The units in which count is measured
+   */
+  countUnit?: string | null;
+  /**
+   * A plain-language description of the usage category
+   */
+  description?: string | null;
+  /**
+   * The last date for which usage is included in the UsageRecord
+   */
+  endDate?: Date | null;
+  /**
+   * The total price of the usage
+   */
+  price?: number | null;
+  /**
+   * The currency in which `price` is measured
+   */
+  priceUnit?: string | null;
+  /**
+   * The first date for which usage is included in this UsageRecord
+   */
+  startDate?: Date | null;
+  /**
+   * A list of related resources identified by their relative URIs
+   */
+  subresourceUris?: object | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  /**
+   * The amount of usage
+   */
+  usage?: string | null;
+  /**
+   * The units in which usage is measured
+   */
+  usageUnit?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -798,15 +798,21 @@ export class RecordInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      apiVersion: this.apiVersion,
+      asOf: this.asOf,
+      category: this.category,
+      count: this.count,
+      countUnit: this.countUnit,
+      description: this.description,
+      endDate: this.endDate,
+      price: this.price,
+      priceUnit: this.priceUnit,
+      startDate: this.startDate,
+      subresourceUris: this.subresourceUris,
       uri: this.uri,
+      usage: this.usage,
+      usageUnit: this.usageUnit,
     };
   }
 

--- a/lib/rest/api/v2010/account/usage/record/allTime.ts
+++ b/lib/rest/api/v2010/account/usage/record/allTime.ts
@@ -19,66 +19,6 @@ import V2010 from "../../../../V2010";
 const deserialize = require("../../../../../../base/deserialize");
 const serialize = require("../../../../../../base/serialize");
 
-export class ApiV2010AccountUsageUsageRecordUsageRecordAllTime {
-  /**
-   * The SID of the Account accrued the usage
-   */
-  "accountSid"?: string | null;
-  /**
-   * The API version used to create the resource
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Usage records up to date as of this timestamp
-   */
-  "asOf"?: string | null;
-  "category"?: UsageRecordAllTimeEnumCategory;
-  /**
-   * The number of usage events
-   */
-  "count"?: string | null;
-  /**
-   * The units in which count is measured
-   */
-  "countUnit"?: string | null;
-  /**
-   * A plain-language description of the usage category
-   */
-  "description"?: string | null;
-  /**
-   * The last date for which usage is included in the UsageRecord
-   */
-  "endDate"?: string | null;
-  /**
-   * The total price of the usage
-   */
-  "price"?: number | null;
-  /**
-   * The currency in which `price` is measured
-   */
-  "priceUnit"?: string | null;
-  /**
-   * The first date for which usage is included in this UsageRecord
-   */
-  "startDate"?: string | null;
-  /**
-   * A list of related resources identified by their relative URIs
-   */
-  "subresourceUris"?: object | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  /**
-   * The amount of usage
-   */
-  "usage"?: string | null;
-  /**
-   * The units in which usage is measured
-   */
-  "usageUnit"?: string | null;
-}
-
 type UsageRecordAllTimeCategory =
   | "a2p-registration-fees"
   | "agent-conference"
@@ -631,15 +571,21 @@ export function AllTimeListInstance(
 interface AllTimePayload extends AllTimeResource, Page.TwilioResponsePayload {}
 
 interface AllTimeResource {
-  usage_records?: Array<ApiV2010AccountUsageUsageRecordUsageRecordAllTime>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  api_version?: string | null;
+  as_of?: string | null;
+  category?: UsageRecordAllTimeCategory;
+  count?: string | null;
+  count_unit?: string | null;
+  description?: string | null;
+  end_date?: Date | null;
+  price?: number | null;
+  price_unit?: string | null;
+  start_date?: Date | null;
+  subresource_uris?: object | null;
+  uri?: string | null;
+  usage?: string | null;
+  usage_unit?: string | null;
 }
 
 export class AllTimeInstance {
@@ -648,26 +594,80 @@ export class AllTimeInstance {
     payload: AllTimePayload,
     accountSid?: string
   ) {
-    this.usageRecords = payload.usage_records;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.apiVersion = payload.api_version;
+    this.asOf = payload.as_of;
+    this.category = payload.category;
+    this.count = payload.count;
+    this.countUnit = payload.count_unit;
+    this.description = payload.description;
+    this.endDate = deserialize.iso8601Date(payload.end_date);
+    this.price = payload.price;
+    this.priceUnit = payload.price_unit;
+    this.startDate = deserialize.iso8601Date(payload.start_date);
+    this.subresourceUris = payload.subresource_uris;
     this.uri = payload.uri;
+    this.usage = payload.usage;
+    this.usageUnit = payload.usage_unit;
   }
 
-  usageRecords?: Array<ApiV2010AccountUsageUsageRecordUsageRecordAllTime>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account accrued the usage
+   */
+  accountSid?: string | null;
+  /**
+   * The API version used to create the resource
+   */
+  apiVersion?: string | null;
+  /**
+   * Usage records up to date as of this timestamp
+   */
+  asOf?: string | null;
+  category?: UsageRecordAllTimeCategory;
+  /**
+   * The number of usage events
+   */
+  count?: string | null;
+  /**
+   * The units in which count is measured
+   */
+  countUnit?: string | null;
+  /**
+   * A plain-language description of the usage category
+   */
+  description?: string | null;
+  /**
+   * The last date for which usage is included in the UsageRecord
+   */
+  endDate?: Date | null;
+  /**
+   * The total price of the usage
+   */
+  price?: number | null;
+  /**
+   * The currency in which `price` is measured
+   */
+  priceUnit?: string | null;
+  /**
+   * The first date for which usage is included in this UsageRecord
+   */
+  startDate?: Date | null;
+  /**
+   * A list of related resources identified by their relative URIs
+   */
+  subresourceUris?: object | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  /**
+   * The amount of usage
+   */
+  usage?: string | null;
+  /**
+   * The units in which usage is measured
+   */
+  usageUnit?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -676,15 +676,21 @@ export class AllTimeInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      apiVersion: this.apiVersion,
+      asOf: this.asOf,
+      category: this.category,
+      count: this.count,
+      countUnit: this.countUnit,
+      description: this.description,
+      endDate: this.endDate,
+      price: this.price,
+      priceUnit: this.priceUnit,
+      startDate: this.startDate,
+      subresourceUris: this.subresourceUris,
       uri: this.uri,
+      usage: this.usage,
+      usageUnit: this.usageUnit,
     };
   }
 

--- a/lib/rest/api/v2010/account/usage/record/daily.ts
+++ b/lib/rest/api/v2010/account/usage/record/daily.ts
@@ -19,66 +19,6 @@ import V2010 from "../../../../V2010";
 const deserialize = require("../../../../../../base/deserialize");
 const serialize = require("../../../../../../base/serialize");
 
-export class ApiV2010AccountUsageUsageRecordUsageRecordDaily {
-  /**
-   * The SID of the Account accrued the usage
-   */
-  "accountSid"?: string | null;
-  /**
-   * The API version used to create the resource
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Usage records up to date as of this timestamp
-   */
-  "asOf"?: string | null;
-  "category"?: UsageRecordDailyEnumCategory;
-  /**
-   * The number of usage events
-   */
-  "count"?: string | null;
-  /**
-   * The units in which count is measured
-   */
-  "countUnit"?: string | null;
-  /**
-   * A plain-language description of the usage category
-   */
-  "description"?: string | null;
-  /**
-   * The last date for which usage is included in the UsageRecord
-   */
-  "endDate"?: string | null;
-  /**
-   * The total price of the usage
-   */
-  "price"?: number | null;
-  /**
-   * The currency in which `price` is measured
-   */
-  "priceUnit"?: string | null;
-  /**
-   * The first date for which usage is included in this UsageRecord
-   */
-  "startDate"?: string | null;
-  /**
-   * A list of related resources identified by their relative URIs
-   */
-  "subresourceUris"?: object | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  /**
-   * The amount of usage
-   */
-  "usage"?: string | null;
-  /**
-   * The units in which usage is measured
-   */
-  "usageUnit"?: string | null;
-}
-
 type UsageRecordDailyCategory =
   | "a2p-registration-fees"
   | "agent-conference"
@@ -631,15 +571,21 @@ export function DailyListInstance(
 interface DailyPayload extends DailyResource, Page.TwilioResponsePayload {}
 
 interface DailyResource {
-  usage_records?: Array<ApiV2010AccountUsageUsageRecordUsageRecordDaily>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  api_version?: string | null;
+  as_of?: string | null;
+  category?: UsageRecordDailyCategory;
+  count?: string | null;
+  count_unit?: string | null;
+  description?: string | null;
+  end_date?: Date | null;
+  price?: number | null;
+  price_unit?: string | null;
+  start_date?: Date | null;
+  subresource_uris?: object | null;
+  uri?: string | null;
+  usage?: string | null;
+  usage_unit?: string | null;
 }
 
 export class DailyInstance {
@@ -648,26 +594,80 @@ export class DailyInstance {
     payload: DailyPayload,
     accountSid?: string
   ) {
-    this.usageRecords = payload.usage_records;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.apiVersion = payload.api_version;
+    this.asOf = payload.as_of;
+    this.category = payload.category;
+    this.count = payload.count;
+    this.countUnit = payload.count_unit;
+    this.description = payload.description;
+    this.endDate = deserialize.iso8601Date(payload.end_date);
+    this.price = payload.price;
+    this.priceUnit = payload.price_unit;
+    this.startDate = deserialize.iso8601Date(payload.start_date);
+    this.subresourceUris = payload.subresource_uris;
     this.uri = payload.uri;
+    this.usage = payload.usage;
+    this.usageUnit = payload.usage_unit;
   }
 
-  usageRecords?: Array<ApiV2010AccountUsageUsageRecordUsageRecordDaily>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account accrued the usage
+   */
+  accountSid?: string | null;
+  /**
+   * The API version used to create the resource
+   */
+  apiVersion?: string | null;
+  /**
+   * Usage records up to date as of this timestamp
+   */
+  asOf?: string | null;
+  category?: UsageRecordDailyCategory;
+  /**
+   * The number of usage events
+   */
+  count?: string | null;
+  /**
+   * The units in which count is measured
+   */
+  countUnit?: string | null;
+  /**
+   * A plain-language description of the usage category
+   */
+  description?: string | null;
+  /**
+   * The last date for which usage is included in the UsageRecord
+   */
+  endDate?: Date | null;
+  /**
+   * The total price of the usage
+   */
+  price?: number | null;
+  /**
+   * The currency in which `price` is measured
+   */
+  priceUnit?: string | null;
+  /**
+   * The first date for which usage is included in this UsageRecord
+   */
+  startDate?: Date | null;
+  /**
+   * A list of related resources identified by their relative URIs
+   */
+  subresourceUris?: object | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  /**
+   * The amount of usage
+   */
+  usage?: string | null;
+  /**
+   * The units in which usage is measured
+   */
+  usageUnit?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -676,15 +676,21 @@ export class DailyInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      apiVersion: this.apiVersion,
+      asOf: this.asOf,
+      category: this.category,
+      count: this.count,
+      countUnit: this.countUnit,
+      description: this.description,
+      endDate: this.endDate,
+      price: this.price,
+      priceUnit: this.priceUnit,
+      startDate: this.startDate,
+      subresourceUris: this.subresourceUris,
       uri: this.uri,
+      usage: this.usage,
+      usageUnit: this.usageUnit,
     };
   }
 

--- a/lib/rest/api/v2010/account/usage/record/lastMonth.ts
+++ b/lib/rest/api/v2010/account/usage/record/lastMonth.ts
@@ -19,66 +19,6 @@ import V2010 from "../../../../V2010";
 const deserialize = require("../../../../../../base/deserialize");
 const serialize = require("../../../../../../base/serialize");
 
-export class ApiV2010AccountUsageUsageRecordUsageRecordLastMonth {
-  /**
-   * The SID of the Account accrued the usage
-   */
-  "accountSid"?: string | null;
-  /**
-   * The API version used to create the resource
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Usage records up to date as of this timestamp
-   */
-  "asOf"?: string | null;
-  "category"?: UsageRecordLastMonthEnumCategory;
-  /**
-   * The number of usage events
-   */
-  "count"?: string | null;
-  /**
-   * The units in which count is measured
-   */
-  "countUnit"?: string | null;
-  /**
-   * A plain-language description of the usage category
-   */
-  "description"?: string | null;
-  /**
-   * The last date for which usage is included in the UsageRecord
-   */
-  "endDate"?: string | null;
-  /**
-   * The total price of the usage
-   */
-  "price"?: number | null;
-  /**
-   * The currency in which `price` is measured
-   */
-  "priceUnit"?: string | null;
-  /**
-   * The first date for which usage is included in this UsageRecord
-   */
-  "startDate"?: string | null;
-  /**
-   * A list of related resources identified by their relative URIs
-   */
-  "subresourceUris"?: object | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  /**
-   * The amount of usage
-   */
-  "usage"?: string | null;
-  /**
-   * The units in which usage is measured
-   */
-  "usageUnit"?: string | null;
-}
-
 type UsageRecordLastMonthCategory =
   | "a2p-registration-fees"
   | "agent-conference"
@@ -633,15 +573,21 @@ interface LastMonthPayload
     Page.TwilioResponsePayload {}
 
 interface LastMonthResource {
-  usage_records?: Array<ApiV2010AccountUsageUsageRecordUsageRecordLastMonth>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  api_version?: string | null;
+  as_of?: string | null;
+  category?: UsageRecordLastMonthCategory;
+  count?: string | null;
+  count_unit?: string | null;
+  description?: string | null;
+  end_date?: Date | null;
+  price?: number | null;
+  price_unit?: string | null;
+  start_date?: Date | null;
+  subresource_uris?: object | null;
+  uri?: string | null;
+  usage?: string | null;
+  usage_unit?: string | null;
 }
 
 export class LastMonthInstance {
@@ -650,26 +596,80 @@ export class LastMonthInstance {
     payload: LastMonthPayload,
     accountSid?: string
   ) {
-    this.usageRecords = payload.usage_records;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.apiVersion = payload.api_version;
+    this.asOf = payload.as_of;
+    this.category = payload.category;
+    this.count = payload.count;
+    this.countUnit = payload.count_unit;
+    this.description = payload.description;
+    this.endDate = deserialize.iso8601Date(payload.end_date);
+    this.price = payload.price;
+    this.priceUnit = payload.price_unit;
+    this.startDate = deserialize.iso8601Date(payload.start_date);
+    this.subresourceUris = payload.subresource_uris;
     this.uri = payload.uri;
+    this.usage = payload.usage;
+    this.usageUnit = payload.usage_unit;
   }
 
-  usageRecords?: Array<ApiV2010AccountUsageUsageRecordUsageRecordLastMonth>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account accrued the usage
+   */
+  accountSid?: string | null;
+  /**
+   * The API version used to create the resource
+   */
+  apiVersion?: string | null;
+  /**
+   * Usage records up to date as of this timestamp
+   */
+  asOf?: string | null;
+  category?: UsageRecordLastMonthCategory;
+  /**
+   * The number of usage events
+   */
+  count?: string | null;
+  /**
+   * The units in which count is measured
+   */
+  countUnit?: string | null;
+  /**
+   * A plain-language description of the usage category
+   */
+  description?: string | null;
+  /**
+   * The last date for which usage is included in the UsageRecord
+   */
+  endDate?: Date | null;
+  /**
+   * The total price of the usage
+   */
+  price?: number | null;
+  /**
+   * The currency in which `price` is measured
+   */
+  priceUnit?: string | null;
+  /**
+   * The first date for which usage is included in this UsageRecord
+   */
+  startDate?: Date | null;
+  /**
+   * A list of related resources identified by their relative URIs
+   */
+  subresourceUris?: object | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  /**
+   * The amount of usage
+   */
+  usage?: string | null;
+  /**
+   * The units in which usage is measured
+   */
+  usageUnit?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -678,15 +678,21 @@ export class LastMonthInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      apiVersion: this.apiVersion,
+      asOf: this.asOf,
+      category: this.category,
+      count: this.count,
+      countUnit: this.countUnit,
+      description: this.description,
+      endDate: this.endDate,
+      price: this.price,
+      priceUnit: this.priceUnit,
+      startDate: this.startDate,
+      subresourceUris: this.subresourceUris,
       uri: this.uri,
+      usage: this.usage,
+      usageUnit: this.usageUnit,
     };
   }
 

--- a/lib/rest/api/v2010/account/usage/record/monthly.ts
+++ b/lib/rest/api/v2010/account/usage/record/monthly.ts
@@ -19,66 +19,6 @@ import V2010 from "../../../../V2010";
 const deserialize = require("../../../../../../base/deserialize");
 const serialize = require("../../../../../../base/serialize");
 
-export class ApiV2010AccountUsageUsageRecordUsageRecordMonthly {
-  /**
-   * The SID of the Account accrued the usage
-   */
-  "accountSid"?: string | null;
-  /**
-   * The API version used to create the resource
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Usage records up to date as of this timestamp
-   */
-  "asOf"?: string | null;
-  "category"?: UsageRecordMonthlyEnumCategory;
-  /**
-   * The number of usage events
-   */
-  "count"?: string | null;
-  /**
-   * The units in which count is measured
-   */
-  "countUnit"?: string | null;
-  /**
-   * A plain-language description of the usage category
-   */
-  "description"?: string | null;
-  /**
-   * The last date for which usage is included in the UsageRecord
-   */
-  "endDate"?: string | null;
-  /**
-   * The total price of the usage
-   */
-  "price"?: number | null;
-  /**
-   * The currency in which `price` is measured
-   */
-  "priceUnit"?: string | null;
-  /**
-   * The first date for which usage is included in this UsageRecord
-   */
-  "startDate"?: string | null;
-  /**
-   * A list of related resources identified by their relative URIs
-   */
-  "subresourceUris"?: object | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  /**
-   * The amount of usage
-   */
-  "usage"?: string | null;
-  /**
-   * The units in which usage is measured
-   */
-  "usageUnit"?: string | null;
-}
-
 type UsageRecordMonthlyCategory =
   | "a2p-registration-fees"
   | "agent-conference"
@@ -631,15 +571,21 @@ export function MonthlyListInstance(
 interface MonthlyPayload extends MonthlyResource, Page.TwilioResponsePayload {}
 
 interface MonthlyResource {
-  usage_records?: Array<ApiV2010AccountUsageUsageRecordUsageRecordMonthly>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  api_version?: string | null;
+  as_of?: string | null;
+  category?: UsageRecordMonthlyCategory;
+  count?: string | null;
+  count_unit?: string | null;
+  description?: string | null;
+  end_date?: Date | null;
+  price?: number | null;
+  price_unit?: string | null;
+  start_date?: Date | null;
+  subresource_uris?: object | null;
+  uri?: string | null;
+  usage?: string | null;
+  usage_unit?: string | null;
 }
 
 export class MonthlyInstance {
@@ -648,26 +594,80 @@ export class MonthlyInstance {
     payload: MonthlyPayload,
     accountSid?: string
   ) {
-    this.usageRecords = payload.usage_records;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.apiVersion = payload.api_version;
+    this.asOf = payload.as_of;
+    this.category = payload.category;
+    this.count = payload.count;
+    this.countUnit = payload.count_unit;
+    this.description = payload.description;
+    this.endDate = deserialize.iso8601Date(payload.end_date);
+    this.price = payload.price;
+    this.priceUnit = payload.price_unit;
+    this.startDate = deserialize.iso8601Date(payload.start_date);
+    this.subresourceUris = payload.subresource_uris;
     this.uri = payload.uri;
+    this.usage = payload.usage;
+    this.usageUnit = payload.usage_unit;
   }
 
-  usageRecords?: Array<ApiV2010AccountUsageUsageRecordUsageRecordMonthly>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account accrued the usage
+   */
+  accountSid?: string | null;
+  /**
+   * The API version used to create the resource
+   */
+  apiVersion?: string | null;
+  /**
+   * Usage records up to date as of this timestamp
+   */
+  asOf?: string | null;
+  category?: UsageRecordMonthlyCategory;
+  /**
+   * The number of usage events
+   */
+  count?: string | null;
+  /**
+   * The units in which count is measured
+   */
+  countUnit?: string | null;
+  /**
+   * A plain-language description of the usage category
+   */
+  description?: string | null;
+  /**
+   * The last date for which usage is included in the UsageRecord
+   */
+  endDate?: Date | null;
+  /**
+   * The total price of the usage
+   */
+  price?: number | null;
+  /**
+   * The currency in which `price` is measured
+   */
+  priceUnit?: string | null;
+  /**
+   * The first date for which usage is included in this UsageRecord
+   */
+  startDate?: Date | null;
+  /**
+   * A list of related resources identified by their relative URIs
+   */
+  subresourceUris?: object | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  /**
+   * The amount of usage
+   */
+  usage?: string | null;
+  /**
+   * The units in which usage is measured
+   */
+  usageUnit?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -676,15 +676,21 @@ export class MonthlyInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      apiVersion: this.apiVersion,
+      asOf: this.asOf,
+      category: this.category,
+      count: this.count,
+      countUnit: this.countUnit,
+      description: this.description,
+      endDate: this.endDate,
+      price: this.price,
+      priceUnit: this.priceUnit,
+      startDate: this.startDate,
+      subresourceUris: this.subresourceUris,
       uri: this.uri,
+      usage: this.usage,
+      usageUnit: this.usageUnit,
     };
   }
 

--- a/lib/rest/api/v2010/account/usage/record/thisMonth.ts
+++ b/lib/rest/api/v2010/account/usage/record/thisMonth.ts
@@ -19,66 +19,6 @@ import V2010 from "../../../../V2010";
 const deserialize = require("../../../../../../base/deserialize");
 const serialize = require("../../../../../../base/serialize");
 
-export class ApiV2010AccountUsageUsageRecordUsageRecordThisMonth {
-  /**
-   * The SID of the Account accrued the usage
-   */
-  "accountSid"?: string | null;
-  /**
-   * The API version used to create the resource
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Usage records up to date as of this timestamp
-   */
-  "asOf"?: string | null;
-  "category"?: UsageRecordThisMonthEnumCategory;
-  /**
-   * The number of usage events
-   */
-  "count"?: string | null;
-  /**
-   * The units in which count is measured
-   */
-  "countUnit"?: string | null;
-  /**
-   * A plain-language description of the usage category
-   */
-  "description"?: string | null;
-  /**
-   * The last date for which usage is included in the UsageRecord
-   */
-  "endDate"?: string | null;
-  /**
-   * The total price of the usage
-   */
-  "price"?: number | null;
-  /**
-   * The currency in which `price` is measured
-   */
-  "priceUnit"?: string | null;
-  /**
-   * The first date for which usage is included in this UsageRecord
-   */
-  "startDate"?: string | null;
-  /**
-   * A list of related resources identified by their relative URIs
-   */
-  "subresourceUris"?: object | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  /**
-   * The amount of usage
-   */
-  "usage"?: string | null;
-  /**
-   * The units in which usage is measured
-   */
-  "usageUnit"?: string | null;
-}
-
 type UsageRecordThisMonthCategory =
   | "a2p-registration-fees"
   | "agent-conference"
@@ -633,15 +573,21 @@ interface ThisMonthPayload
     Page.TwilioResponsePayload {}
 
 interface ThisMonthResource {
-  usage_records?: Array<ApiV2010AccountUsageUsageRecordUsageRecordThisMonth>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  api_version?: string | null;
+  as_of?: string | null;
+  category?: UsageRecordThisMonthCategory;
+  count?: string | null;
+  count_unit?: string | null;
+  description?: string | null;
+  end_date?: Date | null;
+  price?: number | null;
+  price_unit?: string | null;
+  start_date?: Date | null;
+  subresource_uris?: object | null;
+  uri?: string | null;
+  usage?: string | null;
+  usage_unit?: string | null;
 }
 
 export class ThisMonthInstance {
@@ -650,26 +596,80 @@ export class ThisMonthInstance {
     payload: ThisMonthPayload,
     accountSid?: string
   ) {
-    this.usageRecords = payload.usage_records;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.apiVersion = payload.api_version;
+    this.asOf = payload.as_of;
+    this.category = payload.category;
+    this.count = payload.count;
+    this.countUnit = payload.count_unit;
+    this.description = payload.description;
+    this.endDate = deserialize.iso8601Date(payload.end_date);
+    this.price = payload.price;
+    this.priceUnit = payload.price_unit;
+    this.startDate = deserialize.iso8601Date(payload.start_date);
+    this.subresourceUris = payload.subresource_uris;
     this.uri = payload.uri;
+    this.usage = payload.usage;
+    this.usageUnit = payload.usage_unit;
   }
 
-  usageRecords?: Array<ApiV2010AccountUsageUsageRecordUsageRecordThisMonth>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account accrued the usage
+   */
+  accountSid?: string | null;
+  /**
+   * The API version used to create the resource
+   */
+  apiVersion?: string | null;
+  /**
+   * Usage records up to date as of this timestamp
+   */
+  asOf?: string | null;
+  category?: UsageRecordThisMonthCategory;
+  /**
+   * The number of usage events
+   */
+  count?: string | null;
+  /**
+   * The units in which count is measured
+   */
+  countUnit?: string | null;
+  /**
+   * A plain-language description of the usage category
+   */
+  description?: string | null;
+  /**
+   * The last date for which usage is included in the UsageRecord
+   */
+  endDate?: Date | null;
+  /**
+   * The total price of the usage
+   */
+  price?: number | null;
+  /**
+   * The currency in which `price` is measured
+   */
+  priceUnit?: string | null;
+  /**
+   * The first date for which usage is included in this UsageRecord
+   */
+  startDate?: Date | null;
+  /**
+   * A list of related resources identified by their relative URIs
+   */
+  subresourceUris?: object | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  /**
+   * The amount of usage
+   */
+  usage?: string | null;
+  /**
+   * The units in which usage is measured
+   */
+  usageUnit?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -678,15 +678,21 @@ export class ThisMonthInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      apiVersion: this.apiVersion,
+      asOf: this.asOf,
+      category: this.category,
+      count: this.count,
+      countUnit: this.countUnit,
+      description: this.description,
+      endDate: this.endDate,
+      price: this.price,
+      priceUnit: this.priceUnit,
+      startDate: this.startDate,
+      subresourceUris: this.subresourceUris,
       uri: this.uri,
+      usage: this.usage,
+      usageUnit: this.usageUnit,
     };
   }
 

--- a/lib/rest/api/v2010/account/usage/record/today.ts
+++ b/lib/rest/api/v2010/account/usage/record/today.ts
@@ -19,66 +19,6 @@ import V2010 from "../../../../V2010";
 const deserialize = require("../../../../../../base/deserialize");
 const serialize = require("../../../../../../base/serialize");
 
-export class ApiV2010AccountUsageUsageRecordUsageRecordToday {
-  /**
-   * The SID of the Account accrued the usage
-   */
-  "accountSid"?: string | null;
-  /**
-   * The API version used to create the resource
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Usage records up to date as of this timestamp
-   */
-  "asOf"?: string | null;
-  "category"?: UsageRecordTodayEnumCategory;
-  /**
-   * The number of usage events
-   */
-  "count"?: string | null;
-  /**
-   * The units in which count is measured
-   */
-  "countUnit"?: string | null;
-  /**
-   * A plain-language description of the usage category
-   */
-  "description"?: string | null;
-  /**
-   * The last date for which usage is included in the UsageRecord
-   */
-  "endDate"?: string | null;
-  /**
-   * The total price of the usage
-   */
-  "price"?: number | null;
-  /**
-   * The currency in which `price` is measured
-   */
-  "priceUnit"?: string | null;
-  /**
-   * The first date for which usage is included in this UsageRecord
-   */
-  "startDate"?: string | null;
-  /**
-   * A list of related resources identified by their relative URIs
-   */
-  "subresourceUris"?: object | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  /**
-   * The amount of usage
-   */
-  "usage"?: string | null;
-  /**
-   * The units in which usage is measured
-   */
-  "usageUnit"?: string | null;
-}
-
 type UsageRecordTodayCategory =
   | "a2p-registration-fees"
   | "agent-conference"
@@ -631,15 +571,21 @@ export function TodayListInstance(
 interface TodayPayload extends TodayResource, Page.TwilioResponsePayload {}
 
 interface TodayResource {
-  usage_records?: Array<ApiV2010AccountUsageUsageRecordUsageRecordToday>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  api_version?: string | null;
+  as_of?: string | null;
+  category?: UsageRecordTodayCategory;
+  count?: string | null;
+  count_unit?: string | null;
+  description?: string | null;
+  end_date?: Date | null;
+  price?: number | null;
+  price_unit?: string | null;
+  start_date?: Date | null;
+  subresource_uris?: object | null;
+  uri?: string | null;
+  usage?: string | null;
+  usage_unit?: string | null;
 }
 
 export class TodayInstance {
@@ -648,26 +594,80 @@ export class TodayInstance {
     payload: TodayPayload,
     accountSid?: string
   ) {
-    this.usageRecords = payload.usage_records;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.apiVersion = payload.api_version;
+    this.asOf = payload.as_of;
+    this.category = payload.category;
+    this.count = payload.count;
+    this.countUnit = payload.count_unit;
+    this.description = payload.description;
+    this.endDate = deserialize.iso8601Date(payload.end_date);
+    this.price = payload.price;
+    this.priceUnit = payload.price_unit;
+    this.startDate = deserialize.iso8601Date(payload.start_date);
+    this.subresourceUris = payload.subresource_uris;
     this.uri = payload.uri;
+    this.usage = payload.usage;
+    this.usageUnit = payload.usage_unit;
   }
 
-  usageRecords?: Array<ApiV2010AccountUsageUsageRecordUsageRecordToday>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account accrued the usage
+   */
+  accountSid?: string | null;
+  /**
+   * The API version used to create the resource
+   */
+  apiVersion?: string | null;
+  /**
+   * Usage records up to date as of this timestamp
+   */
+  asOf?: string | null;
+  category?: UsageRecordTodayCategory;
+  /**
+   * The number of usage events
+   */
+  count?: string | null;
+  /**
+   * The units in which count is measured
+   */
+  countUnit?: string | null;
+  /**
+   * A plain-language description of the usage category
+   */
+  description?: string | null;
+  /**
+   * The last date for which usage is included in the UsageRecord
+   */
+  endDate?: Date | null;
+  /**
+   * The total price of the usage
+   */
+  price?: number | null;
+  /**
+   * The currency in which `price` is measured
+   */
+  priceUnit?: string | null;
+  /**
+   * The first date for which usage is included in this UsageRecord
+   */
+  startDate?: Date | null;
+  /**
+   * A list of related resources identified by their relative URIs
+   */
+  subresourceUris?: object | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  /**
+   * The amount of usage
+   */
+  usage?: string | null;
+  /**
+   * The units in which usage is measured
+   */
+  usageUnit?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -676,15 +676,21 @@ export class TodayInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      apiVersion: this.apiVersion,
+      asOf: this.asOf,
+      category: this.category,
+      count: this.count,
+      countUnit: this.countUnit,
+      description: this.description,
+      endDate: this.endDate,
+      price: this.price,
+      priceUnit: this.priceUnit,
+      startDate: this.startDate,
+      subresourceUris: this.subresourceUris,
       uri: this.uri,
+      usage: this.usage,
+      usageUnit: this.usageUnit,
     };
   }
 

--- a/lib/rest/api/v2010/account/usage/record/yearly.ts
+++ b/lib/rest/api/v2010/account/usage/record/yearly.ts
@@ -19,66 +19,6 @@ import V2010 from "../../../../V2010";
 const deserialize = require("../../../../../../base/deserialize");
 const serialize = require("../../../../../../base/serialize");
 
-export class ApiV2010AccountUsageUsageRecordUsageRecordYearly {
-  /**
-   * The SID of the Account accrued the usage
-   */
-  "accountSid"?: string | null;
-  /**
-   * The API version used to create the resource
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Usage records up to date as of this timestamp
-   */
-  "asOf"?: string | null;
-  "category"?: UsageRecordYearlyEnumCategory;
-  /**
-   * The number of usage events
-   */
-  "count"?: string | null;
-  /**
-   * The units in which count is measured
-   */
-  "countUnit"?: string | null;
-  /**
-   * A plain-language description of the usage category
-   */
-  "description"?: string | null;
-  /**
-   * The last date for which usage is included in the UsageRecord
-   */
-  "endDate"?: string | null;
-  /**
-   * The total price of the usage
-   */
-  "price"?: number | null;
-  /**
-   * The currency in which `price` is measured
-   */
-  "priceUnit"?: string | null;
-  /**
-   * The first date for which usage is included in this UsageRecord
-   */
-  "startDate"?: string | null;
-  /**
-   * A list of related resources identified by their relative URIs
-   */
-  "subresourceUris"?: object | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  /**
-   * The amount of usage
-   */
-  "usage"?: string | null;
-  /**
-   * The units in which usage is measured
-   */
-  "usageUnit"?: string | null;
-}
-
 type UsageRecordYearlyCategory =
   | "a2p-registration-fees"
   | "agent-conference"
@@ -631,15 +571,21 @@ export function YearlyListInstance(
 interface YearlyPayload extends YearlyResource, Page.TwilioResponsePayload {}
 
 interface YearlyResource {
-  usage_records?: Array<ApiV2010AccountUsageUsageRecordUsageRecordYearly>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  api_version?: string | null;
+  as_of?: string | null;
+  category?: UsageRecordYearlyCategory;
+  count?: string | null;
+  count_unit?: string | null;
+  description?: string | null;
+  end_date?: Date | null;
+  price?: number | null;
+  price_unit?: string | null;
+  start_date?: Date | null;
+  subresource_uris?: object | null;
+  uri?: string | null;
+  usage?: string | null;
+  usage_unit?: string | null;
 }
 
 export class YearlyInstance {
@@ -648,26 +594,80 @@ export class YearlyInstance {
     payload: YearlyPayload,
     accountSid?: string
   ) {
-    this.usageRecords = payload.usage_records;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.apiVersion = payload.api_version;
+    this.asOf = payload.as_of;
+    this.category = payload.category;
+    this.count = payload.count;
+    this.countUnit = payload.count_unit;
+    this.description = payload.description;
+    this.endDate = deserialize.iso8601Date(payload.end_date);
+    this.price = payload.price;
+    this.priceUnit = payload.price_unit;
+    this.startDate = deserialize.iso8601Date(payload.start_date);
+    this.subresourceUris = payload.subresource_uris;
     this.uri = payload.uri;
+    this.usage = payload.usage;
+    this.usageUnit = payload.usage_unit;
   }
 
-  usageRecords?: Array<ApiV2010AccountUsageUsageRecordUsageRecordYearly>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account accrued the usage
+   */
+  accountSid?: string | null;
+  /**
+   * The API version used to create the resource
+   */
+  apiVersion?: string | null;
+  /**
+   * Usage records up to date as of this timestamp
+   */
+  asOf?: string | null;
+  category?: UsageRecordYearlyCategory;
+  /**
+   * The number of usage events
+   */
+  count?: string | null;
+  /**
+   * The units in which count is measured
+   */
+  countUnit?: string | null;
+  /**
+   * A plain-language description of the usage category
+   */
+  description?: string | null;
+  /**
+   * The last date for which usage is included in the UsageRecord
+   */
+  endDate?: Date | null;
+  /**
+   * The total price of the usage
+   */
+  price?: number | null;
+  /**
+   * The currency in which `price` is measured
+   */
+  priceUnit?: string | null;
+  /**
+   * The first date for which usage is included in this UsageRecord
+   */
+  startDate?: Date | null;
+  /**
+   * A list of related resources identified by their relative URIs
+   */
+  subresourceUris?: object | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  /**
+   * The amount of usage
+   */
+  usage?: string | null;
+  /**
+   * The units in which usage is measured
+   */
+  usageUnit?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -676,15 +676,21 @@ export class YearlyInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      apiVersion: this.apiVersion,
+      asOf: this.asOf,
+      category: this.category,
+      count: this.count,
+      countUnit: this.countUnit,
+      description: this.description,
+      endDate: this.endDate,
+      price: this.price,
+      priceUnit: this.priceUnit,
+      startDate: this.startDate,
+      subresourceUris: this.subresourceUris,
       uri: this.uri,
+      usage: this.usage,
+      usageUnit: this.usageUnit,
     };
   }
 

--- a/lib/rest/api/v2010/account/usage/record/yesterday.ts
+++ b/lib/rest/api/v2010/account/usage/record/yesterday.ts
@@ -19,66 +19,6 @@ import V2010 from "../../../../V2010";
 const deserialize = require("../../../../../../base/deserialize");
 const serialize = require("../../../../../../base/serialize");
 
-export class ApiV2010AccountUsageUsageRecordUsageRecordYesterday {
-  /**
-   * The SID of the Account accrued the usage
-   */
-  "accountSid"?: string | null;
-  /**
-   * The API version used to create the resource
-   */
-  "apiVersion"?: string | null;
-  /**
-   * Usage records up to date as of this timestamp
-   */
-  "asOf"?: string | null;
-  "category"?: UsageRecordYesterdayEnumCategory;
-  /**
-   * The number of usage events
-   */
-  "count"?: string | null;
-  /**
-   * The units in which count is measured
-   */
-  "countUnit"?: string | null;
-  /**
-   * A plain-language description of the usage category
-   */
-  "description"?: string | null;
-  /**
-   * The last date for which usage is included in the UsageRecord
-   */
-  "endDate"?: string | null;
-  /**
-   * The total price of the usage
-   */
-  "price"?: number | null;
-  /**
-   * The currency in which `price` is measured
-   */
-  "priceUnit"?: string | null;
-  /**
-   * The first date for which usage is included in this UsageRecord
-   */
-  "startDate"?: string | null;
-  /**
-   * A list of related resources identified by their relative URIs
-   */
-  "subresourceUris"?: object | null;
-  /**
-   * The URI of the resource, relative to `https://api.twilio.com`
-   */
-  "uri"?: string | null;
-  /**
-   * The amount of usage
-   */
-  "usage"?: string | null;
-  /**
-   * The units in which usage is measured
-   */
-  "usageUnit"?: string | null;
-}
-
 type UsageRecordYesterdayCategory =
   | "a2p-registration-fees"
   | "agent-conference"
@@ -633,15 +573,21 @@ interface YesterdayPayload
     Page.TwilioResponsePayload {}
 
 interface YesterdayResource {
-  usage_records?: Array<ApiV2010AccountUsageUsageRecordUsageRecordYesterday>;
-  end?: number;
-  first_page_uri?: string;
-  next_page_uri?: string;
-  page?: number;
-  page_size?: number;
-  previous_page_uri?: string;
-  start?: number;
-  uri?: string;
+  account_sid?: string | null;
+  api_version?: string | null;
+  as_of?: string | null;
+  category?: UsageRecordYesterdayCategory;
+  count?: string | null;
+  count_unit?: string | null;
+  description?: string | null;
+  end_date?: Date | null;
+  price?: number | null;
+  price_unit?: string | null;
+  start_date?: Date | null;
+  subresource_uris?: object | null;
+  uri?: string | null;
+  usage?: string | null;
+  usage_unit?: string | null;
 }
 
 export class YesterdayInstance {
@@ -650,26 +596,80 @@ export class YesterdayInstance {
     payload: YesterdayPayload,
     accountSid?: string
   ) {
-    this.usageRecords = payload.usage_records;
-    this.end = deserialize.integer(payload.end);
-    this.firstPageUri = payload.first_page_uri;
-    this.nextPageUri = payload.next_page_uri;
-    this.page = deserialize.integer(payload.page);
-    this.pageSize = deserialize.integer(payload.page_size);
-    this.previousPageUri = payload.previous_page_uri;
-    this.start = deserialize.integer(payload.start);
+    this.accountSid = payload.account_sid;
+    this.apiVersion = payload.api_version;
+    this.asOf = payload.as_of;
+    this.category = payload.category;
+    this.count = payload.count;
+    this.countUnit = payload.count_unit;
+    this.description = payload.description;
+    this.endDate = deserialize.iso8601Date(payload.end_date);
+    this.price = payload.price;
+    this.priceUnit = payload.price_unit;
+    this.startDate = deserialize.iso8601Date(payload.start_date);
+    this.subresourceUris = payload.subresource_uris;
     this.uri = payload.uri;
+    this.usage = payload.usage;
+    this.usageUnit = payload.usage_unit;
   }
 
-  usageRecords?: Array<ApiV2010AccountUsageUsageRecordUsageRecordYesterday>;
-  end?: number;
-  firstPageUri?: string;
-  nextPageUri?: string;
-  page?: number;
-  pageSize?: number;
-  previousPageUri?: string;
-  start?: number;
-  uri?: string;
+  /**
+   * The SID of the Account accrued the usage
+   */
+  accountSid?: string | null;
+  /**
+   * The API version used to create the resource
+   */
+  apiVersion?: string | null;
+  /**
+   * Usage records up to date as of this timestamp
+   */
+  asOf?: string | null;
+  category?: UsageRecordYesterdayCategory;
+  /**
+   * The number of usage events
+   */
+  count?: string | null;
+  /**
+   * The units in which count is measured
+   */
+  countUnit?: string | null;
+  /**
+   * A plain-language description of the usage category
+   */
+  description?: string | null;
+  /**
+   * The last date for which usage is included in the UsageRecord
+   */
+  endDate?: Date | null;
+  /**
+   * The total price of the usage
+   */
+  price?: number | null;
+  /**
+   * The currency in which `price` is measured
+   */
+  priceUnit?: string | null;
+  /**
+   * The first date for which usage is included in this UsageRecord
+   */
+  startDate?: Date | null;
+  /**
+   * A list of related resources identified by their relative URIs
+   */
+  subresourceUris?: object | null;
+  /**
+   * The URI of the resource, relative to `https://api.twilio.com`
+   */
+  uri?: string | null;
+  /**
+   * The amount of usage
+   */
+  usage?: string | null;
+  /**
+   * The units in which usage is measured
+   */
+  usageUnit?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -678,15 +678,21 @@ export class YesterdayInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      end: this.end,
-      firstPageUri: this.firstPageUri,
-      nextPageUri: this.nextPageUri,
-      page: this.page,
-      pageSize: this.pageSize,
-      previousPageUri: this.previousPageUri,
-      start: this.start,
+      accountSid: this.accountSid,
+      apiVersion: this.apiVersion,
+      asOf: this.asOf,
+      category: this.category,
+      count: this.count,
+      countUnit: this.countUnit,
+      description: this.description,
+      endDate: this.endDate,
+      price: this.price,
+      priceUnit: this.priceUnit,
+      startDate: this.startDate,
+      subresourceUris: this.subresourceUris,
       uri: this.uri,
+      usage: this.usage,
+      usageUnit: this.usageUnit,
     };
   }
 

--- a/lib/rest/bulkexports/v1/export/exportCustomJob.ts
+++ b/lib/rest/bulkexports/v1/export/exportCustomJob.ts
@@ -19,63 +19,6 @@ import V1 from "../../V1";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
 
-export class BulkexportsV1ExportExportCustomJob {
-  /**
-   * The friendly name specified when creating the job
-   */
-  "friendlyName"?: string | null;
-  /**
-   * The type of communication – Messages, Calls, Conferences, and Participants
-   */
-  "resourceType"?: string | null;
-  /**
-   * The start day for the custom export specified as a string in the format of yyyy-MM-dd
-   */
-  "startDay"?: string | null;
-  /**
-   * The end day for the custom export specified as a string in the format of yyyy-MM-dd. This will be the last day exported. For instance, to export a single day, choose the same day for start and end day. To export the first 4 days of July, you would set the start date to 2020-07-01 and the end date to 2020-07-04. The end date must be the UTC day before yesterday.
-   */
-  "endDay"?: string | null;
-  /**
-   * The optional webhook url called on completion
-   */
-  "webhookUrl"?: string | null;
-  /**
-   * This is the method used to call the webhook
-   */
-  "webhookMethod"?: string | null;
-  /**
-   * The optional email to send the completion notification to
-   */
-  "email"?: string | null;
-  /**
-   * The unique job_sid returned when the custom export was created. This can be used to look up the status of the job.
-   */
-  "jobSid"?: string | null;
-  /**
-   * The details of a job state which is an object that contains a `status` string, a day count integer, and list of days in the job
-   */
-  "details"?: any | null;
-  /**
-   * This is the job position from the 1st in line. Your queue position will never increase. As jobs ahead of yours in the queue are processed, the queue position number will decrease
-   */
-  "jobQueuePosition"?: string | null;
-  /**
-   * this is the time estimated until your job is complete. This is calculated each time you request the job list. The time is calculated based on the current rate of job completion (which may vary) and your job queue position
-   */
-  "estimatedCompletionTime"?: string | null;
-}
-
-export class ListDayResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
 /**
  * Options to pass to create a ExportCustomJobInstance
  *
@@ -458,8 +401,17 @@ interface ExportCustomJobPayload
     Page.TwilioResponsePayload {}
 
 interface ExportCustomJobResource {
-  jobs?: Array<BulkexportsV1ExportExportCustomJob>;
-  meta?: ListDayResponseMeta;
+  friendly_name?: string | null;
+  resource_type?: string | null;
+  start_day?: string | null;
+  end_day?: string | null;
+  webhook_url?: string | null;
+  webhook_method?: string | null;
+  email?: string | null;
+  job_sid?: string | null;
+  details?: any | null;
+  job_queue_position?: string | null;
+  estimated_completion_time?: string | null;
 }
 
 export class ExportCustomJobInstance {
@@ -468,12 +420,63 @@ export class ExportCustomJobInstance {
     payload: ExportCustomJobPayload,
     resourceType?: string
   ) {
-    this.jobs = payload.jobs;
-    this.meta = payload.meta;
+    this.friendlyName = payload.friendly_name;
+    this.resourceType = payload.resource_type;
+    this.startDay = payload.start_day;
+    this.endDay = payload.end_day;
+    this.webhookUrl = payload.webhook_url;
+    this.webhookMethod = payload.webhook_method;
+    this.email = payload.email;
+    this.jobSid = payload.job_sid;
+    this.details = payload.details;
+    this.jobQueuePosition = payload.job_queue_position;
+    this.estimatedCompletionTime = payload.estimated_completion_time;
   }
 
-  jobs?: Array<BulkexportsV1ExportExportCustomJob>;
-  meta?: ListDayResponseMeta;
+  /**
+   * The friendly name specified when creating the job
+   */
+  friendlyName?: string | null;
+  /**
+   * The type of communication – Messages, Calls, Conferences, and Participants
+   */
+  resourceType?: string | null;
+  /**
+   * The start day for the custom export specified as a string in the format of yyyy-MM-dd
+   */
+  startDay?: string | null;
+  /**
+   * The end day for the custom export specified as a string in the format of yyyy-MM-dd. This will be the last day exported. For instance, to export a single day, choose the same day for start and end day. To export the first 4 days of July, you would set the start date to 2020-07-01 and the end date to 2020-07-04. The end date must be the UTC day before yesterday.
+   */
+  endDay?: string | null;
+  /**
+   * The optional webhook url called on completion
+   */
+  webhookUrl?: string | null;
+  /**
+   * This is the method used to call the webhook
+   */
+  webhookMethod?: string | null;
+  /**
+   * The optional email to send the completion notification to
+   */
+  email?: string | null;
+  /**
+   * The unique job_sid returned when the custom export was created. This can be used to look up the status of the job.
+   */
+  jobSid?: string | null;
+  /**
+   * The details of a job state which is an object that contains a `status` string, a day count integer, and list of days in the job
+   */
+  details?: any | null;
+  /**
+   * This is the job position from the 1st in line. Your queue position will never increase. As jobs ahead of yours in the queue are processed, the queue position number will decrease
+   */
+  jobQueuePosition?: string | null;
+  /**
+   * this is the time estimated until your job is complete. This is calculated each time you request the job list. The time is calculated based on the current rate of job completion (which may vary) and your job queue position
+   */
+  estimatedCompletionTime?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -482,8 +485,17 @@ export class ExportCustomJobInstance {
    */
   toJSON() {
     return {
-      jobs: this.jobs,
-      meta: this.meta,
+      friendlyName: this.friendlyName,
+      resourceType: this.resourceType,
+      startDay: this.startDay,
+      endDay: this.endDay,
+      webhookUrl: this.webhookUrl,
+      webhookMethod: this.webhookMethod,
+      email: this.email,
+      jobSid: this.jobSid,
+      details: this.details,
+      jobQueuePosition: this.jobQueuePosition,
+      estimatedCompletionTime: this.estimatedCompletionTime,
     };
   }
 

--- a/lib/rest/chat/v1/service/user/userChannel.ts
+++ b/lib/rest/chat/v1/service/user/userChannel.ts
@@ -19,47 +19,7 @@ import V1 from "../../../V1";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
 
-export class ChatV1ServiceUserUserChannel {
-  /**
-   * The SID of the Account that created the resource
-   */
-  "accountSid"?: string | null;
-  /**
-   * The SID of the Service that the resource is associated with
-   */
-  "serviceSid"?: string | null;
-  /**
-   * The SID of the Channel the resource belongs to
-   */
-  "channelSid"?: string | null;
-  /**
-   * The SID of the User as a Member in the Channel
-   */
-  "memberSid"?: string | null;
-  "status"?: UserChannelEnumChannelStatus;
-  /**
-   * The index of the last Message in the Channel the Member has read
-   */
-  "lastConsumedMessageIndex"?: number | null;
-  /**
-   * The number of unread Messages in the Channel for the User
-   */
-  "unreadMessagesCount"?: number | null;
-  /**
-   * Absolute URLs to access the Members, Messages , Invites and, if it exists, the last Message for the Channel
-   */
-  "links"?: object | null;
-}
-
-export class ListChannelResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
+type UserChannelChannelStatus = "joined" | "invited" | "not_participating";
 
 /**
  * Options to pass to each
@@ -340,8 +300,14 @@ interface UserChannelPayload
     Page.TwilioResponsePayload {}
 
 interface UserChannelResource {
-  channels?: Array<ChatV1ServiceUserUserChannel>;
-  meta?: ListChannelResponseMeta;
+  account_sid?: string | null;
+  service_sid?: string | null;
+  channel_sid?: string | null;
+  member_sid?: string | null;
+  status?: UserChannelChannelStatus;
+  last_consumed_message_index?: number | null;
+  unread_messages_count?: number | null;
+  links?: object | null;
 }
 
 export class UserChannelInstance {
@@ -351,12 +317,49 @@ export class UserChannelInstance {
     serviceSid: string,
     userSid?: string
   ) {
-    this.channels = payload.channels;
-    this.meta = payload.meta;
+    this.accountSid = payload.account_sid;
+    this.serviceSid = payload.service_sid;
+    this.channelSid = payload.channel_sid;
+    this.memberSid = payload.member_sid;
+    this.status = payload.status;
+    this.lastConsumedMessageIndex = deserialize.integer(
+      payload.last_consumed_message_index
+    );
+    this.unreadMessagesCount = deserialize.integer(
+      payload.unread_messages_count
+    );
+    this.links = payload.links;
   }
 
-  channels?: Array<ChatV1ServiceUserUserChannel>;
-  meta?: ListChannelResponseMeta;
+  /**
+   * The SID of the Account that created the resource
+   */
+  accountSid?: string | null;
+  /**
+   * The SID of the Service that the resource is associated with
+   */
+  serviceSid?: string | null;
+  /**
+   * The SID of the Channel the resource belongs to
+   */
+  channelSid?: string | null;
+  /**
+   * The SID of the User as a Member in the Channel
+   */
+  memberSid?: string | null;
+  status?: UserChannelChannelStatus;
+  /**
+   * The index of the last Message in the Channel the Member has read
+   */
+  lastConsumedMessageIndex?: number | null;
+  /**
+   * The number of unread Messages in the Channel for the User
+   */
+  unreadMessagesCount?: number | null;
+  /**
+   * Absolute URLs to access the Members, Messages , Invites and, if it exists, the last Message for the Channel
+   */
+  links?: object | null;
 
   /**
    * Provide a user-friendly representation
@@ -365,8 +368,14 @@ export class UserChannelInstance {
    */
   toJSON() {
     return {
-      channels: this.channels,
-      meta: this.meta,
+      accountSid: this.accountSid,
+      serviceSid: this.serviceSid,
+      channelSid: this.channelSid,
+      memberSid: this.memberSid,
+      status: this.status,
+      lastConsumedMessageIndex: this.lastConsumedMessageIndex,
+      unreadMessagesCount: this.unreadMessagesCount,
+      links: this.links,
     };
   }
 

--- a/lib/rest/conversations/v1/participantConversation.ts
+++ b/lib/rest/conversations/v1/participantConversation.ts
@@ -19,79 +19,7 @@ import V1 from "../V1";
 const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");
 
-export class ConversationsV1ParticipantConversation {
-  /**
-   * The unique ID of the Account responsible for this conversation.
-   */
-  "accountSid"?: string | null;
-  /**
-   * The unique ID of the Conversation Service this conversation belongs to.
-   */
-  "chatServiceSid"?: string | null;
-  /**
-   * The unique ID of the Participant.
-   */
-  "participantSid"?: string | null;
-  /**
-   * The unique ID for the conversation participant as Conversation User.
-   */
-  "participantUserSid"?: string | null;
-  /**
-   * A unique string identifier for the conversation participant as Conversation User.
-   */
-  "participantIdentity"?: string | null;
-  /**
-   * Information about how this participant exchanges messages with the conversation.
-   */
-  "participantMessagingBinding"?: any | null;
-  /**
-   * The unique ID of the Conversation this Participant belongs to.
-   */
-  "conversationSid"?: string | null;
-  /**
-   * An application-defined string that uniquely identifies the Conversation resource
-   */
-  "conversationUniqueName"?: string | null;
-  /**
-   * The human-readable name of this conversation.
-   */
-  "conversationFriendlyName"?: string | null;
-  /**
-   * An optional string metadata field you can use to store any data you wish.
-   */
-  "conversationAttributes"?: string | null;
-  /**
-   * The date that this conversation was created.
-   */
-  "conversationDateCreated"?: Date | null;
-  /**
-   * The date that this conversation was last updated.
-   */
-  "conversationDateUpdated"?: Date | null;
-  /**
-   * Creator of this conversation.
-   */
-  "conversationCreatedBy"?: string | null;
-  "conversationState"?: ParticipantConversationEnumState;
-  /**
-   * Timer date values for this conversation.
-   */
-  "conversationTimers"?: any | null;
-  /**
-   * Absolute URLs to access the participant and conversation of this Participant Conversation.
-   */
-  "links"?: object | null;
-}
-
-export class ListConfigurationAddressResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
+type ParticipantConversationState = "inactive" | "active" | "closed";
 
 /**
  * Options to pass to each
@@ -407,18 +335,109 @@ interface ParticipantConversationPayload
     Page.TwilioResponsePayload {}
 
 interface ParticipantConversationResource {
-  conversations?: Array<ConversationsV1ParticipantConversation>;
-  meta?: ListConfigurationAddressResponseMeta;
+  account_sid?: string | null;
+  chat_service_sid?: string | null;
+  participant_sid?: string | null;
+  participant_user_sid?: string | null;
+  participant_identity?: string | null;
+  participant_messaging_binding?: any | null;
+  conversation_sid?: string | null;
+  conversation_unique_name?: string | null;
+  conversation_friendly_name?: string | null;
+  conversation_attributes?: string | null;
+  conversation_date_created?: Date | null;
+  conversation_date_updated?: Date | null;
+  conversation_created_by?: string | null;
+  conversation_state?: ParticipantConversationState;
+  conversation_timers?: any | null;
+  links?: object | null;
 }
 
 export class ParticipantConversationInstance {
   constructor(protected _version: V1, payload: ParticipantConversationPayload) {
-    this.conversations = payload.conversations;
-    this.meta = payload.meta;
+    this.accountSid = payload.account_sid;
+    this.chatServiceSid = payload.chat_service_sid;
+    this.participantSid = payload.participant_sid;
+    this.participantUserSid = payload.participant_user_sid;
+    this.participantIdentity = payload.participant_identity;
+    this.participantMessagingBinding = payload.participant_messaging_binding;
+    this.conversationSid = payload.conversation_sid;
+    this.conversationUniqueName = payload.conversation_unique_name;
+    this.conversationFriendlyName = payload.conversation_friendly_name;
+    this.conversationAttributes = payload.conversation_attributes;
+    this.conversationDateCreated = deserialize.iso8601DateTime(
+      payload.conversation_date_created
+    );
+    this.conversationDateUpdated = deserialize.iso8601DateTime(
+      payload.conversation_date_updated
+    );
+    this.conversationCreatedBy = payload.conversation_created_by;
+    this.conversationState = payload.conversation_state;
+    this.conversationTimers = payload.conversation_timers;
+    this.links = payload.links;
   }
 
-  conversations?: Array<ConversationsV1ParticipantConversation>;
-  meta?: ListConfigurationAddressResponseMeta;
+  /**
+   * The unique ID of the Account responsible for this conversation.
+   */
+  accountSid?: string | null;
+  /**
+   * The unique ID of the Conversation Service this conversation belongs to.
+   */
+  chatServiceSid?: string | null;
+  /**
+   * The unique ID of the Participant.
+   */
+  participantSid?: string | null;
+  /**
+   * The unique ID for the conversation participant as Conversation User.
+   */
+  participantUserSid?: string | null;
+  /**
+   * A unique string identifier for the conversation participant as Conversation User.
+   */
+  participantIdentity?: string | null;
+  /**
+   * Information about how this participant exchanges messages with the conversation.
+   */
+  participantMessagingBinding?: any | null;
+  /**
+   * The unique ID of the Conversation this Participant belongs to.
+   */
+  conversationSid?: string | null;
+  /**
+   * An application-defined string that uniquely identifies the Conversation resource
+   */
+  conversationUniqueName?: string | null;
+  /**
+   * The human-readable name of this conversation.
+   */
+  conversationFriendlyName?: string | null;
+  /**
+   * An optional string metadata field you can use to store any data you wish.
+   */
+  conversationAttributes?: string | null;
+  /**
+   * The date that this conversation was created.
+   */
+  conversationDateCreated?: Date | null;
+  /**
+   * The date that this conversation was last updated.
+   */
+  conversationDateUpdated?: Date | null;
+  /**
+   * Creator of this conversation.
+   */
+  conversationCreatedBy?: string | null;
+  conversationState?: ParticipantConversationState;
+  /**
+   * Timer date values for this conversation.
+   */
+  conversationTimers?: any | null;
+  /**
+   * Absolute URLs to access the participant and conversation of this Participant Conversation.
+   */
+  links?: object | null;
 
   /**
    * Provide a user-friendly representation
@@ -427,8 +446,22 @@ export class ParticipantConversationInstance {
    */
   toJSON() {
     return {
-      conversations: this.conversations,
-      meta: this.meta,
+      accountSid: this.accountSid,
+      chatServiceSid: this.chatServiceSid,
+      participantSid: this.participantSid,
+      participantUserSid: this.participantUserSid,
+      participantIdentity: this.participantIdentity,
+      participantMessagingBinding: this.participantMessagingBinding,
+      conversationSid: this.conversationSid,
+      conversationUniqueName: this.conversationUniqueName,
+      conversationFriendlyName: this.conversationFriendlyName,
+      conversationAttributes: this.conversationAttributes,
+      conversationDateCreated: this.conversationDateCreated,
+      conversationDateUpdated: this.conversationDateUpdated,
+      conversationCreatedBy: this.conversationCreatedBy,
+      conversationState: this.conversationState,
+      conversationTimers: this.conversationTimers,
+      links: this.links,
     };
   }
 

--- a/lib/rest/conversations/v1/service/participantConversation.ts
+++ b/lib/rest/conversations/v1/service/participantConversation.ts
@@ -19,79 +19,7 @@ import V1 from "../../V1";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
 
-export class ConversationsV1ServiceServiceParticipantConversation {
-  /**
-   * The unique ID of the Account responsible for this conversation.
-   */
-  "accountSid"?: string | null;
-  /**
-   * The unique ID of the Conversation Service this conversation belongs to.
-   */
-  "chatServiceSid"?: string | null;
-  /**
-   * The unique ID of the Participant.
-   */
-  "participantSid"?: string | null;
-  /**
-   * The unique ID for the conversation participant as Conversation User.
-   */
-  "participantUserSid"?: string | null;
-  /**
-   * A unique string identifier for the conversation participant as Conversation User.
-   */
-  "participantIdentity"?: string | null;
-  /**
-   * Information about how this participant exchanges messages with the conversation.
-   */
-  "participantMessagingBinding"?: any | null;
-  /**
-   * The unique ID of the Conversation this Participant belongs to.
-   */
-  "conversationSid"?: string | null;
-  /**
-   * An application-defined string that uniquely identifies the Conversation resource.
-   */
-  "conversationUniqueName"?: string | null;
-  /**
-   * The human-readable name of this conversation.
-   */
-  "conversationFriendlyName"?: string | null;
-  /**
-   * An optional string metadata field you can use to store any data you wish.
-   */
-  "conversationAttributes"?: string | null;
-  /**
-   * The date that this conversation was created.
-   */
-  "conversationDateCreated"?: Date | null;
-  /**
-   * The date that this conversation was last updated.
-   */
-  "conversationDateUpdated"?: Date | null;
-  /**
-   * Creator of this conversation.
-   */
-  "conversationCreatedBy"?: string | null;
-  "conversationState"?: ServiceParticipantConversationEnumState;
-  /**
-   * Timer date values for this conversation.
-   */
-  "conversationTimers"?: any | null;
-  /**
-   * Absolute URLs to access the participant and conversation of this Participant Conversation.
-   */
-  "links"?: object | null;
-}
-
-export class ListConfigurationAddressResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
+type ServiceParticipantConversationState = "inactive" | "active" | "closed";
 
 /**
  * Options to pass to each
@@ -410,8 +338,22 @@ interface ParticipantConversationPayload
     Page.TwilioResponsePayload {}
 
 interface ParticipantConversationResource {
-  conversations?: Array<ConversationsV1ServiceServiceParticipantConversation>;
-  meta?: ListConfigurationAddressResponseMeta;
+  account_sid?: string | null;
+  chat_service_sid?: string | null;
+  participant_sid?: string | null;
+  participant_user_sid?: string | null;
+  participant_identity?: string | null;
+  participant_messaging_binding?: any | null;
+  conversation_sid?: string | null;
+  conversation_unique_name?: string | null;
+  conversation_friendly_name?: string | null;
+  conversation_attributes?: string | null;
+  conversation_date_created?: Date | null;
+  conversation_date_updated?: Date | null;
+  conversation_created_by?: string | null;
+  conversation_state?: ServiceParticipantConversationState;
+  conversation_timers?: any | null;
+  links?: object | null;
 }
 
 export class ParticipantConversationInstance {
@@ -420,12 +362,89 @@ export class ParticipantConversationInstance {
     payload: ParticipantConversationPayload,
     chatServiceSid?: string
   ) {
-    this.conversations = payload.conversations;
-    this.meta = payload.meta;
+    this.accountSid = payload.account_sid;
+    this.chatServiceSid = payload.chat_service_sid;
+    this.participantSid = payload.participant_sid;
+    this.participantUserSid = payload.participant_user_sid;
+    this.participantIdentity = payload.participant_identity;
+    this.participantMessagingBinding = payload.participant_messaging_binding;
+    this.conversationSid = payload.conversation_sid;
+    this.conversationUniqueName = payload.conversation_unique_name;
+    this.conversationFriendlyName = payload.conversation_friendly_name;
+    this.conversationAttributes = payload.conversation_attributes;
+    this.conversationDateCreated = deserialize.iso8601DateTime(
+      payload.conversation_date_created
+    );
+    this.conversationDateUpdated = deserialize.iso8601DateTime(
+      payload.conversation_date_updated
+    );
+    this.conversationCreatedBy = payload.conversation_created_by;
+    this.conversationState = payload.conversation_state;
+    this.conversationTimers = payload.conversation_timers;
+    this.links = payload.links;
   }
 
-  conversations?: Array<ConversationsV1ServiceServiceParticipantConversation>;
-  meta?: ListConfigurationAddressResponseMeta;
+  /**
+   * The unique ID of the Account responsible for this conversation.
+   */
+  accountSid?: string | null;
+  /**
+   * The unique ID of the Conversation Service this conversation belongs to.
+   */
+  chatServiceSid?: string | null;
+  /**
+   * The unique ID of the Participant.
+   */
+  participantSid?: string | null;
+  /**
+   * The unique ID for the conversation participant as Conversation User.
+   */
+  participantUserSid?: string | null;
+  /**
+   * A unique string identifier for the conversation participant as Conversation User.
+   */
+  participantIdentity?: string | null;
+  /**
+   * Information about how this participant exchanges messages with the conversation.
+   */
+  participantMessagingBinding?: any | null;
+  /**
+   * The unique ID of the Conversation this Participant belongs to.
+   */
+  conversationSid?: string | null;
+  /**
+   * An application-defined string that uniquely identifies the Conversation resource.
+   */
+  conversationUniqueName?: string | null;
+  /**
+   * The human-readable name of this conversation.
+   */
+  conversationFriendlyName?: string | null;
+  /**
+   * An optional string metadata field you can use to store any data you wish.
+   */
+  conversationAttributes?: string | null;
+  /**
+   * The date that this conversation was created.
+   */
+  conversationDateCreated?: Date | null;
+  /**
+   * The date that this conversation was last updated.
+   */
+  conversationDateUpdated?: Date | null;
+  /**
+   * Creator of this conversation.
+   */
+  conversationCreatedBy?: string | null;
+  conversationState?: ServiceParticipantConversationState;
+  /**
+   * Timer date values for this conversation.
+   */
+  conversationTimers?: any | null;
+  /**
+   * Absolute URLs to access the participant and conversation of this Participant Conversation.
+   */
+  links?: object | null;
 
   /**
    * Provide a user-friendly representation
@@ -434,8 +453,22 @@ export class ParticipantConversationInstance {
    */
   toJSON() {
     return {
-      conversations: this.conversations,
-      meta: this.meta,
+      accountSid: this.accountSid,
+      chatServiceSid: this.chatServiceSid,
+      participantSid: this.participantSid,
+      participantUserSid: this.participantUserSid,
+      participantIdentity: this.participantIdentity,
+      participantMessagingBinding: this.participantMessagingBinding,
+      conversationSid: this.conversationSid,
+      conversationUniqueName: this.conversationUniqueName,
+      conversationFriendlyName: this.conversationFriendlyName,
+      conversationAttributes: this.conversationAttributes,
+      conversationDateCreated: this.conversationDateCreated,
+      conversationDateUpdated: this.conversationDateUpdated,
+      conversationCreatedBy: this.conversationCreatedBy,
+      conversationState: this.conversationState,
+      conversationTimers: this.conversationTimers,
+      links: this.links,
     };
   }
 

--- a/lib/rest/flexApi/v1/interaction/interactionChannel/interactionChannelInvite.ts
+++ b/lib/rest/flexApi/v1/interaction/interactionChannel/interactionChannelInvite.ts
@@ -19,36 +19,6 @@ import V1 from "../../../V1";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
 
-export class FlexV1InteractionInteractionChannelInteractionChannelInvite {
-  /**
-   * The unique string that identifies the resource
-   */
-  "sid"?: string | null;
-  /**
-   * The Interaction SID for this Channel
-   */
-  "interactionSid"?: string | null;
-  /**
-   * The Channel SID for this Invite
-   */
-  "channelSid"?: string | null;
-  /**
-   * A JSON object representing the routing rules for the Interaction Channel
-   */
-  "routing"?: any | null;
-  "url"?: string | null;
-}
-
-export class ListChannelResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
 /**
  * Options to pass to create a InteractionChannelInviteInstance
  *
@@ -426,8 +396,11 @@ interface InteractionChannelInvitePayload
     Page.TwilioResponsePayload {}
 
 interface InteractionChannelInviteResource {
-  invites?: Array<FlexV1InteractionInteractionChannelInteractionChannelInvite>;
-  meta?: ListChannelResponseMeta;
+  sid?: string | null;
+  interaction_sid?: string | null;
+  channel_sid?: string | null;
+  routing?: any | null;
+  url?: string | null;
 }
 
 export class InteractionChannelInviteInstance {
@@ -437,12 +410,30 @@ export class InteractionChannelInviteInstance {
     interactionSid: string,
     channelSid?: string
   ) {
-    this.invites = payload.invites;
-    this.meta = payload.meta;
+    this.sid = payload.sid;
+    this.interactionSid = payload.interaction_sid;
+    this.channelSid = payload.channel_sid;
+    this.routing = payload.routing;
+    this.url = payload.url;
   }
 
-  invites?: Array<FlexV1InteractionInteractionChannelInteractionChannelInvite>;
-  meta?: ListChannelResponseMeta;
+  /**
+   * The unique string that identifies the resource
+   */
+  sid?: string | null;
+  /**
+   * The Interaction SID for this Channel
+   */
+  interactionSid?: string | null;
+  /**
+   * The Channel SID for this Invite
+   */
+  channelSid?: string | null;
+  /**
+   * A JSON object representing the routing rules for the Interaction Channel
+   */
+  routing?: any | null;
+  url?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -451,8 +442,11 @@ export class InteractionChannelInviteInstance {
    */
   toJSON() {
     return {
-      invites: this.invites,
-      meta: this.meta,
+      sid: this.sid,
+      interactionSid: this.interactionSid,
+      channelSid: this.channelSid,
+      routing: this.routing,
+      url: this.url,
     };
   }
 

--- a/lib/rest/insights/v1/call/event.ts
+++ b/lib/rest/insights/v1/call/event.ts
@@ -19,36 +19,14 @@ import V1 from "../../V1";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
 
+type EventLevel = "UNKNOWN" | "DEBUG" | "INFO" | "WARNING" | "ERROR";
+
 type EventTwilioEdge =
   | "unknown_edge"
   | "carrier_edge"
   | "sip_edge"
   | "sdk_edge"
   | "client_edge";
-
-export class InsightsV1CallEvent {
-  "timestamp"?: string | null;
-  "callSid"?: string | null;
-  "accountSid"?: string | null;
-  "edge"?: EventEnumTwilioEdge;
-  "group"?: string | null;
-  "level"?: EventEnumLevel;
-  "name"?: string | null;
-  "carrierEdge"?: any | null;
-  "sipEdge"?: any | null;
-  "sdkEdge"?: any | null;
-  "clientEdge"?: any | null;
-}
-
-export class ListCallSummariesResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
 
 /**
  * Options to pass to each
@@ -331,18 +309,45 @@ export function EventListInstance(
 interface EventPayload extends EventResource, Page.TwilioResponsePayload {}
 
 interface EventResource {
-  events?: Array<InsightsV1CallEvent>;
-  meta?: ListCallSummariesResponseMeta;
+  timestamp?: string | null;
+  call_sid?: string | null;
+  account_sid?: string | null;
+  edge?: EventTwilioEdge;
+  group?: string | null;
+  level?: EventLevel;
+  name?: string | null;
+  carrier_edge?: any | null;
+  sip_edge?: any | null;
+  sdk_edge?: any | null;
+  client_edge?: any | null;
 }
 
 export class EventInstance {
   constructor(protected _version: V1, payload: EventPayload, callSid?: string) {
-    this.events = payload.events;
-    this.meta = payload.meta;
+    this.timestamp = payload.timestamp;
+    this.callSid = payload.call_sid;
+    this.accountSid = payload.account_sid;
+    this.edge = payload.edge;
+    this.group = payload.group;
+    this.level = payload.level;
+    this.name = payload.name;
+    this.carrierEdge = payload.carrier_edge;
+    this.sipEdge = payload.sip_edge;
+    this.sdkEdge = payload.sdk_edge;
+    this.clientEdge = payload.client_edge;
   }
 
-  events?: Array<InsightsV1CallEvent>;
-  meta?: ListCallSummariesResponseMeta;
+  timestamp?: string | null;
+  callSid?: string | null;
+  accountSid?: string | null;
+  edge?: EventTwilioEdge;
+  group?: string | null;
+  level?: EventLevel;
+  name?: string | null;
+  carrierEdge?: any | null;
+  sipEdge?: any | null;
+  sdkEdge?: any | null;
+  clientEdge?: any | null;
 
   /**
    * Provide a user-friendly representation
@@ -351,8 +356,17 @@ export class EventInstance {
    */
   toJSON() {
     return {
-      events: this.events,
-      meta: this.meta,
+      timestamp: this.timestamp,
+      callSid: this.callSid,
+      accountSid: this.accountSid,
+      edge: this.edge,
+      group: this.group,
+      level: this.level,
+      name: this.name,
+      carrierEdge: this.carrierEdge,
+      sipEdge: this.sipEdge,
+      sdkEdge: this.sdkEdge,
+      clientEdge: this.clientEdge,
     };
   }
 

--- a/lib/rest/insights/v1/call/metric.ts
+++ b/lib/rest/insights/v1/call/metric.ts
@@ -19,28 +19,6 @@ import V1 from "../../V1";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
 
-export class InsightsV1CallMetric {
-  "timestamp"?: string | null;
-  "callSid"?: string | null;
-  "accountSid"?: string | null;
-  "edge"?: MetricEnumTwilioEdge;
-  "direction"?: MetricEnumStreamDirection;
-  "carrierEdge"?: any | null;
-  "sipEdge"?: any | null;
-  "sdkEdge"?: any | null;
-  "clientEdge"?: any | null;
-}
-
-export class ListCallSummariesResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
 type MetricStreamDirection = "unknown" | "inbound" | "outbound" | "both";
 
 type MetricTwilioEdge =
@@ -339,8 +317,15 @@ export function MetricListInstance(
 interface MetricPayload extends MetricResource, Page.TwilioResponsePayload {}
 
 interface MetricResource {
-  metrics?: Array<InsightsV1CallMetric>;
-  meta?: ListCallSummariesResponseMeta;
+  timestamp?: string | null;
+  call_sid?: string | null;
+  account_sid?: string | null;
+  edge?: MetricTwilioEdge;
+  direction?: MetricStreamDirection;
+  carrier_edge?: any | null;
+  sip_edge?: any | null;
+  sdk_edge?: any | null;
+  client_edge?: any | null;
 }
 
 export class MetricInstance {
@@ -349,12 +334,26 @@ export class MetricInstance {
     payload: MetricPayload,
     callSid?: string
   ) {
-    this.metrics = payload.metrics;
-    this.meta = payload.meta;
+    this.timestamp = payload.timestamp;
+    this.callSid = payload.call_sid;
+    this.accountSid = payload.account_sid;
+    this.edge = payload.edge;
+    this.direction = payload.direction;
+    this.carrierEdge = payload.carrier_edge;
+    this.sipEdge = payload.sip_edge;
+    this.sdkEdge = payload.sdk_edge;
+    this.clientEdge = payload.client_edge;
   }
 
-  metrics?: Array<InsightsV1CallMetric>;
-  meta?: ListCallSummariesResponseMeta;
+  timestamp?: string | null;
+  callSid?: string | null;
+  accountSid?: string | null;
+  edge?: MetricTwilioEdge;
+  direction?: MetricStreamDirection;
+  carrierEdge?: any | null;
+  sipEdge?: any | null;
+  sdkEdge?: any | null;
+  clientEdge?: any | null;
 
   /**
    * Provide a user-friendly representation
@@ -363,8 +362,15 @@ export class MetricInstance {
    */
   toJSON() {
     return {
-      metrics: this.metrics,
-      meta: this.meta,
+      timestamp: this.timestamp,
+      callSid: this.callSid,
+      accountSid: this.accountSid,
+      edge: this.edge,
+      direction: this.direction,
+      carrierEdge: this.carrierEdge,
+      sipEdge: this.sipEdge,
+      sdkEdge: this.sdkEdge,
+      clientEdge: this.clientEdge,
     };
   }
 

--- a/lib/rest/insights/v1/callSummaries.ts
+++ b/lib/rest/insights/v1/callSummaries.ts
@@ -19,6 +19,29 @@ import V1 from "../V1";
 const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");
 
+type CallSummariesAnsweredBy =
+  | "unknown"
+  | "machine_start"
+  | "machine_end_beep"
+  | "machine_end_silence"
+  | "machine_end_other"
+  | "human"
+  | "fax";
+
+type CallSummariesCallState =
+  | "ringing"
+  | "completed"
+  | "busy"
+  | "fail"
+  | "noanswer"
+  | "canceled"
+  | "answered"
+  | "undialed";
+
+type CallSummariesCallType = "carrier" | "sip" | "trunking" | "client";
+
+type CallSummariesProcessingState = "complete" | "partial";
+
 type CallSummariesProcessingStateRequest =
   | "completed"
   | "started"
@@ -26,41 +49,6 @@ type CallSummariesProcessingStateRequest =
   | "all";
 
 type CallSummariesSortBy = "start_time" | "end_time";
-
-export class InsightsV1CallSummaries {
-  "accountSid"?: string | null;
-  "callSid"?: string | null;
-  "answeredBy"?: CallSummariesEnumAnsweredBy;
-  "callType"?: CallSummariesEnumCallType;
-  "callState"?: CallSummariesEnumCallState;
-  "processingState"?: CallSummariesEnumProcessingState;
-  "createdTime"?: Date | null;
-  "startTime"?: Date | null;
-  "endTime"?: Date | null;
-  "duration"?: number | null;
-  "connectDuration"?: number | null;
-  "from"?: any | null;
-  "to"?: any | null;
-  "carrierEdge"?: any | null;
-  "clientEdge"?: any | null;
-  "sdkEdge"?: any | null;
-  "sipEdge"?: any | null;
-  "tags"?: Array<string> | null;
-  "url"?: string | null;
-  "attributes"?: any | null;
-  "properties"?: any | null;
-  "trust"?: any | null;
-}
-
-export class ListCallSummariesResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
 
 /**
  * Options to pass to each
@@ -481,18 +469,78 @@ interface CallSummariesPayload
     Page.TwilioResponsePayload {}
 
 interface CallSummariesResource {
-  call_summaries?: Array<InsightsV1CallSummaries>;
-  meta?: ListCallSummariesResponseMeta;
+  account_sid?: string | null;
+  call_sid?: string | null;
+  answered_by?: CallSummariesAnsweredBy;
+  call_type?: CallSummariesCallType;
+  call_state?: CallSummariesCallState;
+  processing_state?: CallSummariesProcessingState;
+  created_time?: Date | null;
+  start_time?: Date | null;
+  end_time?: Date | null;
+  duration?: number | null;
+  connect_duration?: number | null;
+  from?: any | null;
+  to?: any | null;
+  carrier_edge?: any | null;
+  client_edge?: any | null;
+  sdk_edge?: any | null;
+  sip_edge?: any | null;
+  tags?: Array<string> | null;
+  url?: string | null;
+  attributes?: any | null;
+  properties?: any | null;
+  trust?: any | null;
 }
 
 export class CallSummariesInstance {
   constructor(protected _version: V1, payload: CallSummariesPayload) {
-    this.callSummaries = payload.call_summaries;
-    this.meta = payload.meta;
+    this.accountSid = payload.account_sid;
+    this.callSid = payload.call_sid;
+    this.answeredBy = payload.answered_by;
+    this.callType = payload.call_type;
+    this.callState = payload.call_state;
+    this.processingState = payload.processing_state;
+    this.createdTime = deserialize.iso8601DateTime(payload.created_time);
+    this.startTime = deserialize.iso8601DateTime(payload.start_time);
+    this.endTime = deserialize.iso8601DateTime(payload.end_time);
+    this.duration = deserialize.integer(payload.duration);
+    this.connectDuration = deserialize.integer(payload.connect_duration);
+    this.from = payload.from;
+    this.to = payload.to;
+    this.carrierEdge = payload.carrier_edge;
+    this.clientEdge = payload.client_edge;
+    this.sdkEdge = payload.sdk_edge;
+    this.sipEdge = payload.sip_edge;
+    this.tags = payload.tags;
+    this.url = payload.url;
+    this.attributes = payload.attributes;
+    this.properties = payload.properties;
+    this.trust = payload.trust;
   }
 
-  callSummaries?: Array<InsightsV1CallSummaries>;
-  meta?: ListCallSummariesResponseMeta;
+  accountSid?: string | null;
+  callSid?: string | null;
+  answeredBy?: CallSummariesAnsweredBy;
+  callType?: CallSummariesCallType;
+  callState?: CallSummariesCallState;
+  processingState?: CallSummariesProcessingState;
+  createdTime?: Date | null;
+  startTime?: Date | null;
+  endTime?: Date | null;
+  duration?: number | null;
+  connectDuration?: number | null;
+  from?: any | null;
+  to?: any | null;
+  carrierEdge?: any | null;
+  clientEdge?: any | null;
+  sdkEdge?: any | null;
+  sipEdge?: any | null;
+  tags?: Array<string> | null;
+  url?: string | null;
+  attributes?: any | null;
+  properties?: any | null;
+  trust?: any | null;
 
   /**
    * Provide a user-friendly representation
@@ -501,8 +549,28 @@ export class CallSummariesInstance {
    */
   toJSON() {
     return {
-      callSummaries: this.callSummaries,
-      meta: this.meta,
+      accountSid: this.accountSid,
+      callSid: this.callSid,
+      answeredBy: this.answeredBy,
+      callType: this.callType,
+      callState: this.callState,
+      processingState: this.processingState,
+      createdTime: this.createdTime,
+      startTime: this.startTime,
+      endTime: this.endTime,
+      duration: this.duration,
+      connectDuration: this.connectDuration,
+      from: this.from,
+      to: this.to,
+      carrierEdge: this.carrierEdge,
+      clientEdge: this.clientEdge,
+      sdkEdge: this.sdkEdge,
+      sipEdge: this.sipEdge,
+      tags: this.tags,
+      url: this.url,
+      attributes: this.attributes,
+      properties: this.properties,
+      trust: this.trust,
     };
   }
 

--- a/lib/rest/ipMessaging/v1/service/user/userChannel.ts
+++ b/lib/rest/ipMessaging/v1/service/user/userChannel.ts
@@ -19,26 +19,7 @@ import V1 from "../../../V1";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
 
-export class IpMessagingV1ServiceUserUserChannel {
-  "accountSid"?: string | null;
-  "serviceSid"?: string | null;
-  "channelSid"?: string | null;
-  "memberSid"?: string | null;
-  "status"?: UserChannelEnumChannelStatus;
-  "lastConsumedMessageIndex"?: number | null;
-  "unreadMessagesCount"?: number | null;
-  "links"?: object | null;
-}
-
-export class ListChannelResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
+type UserChannelChannelStatus = "joined" | "invited" | "not_participating";
 
 /**
  * Options to pass to each
@@ -319,8 +300,14 @@ interface UserChannelPayload
     Page.TwilioResponsePayload {}
 
 interface UserChannelResource {
-  channels?: Array<IpMessagingV1ServiceUserUserChannel>;
-  meta?: ListChannelResponseMeta;
+  account_sid?: string | null;
+  service_sid?: string | null;
+  channel_sid?: string | null;
+  member_sid?: string | null;
+  status?: UserChannelChannelStatus;
+  last_consumed_message_index?: number | null;
+  unread_messages_count?: number | null;
+  links?: object | null;
 }
 
 export class UserChannelInstance {
@@ -330,12 +317,28 @@ export class UserChannelInstance {
     serviceSid: string,
     userSid?: string
   ) {
-    this.channels = payload.channels;
-    this.meta = payload.meta;
+    this.accountSid = payload.account_sid;
+    this.serviceSid = payload.service_sid;
+    this.channelSid = payload.channel_sid;
+    this.memberSid = payload.member_sid;
+    this.status = payload.status;
+    this.lastConsumedMessageIndex = deserialize.integer(
+      payload.last_consumed_message_index
+    );
+    this.unreadMessagesCount = deserialize.integer(
+      payload.unread_messages_count
+    );
+    this.links = payload.links;
   }
 
-  channels?: Array<IpMessagingV1ServiceUserUserChannel>;
-  meta?: ListChannelResponseMeta;
+  accountSid?: string | null;
+  serviceSid?: string | null;
+  channelSid?: string | null;
+  memberSid?: string | null;
+  status?: UserChannelChannelStatus;
+  lastConsumedMessageIndex?: number | null;
+  unreadMessagesCount?: number | null;
+  links?: object | null;
 
   /**
    * Provide a user-friendly representation
@@ -344,8 +347,14 @@ export class UserChannelInstance {
    */
   toJSON() {
     return {
-      channels: this.channels,
-      meta: this.meta,
+      accountSid: this.accountSid,
+      serviceSid: this.serviceSid,
+      channelSid: this.channelSid,
+      memberSid: this.memberSid,
+      status: this.status,
+      lastConsumedMessageIndex: this.lastConsumedMessageIndex,
+      unreadMessagesCount: this.unreadMessagesCount,
+      links: this.links,
     };
   }
 

--- a/lib/rest/numbers/v2/regulatoryCompliance/bundle/bundleCopy.ts
+++ b/lib/rest/numbers/v2/regulatoryCompliance/bundle/bundleCopy.ts
@@ -27,56 +27,6 @@ type BundleCopyStatus =
   | "twilio-approved"
   | "provisionally-approved";
 
-export class ListBundleResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class NumbersV2RegulatoryComplianceBundleBundleCopy {
-  /**
-   * The unique string that identifies the resource
-   */
-  "sid"?: string | null;
-  /**
-   * The SID of the Account that created the resource
-   */
-  "accountSid"?: string | null;
-  /**
-   * The unique string of a regulation
-   */
-  "regulationSid"?: string | null;
-  /**
-   * The string that you assigned to describe the resource
-   */
-  "friendlyName"?: string | null;
-  "status"?: BundleCopyStatus;
-  /**
-   * The ISO 8601 date and time in GMT when the resource will be valid until
-   */
-  "validUntil"?: Date | null;
-  /**
-   * The email address
-   */
-  "email"?: string | null;
-  /**
-   * The URL we call to inform your application of status changes
-   */
-  "statusCallback"?: string | null;
-  /**
-   * The ISO 8601 date and time in GMT when the resource was created
-   */
-  "dateCreated"?: Date | null;
-  /**
-   * The ISO 8601 date and time in GMT when the resource was last updated
-   */
-  "dateUpdated"?: Date | null;
-}
-
 /**
  * Options to pass to create a BundleCopyInstance
  *
@@ -428,8 +378,16 @@ interface BundleCopyPayload
     Page.TwilioResponsePayload {}
 
 interface BundleCopyResource {
-  results?: Array<NumbersV2RegulatoryComplianceBundleBundleCopy>;
-  meta?: ListBundleResponseMeta;
+  sid?: string | null;
+  account_sid?: string | null;
+  regulation_sid?: string | null;
+  friendly_name?: string | null;
+  status?: BundleCopyStatus;
+  valid_until?: Date | null;
+  email?: string | null;
+  status_callback?: string | null;
+  date_created?: Date | null;
+  date_updated?: Date | null;
 }
 
 export class BundleCopyInstance {
@@ -438,12 +396,55 @@ export class BundleCopyInstance {
     payload: BundleCopyPayload,
     bundleSid?: string
   ) {
-    this.results = payload.results;
-    this.meta = payload.meta;
+    this.sid = payload.sid;
+    this.accountSid = payload.account_sid;
+    this.regulationSid = payload.regulation_sid;
+    this.friendlyName = payload.friendly_name;
+    this.status = payload.status;
+    this.validUntil = deserialize.iso8601DateTime(payload.valid_until);
+    this.email = payload.email;
+    this.statusCallback = payload.status_callback;
+    this.dateCreated = deserialize.iso8601DateTime(payload.date_created);
+    this.dateUpdated = deserialize.iso8601DateTime(payload.date_updated);
   }
 
-  results?: Array<NumbersV2RegulatoryComplianceBundleBundleCopy>;
-  meta?: ListBundleResponseMeta;
+  /**
+   * The unique string that identifies the resource
+   */
+  sid?: string | null;
+  /**
+   * The SID of the Account that created the resource
+   */
+  accountSid?: string | null;
+  /**
+   * The unique string of a regulation
+   */
+  regulationSid?: string | null;
+  /**
+   * The string that you assigned to describe the resource
+   */
+  friendlyName?: string | null;
+  status?: BundleCopyStatus;
+  /**
+   * The ISO 8601 date and time in GMT when the resource will be valid until
+   */
+  validUntil?: Date | null;
+  /**
+   * The email address
+   */
+  email?: string | null;
+  /**
+   * The URL we call to inform your application of status changes
+   */
+  statusCallback?: string | null;
+  /**
+   * The ISO 8601 date and time in GMT when the resource was created
+   */
+  dateCreated?: Date | null;
+  /**
+   * The ISO 8601 date and time in GMT when the resource was last updated
+   */
+  dateUpdated?: Date | null;
 
   /**
    * Provide a user-friendly representation
@@ -452,8 +453,16 @@ export class BundleCopyInstance {
    */
   toJSON() {
     return {
-      results: this.results,
-      meta: this.meta,
+      sid: this.sid,
+      accountSid: this.accountSid,
+      regulationSid: this.regulationSid,
+      friendlyName: this.friendlyName,
+      status: this.status,
+      validUntil: this.validUntil,
+      email: this.email,
+      statusCallback: this.statusCallback,
+      dateCreated: this.dateCreated,
+      dateUpdated: this.dateUpdated,
     };
   }
 

--- a/lib/rest/preview/hosted_numbers/authorizationDocument/dependentHostedNumberOrder.ts
+++ b/lib/rest/preview/hosted_numbers/authorizationDocument/dependentHostedNumberOrder.ts
@@ -18,6 +18,7 @@ import Response from "../../../../http/response";
 import HostedNumbers from "../../HostedNumbers";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
+import { PhoneNumberCapabilities } from "../../../../interfaces";
 
 type DependentHostedNumberOrderStatus =
   | "received"
@@ -30,97 +31,7 @@ type DependentHostedNumberOrderStatus =
   | "failed"
   | "action-required";
 
-export class ListDeployedDevicesCertificateResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class PreviewHostedNumbersAuthorizationDocumentDependentHostedNumberOrder {
-  /**
-   * HostedNumberOrder sid.
-   */
-  "sid"?: string | null;
-  /**
-   * Account sid.
-   */
-  "accountSid"?: string | null;
-  /**
-   * IncomingPhoneNumber sid.
-   */
-  "incomingPhoneNumberSid"?: string | null;
-  /**
-   * Address sid.
-   */
-  "addressSid"?: string | null;
-  /**
-   * LOA document sid.
-   */
-  "signingDocumentSid"?: string | null;
-  /**
-   * An E164 formatted phone number.
-   */
-  "phoneNumber"?: string | null;
-  "capabilities"?: PreviewHostedNumbersAuthorizationDocumentDependentHostedNumberOrderCapabilities | null;
-  /**
-   * A human readable description of this resource.
-   */
-  "friendlyName"?: string | null;
-  /**
-   * A unique, developer assigned name of this HostedNumberOrder.
-   */
-  "uniqueName"?: string | null;
-  "status"?: DependentHostedNumberOrderEnumStatus;
-  /**
-   * Why a hosted_number_order reached status \"action-required\"
-   */
-  "failureReason"?: string | null;
-  /**
-   * The date this HostedNumberOrder was created.
-   */
-  "dateCreated"?: Date | null;
-  /**
-   * The date this HostedNumberOrder was updated.
-   */
-  "dateUpdated"?: Date | null;
-  /**
-   * The number of attempts made to verify ownership of the phone number.
-   */
-  "verificationAttempts"?: number | null;
-  /**
-   * Email.
-   */
-  "email"?: string | null;
-  /**
-   * A list of emails.
-   */
-  "ccEmails"?: Array<string> | null;
-  "verificationType"?: DependentHostedNumberOrderEnumVerificationType;
-  /**
-   * Verification Document Sid.
-   */
-  "verificationDocumentSid"?: string | null;
-  /**
-   * Phone extension to use for ownership verification call.
-   */
-  "extension"?: string | null;
-  /**
-   * Seconds (0-30) to delay ownership verification call by.
-   */
-  "callDelay"?: number | null;
-  /**
-   * The digits passed during the ownership verification call.
-   */
-  "verificationCode"?: string | null;
-  /**
-   * List of IDs for ownership verification calls.
-   */
-  "verificationCallSids"?: Array<string> | null;
-}
+type DependentHostedNumberOrderVerificationType = "phone-call" | "phone-bill";
 
 /**
  * A mapping of phone number capabilities.
@@ -493,8 +404,28 @@ interface DependentHostedNumberOrderPayload
     Page.TwilioResponsePayload {}
 
 interface DependentHostedNumberOrderResource {
-  items?: Array<PreviewHostedNumbersAuthorizationDocumentDependentHostedNumberOrder>;
-  meta?: ListDeployedDevicesCertificateResponseMeta;
+  sid?: string | null;
+  account_sid?: string | null;
+  incoming_phone_number_sid?: string | null;
+  address_sid?: string | null;
+  signing_document_sid?: string | null;
+  phone_number?: string | null;
+  capabilities?: PhoneNumberCapabilities | null;
+  friendly_name?: string | null;
+  unique_name?: string | null;
+  status?: DependentHostedNumberOrderStatus;
+  failure_reason?: string | null;
+  date_created?: Date | null;
+  date_updated?: Date | null;
+  verification_attempts?: number | null;
+  email?: string | null;
+  cc_emails?: Array<string> | null;
+  verification_type?: DependentHostedNumberOrderVerificationType;
+  verification_document_sid?: string | null;
+  extension?: string | null;
+  call_delay?: number | null;
+  verification_code?: string | null;
+  verification_call_sids?: Array<string> | null;
 }
 
 export class DependentHostedNumberOrderInstance {
@@ -503,12 +434,111 @@ export class DependentHostedNumberOrderInstance {
     payload: DependentHostedNumberOrderPayload,
     signingDocumentSid?: string
   ) {
-    this.items = payload.items;
-    this.meta = payload.meta;
+    this.sid = payload.sid;
+    this.accountSid = payload.account_sid;
+    this.incomingPhoneNumberSid = payload.incoming_phone_number_sid;
+    this.addressSid = payload.address_sid;
+    this.signingDocumentSid = payload.signing_document_sid;
+    this.phoneNumber = payload.phone_number;
+    this.capabilities = payload.capabilities;
+    this.friendlyName = payload.friendly_name;
+    this.uniqueName = payload.unique_name;
+    this.status = payload.status;
+    this.failureReason = payload.failure_reason;
+    this.dateCreated = deserialize.iso8601DateTime(payload.date_created);
+    this.dateUpdated = deserialize.iso8601DateTime(payload.date_updated);
+    this.verificationAttempts = deserialize.integer(
+      payload.verification_attempts
+    );
+    this.email = payload.email;
+    this.ccEmails = payload.cc_emails;
+    this.verificationType = payload.verification_type;
+    this.verificationDocumentSid = payload.verification_document_sid;
+    this.extension = payload.extension;
+    this.callDelay = deserialize.integer(payload.call_delay);
+    this.verificationCode = payload.verification_code;
+    this.verificationCallSids = payload.verification_call_sids;
   }
 
-  items?: Array<PreviewHostedNumbersAuthorizationDocumentDependentHostedNumberOrder>;
-  meta?: ListDeployedDevicesCertificateResponseMeta;
+  /**
+   * HostedNumberOrder sid.
+   */
+  sid?: string | null;
+  /**
+   * Account sid.
+   */
+  accountSid?: string | null;
+  /**
+   * IncomingPhoneNumber sid.
+   */
+  incomingPhoneNumberSid?: string | null;
+  /**
+   * Address sid.
+   */
+  addressSid?: string | null;
+  /**
+   * LOA document sid.
+   */
+  signingDocumentSid?: string | null;
+  /**
+   * An E164 formatted phone number.
+   */
+  phoneNumber?: string | null;
+  capabilities?: PhoneNumberCapabilities | null;
+  /**
+   * A human readable description of this resource.
+   */
+  friendlyName?: string | null;
+  /**
+   * A unique, developer assigned name of this HostedNumberOrder.
+   */
+  uniqueName?: string | null;
+  status?: DependentHostedNumberOrderStatus;
+  /**
+   * Why a hosted_number_order reached status \"action-required\"
+   */
+  failureReason?: string | null;
+  /**
+   * The date this HostedNumberOrder was created.
+   */
+  dateCreated?: Date | null;
+  /**
+   * The date this HostedNumberOrder was updated.
+   */
+  dateUpdated?: Date | null;
+  /**
+   * The number of attempts made to verify ownership of the phone number.
+   */
+  verificationAttempts?: number | null;
+  /**
+   * Email.
+   */
+  email?: string | null;
+  /**
+   * A list of emails.
+   */
+  ccEmails?: Array<string> | null;
+  verificationType?: DependentHostedNumberOrderVerificationType;
+  /**
+   * Verification Document Sid.
+   */
+  verificationDocumentSid?: string | null;
+  /**
+   * Phone extension to use for ownership verification call.
+   */
+  extension?: string | null;
+  /**
+   * Seconds (0-30) to delay ownership verification call by.
+   */
+  callDelay?: number | null;
+  /**
+   * The digits passed during the ownership verification call.
+   */
+  verificationCode?: string | null;
+  /**
+   * List of IDs for ownership verification calls.
+   */
+  verificationCallSids?: Array<string> | null;
 
   /**
    * Provide a user-friendly representation
@@ -517,8 +547,28 @@ export class DependentHostedNumberOrderInstance {
    */
   toJSON() {
     return {
-      items: this.items,
-      meta: this.meta,
+      sid: this.sid,
+      accountSid: this.accountSid,
+      incomingPhoneNumberSid: this.incomingPhoneNumberSid,
+      addressSid: this.addressSid,
+      signingDocumentSid: this.signingDocumentSid,
+      phoneNumber: this.phoneNumber,
+      capabilities: this.capabilities,
+      friendlyName: this.friendlyName,
+      uniqueName: this.uniqueName,
+      status: this.status,
+      failureReason: this.failureReason,
+      dateCreated: this.dateCreated,
+      dateUpdated: this.dateUpdated,
+      verificationAttempts: this.verificationAttempts,
+      email: this.email,
+      ccEmails: this.ccEmails,
+      verificationType: this.verificationType,
+      verificationDocumentSid: this.verificationDocumentSid,
+      extension: this.extension,
+      callDelay: this.callDelay,
+      verificationCode: this.verificationCode,
+      verificationCallSids: this.verificationCallSids,
     };
   }
 

--- a/lib/rest/supersim/v1/settingsUpdate.ts
+++ b/lib/rest/supersim/v1/settingsUpdate.ts
@@ -19,47 +19,11 @@ import V1 from "../V1";
 const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");
 
-export class ListBillingPeriodResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class SupersimV1SettingsUpdate {
-  /**
-   * The unique identifier of this Settings Update
-   */
-  "sid"?: string | null;
-  /**
-   * The ICCID associated with the SIM
-   */
-  "iccid"?: string | null;
-  /**
-   * The SID of the Super SIM to which this Settings Update was applied
-   */
-  "simSid"?: string | null;
-  "status"?: SettingsUpdateEnumStatus;
-  /**
-   * Array containing the different Settings Packages that will be applied to the SIM after the update completes
-   */
-  "packages"?: Array<any> | null;
-  /**
-   * The time when the update successfully completed and the new settings were applied to the SIM
-   */
-  "dateCompleted"?: Date | null;
-  /**
-   * The date this Settings Update was created
-   */
-  "dateCreated"?: Date | null;
-  /**
-   * The date this Settings Update was last updated
-   */
-  "dateUpdated"?: Date | null;
-}
+type SettingsUpdateStatus =
+  | "scheduled"
+  | "in-progress"
+  | "successful"
+  | "failed";
 
 /**
  * Options to pass to each
@@ -352,18 +316,57 @@ interface SettingsUpdatePayload
     Page.TwilioResponsePayload {}
 
 interface SettingsUpdateResource {
-  settings_updates?: Array<SupersimV1SettingsUpdate>;
-  meta?: ListBillingPeriodResponseMeta;
+  sid?: string | null;
+  iccid?: string | null;
+  sim_sid?: string | null;
+  status?: SettingsUpdateStatus;
+  packages?: Array<any> | null;
+  date_completed?: Date | null;
+  date_created?: Date | null;
+  date_updated?: Date | null;
 }
 
 export class SettingsUpdateInstance {
   constructor(protected _version: V1, payload: SettingsUpdatePayload) {
-    this.settingsUpdates = payload.settings_updates;
-    this.meta = payload.meta;
+    this.sid = payload.sid;
+    this.iccid = payload.iccid;
+    this.simSid = payload.sim_sid;
+    this.status = payload.status;
+    this.packages = payload.packages;
+    this.dateCompleted = deserialize.iso8601DateTime(payload.date_completed);
+    this.dateCreated = deserialize.iso8601DateTime(payload.date_created);
+    this.dateUpdated = deserialize.iso8601DateTime(payload.date_updated);
   }
 
-  settingsUpdates?: Array<SupersimV1SettingsUpdate>;
-  meta?: ListBillingPeriodResponseMeta;
+  /**
+   * The unique identifier of this Settings Update
+   */
+  sid?: string | null;
+  /**
+   * The ICCID associated with the SIM
+   */
+  iccid?: string | null;
+  /**
+   * The SID of the Super SIM to which this Settings Update was applied
+   */
+  simSid?: string | null;
+  status?: SettingsUpdateStatus;
+  /**
+   * Array containing the different Settings Packages that will be applied to the SIM after the update completes
+   */
+  packages?: Array<any> | null;
+  /**
+   * The time when the update successfully completed and the new settings were applied to the SIM
+   */
+  dateCompleted?: Date | null;
+  /**
+   * The date this Settings Update was created
+   */
+  dateCreated?: Date | null;
+  /**
+   * The date this Settings Update was last updated
+   */
+  dateUpdated?: Date | null;
 
   /**
    * Provide a user-friendly representation
@@ -372,8 +375,14 @@ export class SettingsUpdateInstance {
    */
   toJSON() {
     return {
-      settingsUpdates: this.settingsUpdates,
-      meta: this.meta,
+      sid: this.sid,
+      iccid: this.iccid,
+      simSid: this.simSid,
+      status: this.status,
+      packages: this.packages,
+      dateCompleted: this.dateCompleted,
+      dateCreated: this.dateCreated,
+      dateUpdated: this.dateUpdated,
     };
   }
 

--- a/lib/rest/supersim/v1/sim/billingPeriod.ts
+++ b/lib/rest/supersim/v1/sim/billingPeriod.ts
@@ -19,47 +19,7 @@ import V1 from "../../V1";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
 
-export class ListBillingPeriodResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class SupersimV1SimBillingPeriod {
-  /**
-   * The SID of the Billing Period
-   */
-  "sid"?: string | null;
-  /**
-   * The SID of the Account the Super SIM belongs to
-   */
-  "accountSid"?: string | null;
-  /**
-   * The SID of the Super SIM the Billing Period belongs to
-   */
-  "simSid"?: string | null;
-  /**
-   * The start time of the Billing Period
-   */
-  "startTime"?: Date | null;
-  /**
-   * The end time of the Billing Period
-   */
-  "endTime"?: Date | null;
-  "periodType"?: BillingPeriodEnumBpType;
-  /**
-   * The ISO 8601 date and time in GMT when the resource was created
-   */
-  "dateCreated"?: Date | null;
-  /**
-   * The ISO 8601 date and time in GMT when the resource was last updated
-   */
-  "dateUpdated"?: Date | null;
-}
+type BillingPeriodBpType = "ready" | "active";
 
 /**
  * Options to pass to each
@@ -344,8 +304,14 @@ interface BillingPeriodPayload
     Page.TwilioResponsePayload {}
 
 interface BillingPeriodResource {
-  billing_periods?: Array<SupersimV1SimBillingPeriod>;
-  meta?: ListBillingPeriodResponseMeta;
+  sid?: string | null;
+  account_sid?: string | null;
+  sim_sid?: string | null;
+  start_time?: Date | null;
+  end_time?: Date | null;
+  period_type?: BillingPeriodBpType;
+  date_created?: Date | null;
+  date_updated?: Date | null;
 }
 
 export class BillingPeriodInstance {
@@ -354,12 +320,45 @@ export class BillingPeriodInstance {
     payload: BillingPeriodPayload,
     simSid?: string
   ) {
-    this.billingPeriods = payload.billing_periods;
-    this.meta = payload.meta;
+    this.sid = payload.sid;
+    this.accountSid = payload.account_sid;
+    this.simSid = payload.sim_sid;
+    this.startTime = deserialize.iso8601DateTime(payload.start_time);
+    this.endTime = deserialize.iso8601DateTime(payload.end_time);
+    this.periodType = payload.period_type;
+    this.dateCreated = deserialize.iso8601DateTime(payload.date_created);
+    this.dateUpdated = deserialize.iso8601DateTime(payload.date_updated);
   }
 
-  billingPeriods?: Array<SupersimV1SimBillingPeriod>;
-  meta?: ListBillingPeriodResponseMeta;
+  /**
+   * The SID of the Billing Period
+   */
+  sid?: string | null;
+  /**
+   * The SID of the Account the Super SIM belongs to
+   */
+  accountSid?: string | null;
+  /**
+   * The SID of the Super SIM the Billing Period belongs to
+   */
+  simSid?: string | null;
+  /**
+   * The start time of the Billing Period
+   */
+  startTime?: Date | null;
+  /**
+   * The end time of the Billing Period
+   */
+  endTime?: Date | null;
+  periodType?: BillingPeriodBpType;
+  /**
+   * The ISO 8601 date and time in GMT when the resource was created
+   */
+  dateCreated?: Date | null;
+  /**
+   * The ISO 8601 date and time in GMT when the resource was last updated
+   */
+  dateUpdated?: Date | null;
 
   /**
    * Provide a user-friendly representation
@@ -368,8 +367,14 @@ export class BillingPeriodInstance {
    */
   toJSON() {
     return {
-      billingPeriods: this.billingPeriods,
-      meta: this.meta,
+      sid: this.sid,
+      accountSid: this.accountSid,
+      simSid: this.simSid,
+      startTime: this.startTime,
+      endTime: this.endTime,
+      periodType: this.periodType,
+      dateCreated: this.dateCreated,
+      dateUpdated: this.dateUpdated,
     };
   }
 

--- a/lib/rest/supersim/v1/sim/simIpAddress.ts
+++ b/lib/rest/supersim/v1/sim/simIpAddress.ts
@@ -19,23 +19,7 @@ import V1 from "../../V1";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
 
-export class ListBillingPeriodResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class SupersimV1SimSimIpAddress {
-  /**
-   * IP address assigned to the given Super SIM
-   */
-  "ipAddress"?: string | null;
-  "ipAddressVersion"?: SimIpAddressEnumIpAddressVersion;
-}
+type SimIpAddressIpAddressVersion = "IPv4" | "IPv6";
 
 /**
  * Options to pass to each
@@ -314,8 +298,8 @@ interface SimIpAddressPayload
     Page.TwilioResponsePayload {}
 
 interface SimIpAddressResource {
-  ip_addresses?: Array<SupersimV1SimSimIpAddress>;
-  meta?: ListBillingPeriodResponseMeta;
+  ip_address?: string | null;
+  ip_address_version?: SimIpAddressIpAddressVersion;
 }
 
 export class SimIpAddressInstance {
@@ -324,12 +308,15 @@ export class SimIpAddressInstance {
     payload: SimIpAddressPayload,
     simSid?: string
   ) {
-    this.ipAddresses = payload.ip_addresses;
-    this.meta = payload.meta;
+    this.ipAddress = payload.ip_address;
+    this.ipAddressVersion = payload.ip_address_version;
   }
 
-  ipAddresses?: Array<SupersimV1SimSimIpAddress>;
-  meta?: ListBillingPeriodResponseMeta;
+  /**
+   * IP address assigned to the given Super SIM
+   */
+  ipAddress?: string | null;
+  ipAddressVersion?: SimIpAddressIpAddressVersion;
 
   /**
    * Provide a user-friendly representation
@@ -338,8 +325,8 @@ export class SimIpAddressInstance {
    */
   toJSON() {
     return {
-      ipAddresses: this.ipAddresses,
-      meta: this.meta,
+      ipAddress: this.ipAddress,
+      ipAddressVersion: this.ipAddressVersion,
     };
   }
 

--- a/lib/rest/supersim/v1/usageRecord.ts
+++ b/lib/rest/supersim/v1/usageRecord.ts
@@ -19,63 +19,6 @@ import V1 from "../V1";
 const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");
 
-export class ListBillingPeriodResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class SupersimV1UsageRecord {
-  /**
-   * The SID of the Account that incurred the usage.
-   */
-  "accountSid"?: string | null;
-  /**
-   * SID of a Sim resource to which the UsageRecord belongs.
-   */
-  "simSid"?: string | null;
-  /**
-   * SID of the Network resource on which the usage occurred.
-   */
-  "networkSid"?: string | null;
-  /**
-   * SID of the Fleet resource on which the usage occurred.
-   */
-  "fleetSid"?: string | null;
-  /**
-   * Alpha-2 ISO Country Code of the country the usage occurred in.
-   */
-  "isoCountry"?: string | null;
-  /**
-   * The time period for which the usage is reported.
-   */
-  "period"?: any | null;
-  /**
-   * Total data uploaded in bytes, aggregated by the query parameters.
-   */
-  "dataUpload"?: number | null;
-  /**
-   * Total data downloaded in bytes, aggregated by the query parameters.
-   */
-  "dataDownload"?: number | null;
-  /**
-   * Total of data_upload and data_download.
-   */
-  "dataTotal"?: number | null;
-  /**
-   * Total amount in the `billed_unit` that was charged for the data uploaded or downloaded.
-   */
-  "dataTotalBilled"?: number | null;
-  /**
-   * The currency in which the billed amounts are measured, specified in the 3 letter ISO 4127 format (e.g. `USD`, `EUR`, `JPY`).
-   */
-  "billedUnit"?: string | null;
-}
-
 type UsageRecordGranularity = "hour" | "day" | "all";
 
 type UsageRecordGroup = "sim" | "fleet" | "network" | "isoCountry";
@@ -412,18 +355,78 @@ interface UsageRecordPayload
     Page.TwilioResponsePayload {}
 
 interface UsageRecordResource {
-  usage_records?: Array<SupersimV1UsageRecord>;
-  meta?: ListBillingPeriodResponseMeta;
+  account_sid?: string | null;
+  sim_sid?: string | null;
+  network_sid?: string | null;
+  fleet_sid?: string | null;
+  iso_country?: string | null;
+  period?: any | null;
+  data_upload?: number | null;
+  data_download?: number | null;
+  data_total?: number | null;
+  data_total_billed?: number | null;
+  billed_unit?: string | null;
 }
 
 export class UsageRecordInstance {
   constructor(protected _version: V1, payload: UsageRecordPayload) {
-    this.usageRecords = payload.usage_records;
-    this.meta = payload.meta;
+    this.accountSid = payload.account_sid;
+    this.simSid = payload.sim_sid;
+    this.networkSid = payload.network_sid;
+    this.fleetSid = payload.fleet_sid;
+    this.isoCountry = payload.iso_country;
+    this.period = payload.period;
+    this.dataUpload = payload.data_upload;
+    this.dataDownload = payload.data_download;
+    this.dataTotal = payload.data_total;
+    this.dataTotalBilled = payload.data_total_billed;
+    this.billedUnit = payload.billed_unit;
   }
 
-  usageRecords?: Array<SupersimV1UsageRecord>;
-  meta?: ListBillingPeriodResponseMeta;
+  /**
+   * The SID of the Account that incurred the usage.
+   */
+  accountSid?: string | null;
+  /**
+   * SID of a Sim resource to which the UsageRecord belongs.
+   */
+  simSid?: string | null;
+  /**
+   * SID of the Network resource on which the usage occurred.
+   */
+  networkSid?: string | null;
+  /**
+   * SID of the Fleet resource on which the usage occurred.
+   */
+  fleetSid?: string | null;
+  /**
+   * Alpha-2 ISO Country Code of the country the usage occurred in.
+   */
+  isoCountry?: string | null;
+  /**
+   * The time period for which the usage is reported.
+   */
+  period?: any | null;
+  /**
+   * Total data uploaded in bytes, aggregated by the query parameters.
+   */
+  dataUpload?: number | null;
+  /**
+   * Total data downloaded in bytes, aggregated by the query parameters.
+   */
+  dataDownload?: number | null;
+  /**
+   * Total of data_upload and data_download.
+   */
+  dataTotal?: number | null;
+  /**
+   * Total amount in the `billed_unit` that was charged for the data uploaded or downloaded.
+   */
+  dataTotalBilled?: number | null;
+  /**
+   * The currency in which the billed amounts are measured, specified in the 3 letter ISO 4127 format (e.g. `USD`, `EUR`, `JPY`).
+   */
+  billedUnit?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -432,8 +435,17 @@ export class UsageRecordInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      meta: this.meta,
+      accountSid: this.accountSid,
+      simSid: this.simSid,
+      networkSid: this.networkSid,
+      fleetSid: this.fleetSid,
+      isoCountry: this.isoCountry,
+      period: this.period,
+      dataUpload: this.dataUpload,
+      dataDownload: this.dataDownload,
+      dataTotal: this.dataTotal,
+      dataTotalBilled: this.dataTotalBilled,
+      billedUnit: this.billedUnit,
     };
   }
 

--- a/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueuesStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueuesStatistics.ts
@@ -19,39 +19,6 @@ import V1 from "../../../V1";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
 
-export class ListActivityResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class TaskrouterV1WorkspaceTaskQueueTaskQueuesStatistics {
-  /**
-   * The SID of the Account that created the resource
-   */
-  "accountSid"?: string | null;
-  /**
-   * An object that contains the cumulative statistics for the TaskQueues
-   */
-  "cumulative"?: any | null;
-  /**
-   * An object that contains the real-time statistics for the TaskQueues
-   */
-  "realtime"?: any | null;
-  /**
-   * The SID of the TaskQueue from which these statistics were calculated
-   */
-  "taskQueueSid"?: string | null;
-  /**
-   * The SID of the Workspace that contains the TaskQueues
-   */
-  "workspaceSid"?: string | null;
-}
-
 /**
  * Options to pass to each
  *
@@ -395,8 +362,11 @@ interface TaskQueuesStatisticsPayload
     Page.TwilioResponsePayload {}
 
 interface TaskQueuesStatisticsResource {
-  task_queues_statistics?: Array<TaskrouterV1WorkspaceTaskQueueTaskQueuesStatistics>;
-  meta?: ListActivityResponseMeta;
+  account_sid?: string | null;
+  cumulative?: any | null;
+  realtime?: any | null;
+  task_queue_sid?: string | null;
+  workspace_sid?: string | null;
 }
 
 export class TaskQueuesStatisticsInstance {
@@ -405,12 +375,33 @@ export class TaskQueuesStatisticsInstance {
     payload: TaskQueuesStatisticsPayload,
     workspaceSid?: string
   ) {
-    this.taskQueuesStatistics = payload.task_queues_statistics;
-    this.meta = payload.meta;
+    this.accountSid = payload.account_sid;
+    this.cumulative = payload.cumulative;
+    this.realtime = payload.realtime;
+    this.taskQueueSid = payload.task_queue_sid;
+    this.workspaceSid = payload.workspace_sid;
   }
 
-  taskQueuesStatistics?: Array<TaskrouterV1WorkspaceTaskQueueTaskQueuesStatistics>;
-  meta?: ListActivityResponseMeta;
+  /**
+   * The SID of the Account that created the resource
+   */
+  accountSid?: string | null;
+  /**
+   * An object that contains the cumulative statistics for the TaskQueues
+   */
+  cumulative?: any | null;
+  /**
+   * An object that contains the real-time statistics for the TaskQueues
+   */
+  realtime?: any | null;
+  /**
+   * The SID of the TaskQueue from which these statistics were calculated
+   */
+  taskQueueSid?: string | null;
+  /**
+   * The SID of the Workspace that contains the TaskQueues
+   */
+  workspaceSid?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -419,8 +410,11 @@ export class TaskQueuesStatisticsInstance {
    */
   toJSON() {
     return {
-      taskQueuesStatistics: this.taskQueuesStatistics,
-      meta: this.meta,
+      accountSid: this.accountSid,
+      cumulative: this.cumulative,
+      realtime: this.realtime,
+      taskQueueSid: this.taskQueueSid,
+      workspaceSid: this.workspaceSid,
     };
   }
 

--- a/lib/rest/verify/v2/template.ts
+++ b/lib/rest/verify/v2/template.ts
@@ -19,39 +19,6 @@ import V2 from "../V2";
 const deserialize = require("../../../base/deserialize");
 const serialize = require("../../../base/serialize");
 
-export class ListBucketResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class VerifyV2VerificationTemplate {
-  /**
-   * A string that uniquely identifies this Template
-   */
-  "sid"?: string | null;
-  /**
-   * Account Sid
-   */
-  "accountSid"?: string | null;
-  /**
-   * A string to describe the verification template
-   */
-  "friendlyName"?: string | null;
-  /**
-   * A list of channels that support the Template
-   */
-  "channels"?: Array<string> | null;
-  /**
-   * Object with the template translations.
-   */
-  "translations"?: any | null;
-}
-
 /**
  * Options to pass to each
  *
@@ -331,18 +298,42 @@ interface TemplatePayload
     Page.TwilioResponsePayload {}
 
 interface TemplateResource {
-  templates?: Array<VerifyV2VerificationTemplate>;
-  meta?: ListBucketResponseMeta;
+  sid?: string | null;
+  account_sid?: string | null;
+  friendly_name?: string | null;
+  channels?: Array<string> | null;
+  translations?: any | null;
 }
 
 export class TemplateInstance {
   constructor(protected _version: V2, payload: TemplatePayload) {
-    this.templates = payload.templates;
-    this.meta = payload.meta;
+    this.sid = payload.sid;
+    this.accountSid = payload.account_sid;
+    this.friendlyName = payload.friendly_name;
+    this.channels = payload.channels;
+    this.translations = payload.translations;
   }
 
-  templates?: Array<VerifyV2VerificationTemplate>;
-  meta?: ListBucketResponseMeta;
+  /**
+   * A string that uniquely identifies this Template
+   */
+  sid?: string | null;
+  /**
+   * Account Sid
+   */
+  accountSid?: string | null;
+  /**
+   * A string to describe the verification template
+   */
+  friendlyName?: string | null;
+  /**
+   * A list of channels that support the Template
+   */
+  channels?: Array<string> | null;
+  /**
+   * Object with the template translations.
+   */
+  translations?: any | null;
 
   /**
    * Provide a user-friendly representation
@@ -351,8 +342,11 @@ export class TemplateInstance {
    */
   toJSON() {
     return {
-      templates: this.templates,
-      meta: this.meta,
+      sid: this.sid,
+      accountSid: this.accountSid,
+      friendlyName: this.friendlyName,
+      channels: this.channels,
+      translations: this.translations,
     };
   }
 

--- a/lib/rest/voice/v1/dialingPermissions/country/highriskSpecialPrefix.ts
+++ b/lib/rest/voice/v1/dialingPermissions/country/highriskSpecialPrefix.ts
@@ -19,23 +19,6 @@ import V1 from "../../../V1";
 const deserialize = require("../../../../../base/deserialize");
 const serialize = require("../../../../../base/serialize");
 
-export class ListByocTrunkResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class VoiceV1DialingPermissionsDialingPermissionsCountryDialingPermissionsHrsPrefixes {
-  /**
-   * A prefix that includes the E.164 assigned country code
-   */
-  "prefix"?: string | null;
-}
-
 /**
  * Options to pass to each
  *
@@ -332,8 +315,7 @@ interface HighriskSpecialPrefixPayload
     Page.TwilioResponsePayload {}
 
 interface HighriskSpecialPrefixResource {
-  content?: Array<VoiceV1DialingPermissionsDialingPermissionsCountryDialingPermissionsHrsPrefixes>;
-  meta?: ListByocTrunkResponseMeta;
+  prefix?: string | null;
 }
 
 export class HighriskSpecialPrefixInstance {
@@ -342,12 +324,13 @@ export class HighriskSpecialPrefixInstance {
     payload: HighriskSpecialPrefixPayload,
     isoCode?: string
   ) {
-    this.content = payload.content;
-    this.meta = payload.meta;
+    this.prefix = payload.prefix;
   }
 
-  content?: Array<VoiceV1DialingPermissionsDialingPermissionsCountryDialingPermissionsHrsPrefixes>;
-  meta?: ListByocTrunkResponseMeta;
+  /**
+   * A prefix that includes the E.164 assigned country code
+   */
+  prefix?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -356,8 +339,7 @@ export class HighriskSpecialPrefixInstance {
    */
   toJSON() {
     return {
-      content: this.content,
-      meta: this.meta,
+      prefix: this.prefix,
     };
   }
 

--- a/lib/rest/wireless/v1/sim/dataSession.ts
+++ b/lib/rest/wireless/v1/sim/dataSession.ts
@@ -19,83 +19,6 @@ import V1 from "../../V1";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
 
-export class ListAccountUsageRecordResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class WirelessV1SimDataSession {
-  /**
-   * The unique string that identifies the resource
-   */
-  "sid"?: string | null;
-  /**
-   * The SID of the Sim resource that the Data Session is for
-   */
-  "simSid"?: string | null;
-  /**
-   * The SID of the Account that created the resource
-   */
-  "accountSid"?: string | null;
-  /**
-   * The generation of wireless technology that the device was using
-   */
-  "radioLink"?: string | null;
-  /**
-   * The \'mobile country code\' is the unique ID of the home country where the Data Session took place
-   */
-  "operatorMcc"?: string | null;
-  /**
-   * The \'mobile network code\' is the unique ID specific to the mobile operator network where the Data Session took place
-   */
-  "operatorMnc"?: string | null;
-  /**
-   * The three letter country code representing where the device\'s Data Session took place
-   */
-  "operatorCountry"?: string | null;
-  /**
-   * The friendly name of the mobile operator network that the SIM-connected device is attached to
-   */
-  "operatorName"?: string | null;
-  /**
-   * The unique ID of the cellular tower that the device was attached to at the moment when the Data Session was last updated
-   */
-  "cellId"?: string | null;
-  /**
-   * An object with the estimated location where the device\'s Data Session took place
-   */
-  "cellLocationEstimate"?: any | null;
-  /**
-   * The number of packets uploaded by the device between the start time and when the Data Session was last updated
-   */
-  "packetsUploaded"?: number | null;
-  /**
-   * The number of packets downloaded by the device between the start time and when the Data Session was last updated
-   */
-  "packetsDownloaded"?: number | null;
-  /**
-   * The date that the resource was last updated, given as GMT in ISO 8601 format
-   */
-  "lastUpdated"?: Date | null;
-  /**
-   * The date that the Data Session started, given as GMT in ISO 8601 format
-   */
-  "start"?: Date | null;
-  /**
-   * The date that the record ended, given as GMT in ISO 8601 format
-   */
-  "end"?: Date | null;
-  /**
-   * The unique ID of the device using the SIM to connect
-   */
-  "imei"?: string | null;
-}
-
 /**
  * Options to pass to each
  *
@@ -373,8 +296,22 @@ interface DataSessionPayload
     Page.TwilioResponsePayload {}
 
 interface DataSessionResource {
-  data_sessions?: Array<WirelessV1SimDataSession>;
-  meta?: ListAccountUsageRecordResponseMeta;
+  sid?: string | null;
+  sim_sid?: string | null;
+  account_sid?: string | null;
+  radio_link?: string | null;
+  operator_mcc?: string | null;
+  operator_mnc?: string | null;
+  operator_country?: string | null;
+  operator_name?: string | null;
+  cell_id?: string | null;
+  cell_location_estimate?: any | null;
+  packets_uploaded?: number | null;
+  packets_downloaded?: number | null;
+  last_updated?: Date | null;
+  start?: Date | null;
+  end?: Date | null;
+  imei?: string | null;
 }
 
 export class DataSessionInstance {
@@ -383,12 +320,88 @@ export class DataSessionInstance {
     payload: DataSessionPayload,
     simSid?: string
   ) {
-    this.dataSessions = payload.data_sessions;
-    this.meta = payload.meta;
+    this.sid = payload.sid;
+    this.simSid = payload.sim_sid;
+    this.accountSid = payload.account_sid;
+    this.radioLink = payload.radio_link;
+    this.operatorMcc = payload.operator_mcc;
+    this.operatorMnc = payload.operator_mnc;
+    this.operatorCountry = payload.operator_country;
+    this.operatorName = payload.operator_name;
+    this.cellId = payload.cell_id;
+    this.cellLocationEstimate = payload.cell_location_estimate;
+    this.packetsUploaded = deserialize.integer(payload.packets_uploaded);
+    this.packetsDownloaded = deserialize.integer(payload.packets_downloaded);
+    this.lastUpdated = deserialize.iso8601DateTime(payload.last_updated);
+    this.start = deserialize.iso8601DateTime(payload.start);
+    this.end = deserialize.iso8601DateTime(payload.end);
+    this.imei = payload.imei;
   }
 
-  dataSessions?: Array<WirelessV1SimDataSession>;
-  meta?: ListAccountUsageRecordResponseMeta;
+  /**
+   * The unique string that identifies the resource
+   */
+  sid?: string | null;
+  /**
+   * The SID of the Sim resource that the Data Session is for
+   */
+  simSid?: string | null;
+  /**
+   * The SID of the Account that created the resource
+   */
+  accountSid?: string | null;
+  /**
+   * The generation of wireless technology that the device was using
+   */
+  radioLink?: string | null;
+  /**
+   * The \'mobile country code\' is the unique ID of the home country where the Data Session took place
+   */
+  operatorMcc?: string | null;
+  /**
+   * The \'mobile network code\' is the unique ID specific to the mobile operator network where the Data Session took place
+   */
+  operatorMnc?: string | null;
+  /**
+   * The three letter country code representing where the device\'s Data Session took place
+   */
+  operatorCountry?: string | null;
+  /**
+   * The friendly name of the mobile operator network that the SIM-connected device is attached to
+   */
+  operatorName?: string | null;
+  /**
+   * The unique ID of the cellular tower that the device was attached to at the moment when the Data Session was last updated
+   */
+  cellId?: string | null;
+  /**
+   * An object with the estimated location where the device\'s Data Session took place
+   */
+  cellLocationEstimate?: any | null;
+  /**
+   * The number of packets uploaded by the device between the start time and when the Data Session was last updated
+   */
+  packetsUploaded?: number | null;
+  /**
+   * The number of packets downloaded by the device between the start time and when the Data Session was last updated
+   */
+  packetsDownloaded?: number | null;
+  /**
+   * The date that the resource was last updated, given as GMT in ISO 8601 format
+   */
+  lastUpdated?: Date | null;
+  /**
+   * The date that the Data Session started, given as GMT in ISO 8601 format
+   */
+  start?: Date | null;
+  /**
+   * The date that the record ended, given as GMT in ISO 8601 format
+   */
+  end?: Date | null;
+  /**
+   * The unique ID of the device using the SIM to connect
+   */
+  imei?: string | null;
 
   /**
    * Provide a user-friendly representation
@@ -397,8 +410,22 @@ export class DataSessionInstance {
    */
   toJSON() {
     return {
-      dataSessions: this.dataSessions,
-      meta: this.meta,
+      sid: this.sid,
+      simSid: this.simSid,
+      accountSid: this.accountSid,
+      radioLink: this.radioLink,
+      operatorMcc: this.operatorMcc,
+      operatorMnc: this.operatorMnc,
+      operatorCountry: this.operatorCountry,
+      operatorName: this.operatorName,
+      cellId: this.cellId,
+      cellLocationEstimate: this.cellLocationEstimate,
+      packetsUploaded: this.packetsUploaded,
+      packetsDownloaded: this.packetsDownloaded,
+      lastUpdated: this.lastUpdated,
+      start: this.start,
+      end: this.end,
+      imei: this.imei,
     };
   }
 

--- a/lib/rest/wireless/v1/sim/usageRecord.ts
+++ b/lib/rest/wireless/v1/sim/usageRecord.ts
@@ -19,40 +19,7 @@ import V1 from "../../V1";
 const deserialize = require("../../../../base/deserialize");
 const serialize = require("../../../../base/serialize");
 
-export class ListAccountUsageRecordResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
 type UsageRecordGranularity = "hourly" | "daily" | "all";
-
-export class WirelessV1SimUsageRecord {
-  /**
-   * The SID of the Sim resource that this Usage Record is for
-   */
-  "simSid"?: string | null;
-  /**
-   * The SID of the Account that created the resource
-   */
-  "accountSid"?: string | null;
-  /**
-   * The time period for which the usage is reported
-   */
-  "period"?: any | null;
-  /**
-   * An object that describes the SIM\'s usage of Commands during the specified period
-   */
-  "commands"?: any | null;
-  /**
-   * An object that describes the SIM\'s data usage during the specified period
-   */
-  "data"?: any | null;
-}
 
 /**
  * Options to pass to each
@@ -355,8 +322,11 @@ interface UsageRecordPayload
     Page.TwilioResponsePayload {}
 
 interface UsageRecordResource {
-  usage_records?: Array<WirelessV1SimUsageRecord>;
-  meta?: ListAccountUsageRecordResponseMeta;
+  sim_sid?: string | null;
+  account_sid?: string | null;
+  period?: any | null;
+  commands?: any | null;
+  data?: any | null;
 }
 
 export class UsageRecordInstance {
@@ -365,12 +335,33 @@ export class UsageRecordInstance {
     payload: UsageRecordPayload,
     simSid?: string
   ) {
-    this.usageRecords = payload.usage_records;
-    this.meta = payload.meta;
+    this.simSid = payload.sim_sid;
+    this.accountSid = payload.account_sid;
+    this.period = payload.period;
+    this.commands = payload.commands;
+    this.data = payload.data;
   }
 
-  usageRecords?: Array<WirelessV1SimUsageRecord>;
-  meta?: ListAccountUsageRecordResponseMeta;
+  /**
+   * The SID of the Sim resource that this Usage Record is for
+   */
+  simSid?: string | null;
+  /**
+   * The SID of the Account that created the resource
+   */
+  accountSid?: string | null;
+  /**
+   * The time period for which the usage is reported
+   */
+  period?: any | null;
+  /**
+   * An object that describes the SIM\'s usage of Commands during the specified period
+   */
+  commands?: any | null;
+  /**
+   * An object that describes the SIM\'s data usage during the specified period
+   */
+  data?: any | null;
 
   /**
    * Provide a user-friendly representation
@@ -379,8 +370,11 @@ export class UsageRecordInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      meta: this.meta,
+      simSid: this.simSid,
+      accountSid: this.accountSid,
+      period: this.period,
+      commands: this.commands,
+      data: this.data,
     };
   }
 

--- a/lib/rest/wireless/v1/usageRecord.ts
+++ b/lib/rest/wireless/v1/usageRecord.ts
@@ -21,35 +21,6 @@ const serialize = require("../../../base/serialize");
 
 type AccountUsageRecordGranularity = "hourly" | "daily" | "all";
 
-export class ListAccountUsageRecordResponseMeta {
-  "firstPageUrl"?: string;
-  "nextPageUrl"?: string;
-  "page"?: number;
-  "pageSize"?: number;
-  "previousPageUrl"?: string;
-  "url"?: string;
-  "key"?: string;
-}
-
-export class WirelessV1AccountUsageRecord {
-  /**
-   * The SID of the Account that created the resource
-   */
-  "accountSid"?: string | null;
-  /**
-   * The time period for which usage is reported
-   */
-  "period"?: any | null;
-  /**
-   * An object that describes the aggregated Commands usage for all SIMs during the specified period
-   */
-  "commands"?: any | null;
-  /**
-   * An object that describes the aggregated Data usage for all SIMs over the period
-   */
-  "data"?: any | null;
-}
-
 /**
  * Options to pass to each
  *
@@ -346,18 +317,36 @@ interface UsageRecordPayload
     Page.TwilioResponsePayload {}
 
 interface UsageRecordResource {
-  usage_records?: Array<WirelessV1AccountUsageRecord>;
-  meta?: ListAccountUsageRecordResponseMeta;
+  account_sid?: string | null;
+  period?: any | null;
+  commands?: any | null;
+  data?: any | null;
 }
 
 export class UsageRecordInstance {
   constructor(protected _version: V1, payload: UsageRecordPayload) {
-    this.usageRecords = payload.usage_records;
-    this.meta = payload.meta;
+    this.accountSid = payload.account_sid;
+    this.period = payload.period;
+    this.commands = payload.commands;
+    this.data = payload.data;
   }
 
-  usageRecords?: Array<WirelessV1AccountUsageRecord>;
-  meta?: ListAccountUsageRecordResponseMeta;
+  /**
+   * The SID of the Account that created the resource
+   */
+  accountSid?: string | null;
+  /**
+   * The time period for which usage is reported
+   */
+  period?: any | null;
+  /**
+   * An object that describes the aggregated Commands usage for all SIMs during the specified period
+   */
+  commands?: any | null;
+  /**
+   * An object that describes the aggregated Data usage for all SIMs over the period
+   */
+  data?: any | null;
 
   /**
    * Provide a user-friendly representation
@@ -366,8 +355,10 @@ export class UsageRecordInstance {
    */
   toJSON() {
     return {
-      usageRecords: this.usageRecords,
-      meta: this.meta,
+      accountSid: this.accountSid,
+      period: this.period,
+      commands: this.commands,
+      data: this.data,
     };
   }
 


### PR DESCRIPTION
There are APIs which have only operations on list path. This was causing issues during generation where the metadata schema was being used instead which is not needed.