### PR TITLE
fix: update non-parent path param handling and instance properties

### DIFF
--- a/lib/rest/api/v2010/account/address/dependentPhoneNumber.ts
+++ b/lib/rest/api/v2010/account/address/dependentPhoneNumber.ts
@@ -393,7 +393,7 @@ export class DependentPhoneNumberInstance {
     protected _version: V2010,
     payload: DependentPhoneNumberPayload,
     accountSid: string,
-    addressSid?: string
+    addressSid: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/local.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/local.ts
@@ -461,7 +461,7 @@ export class LocalInstance {
     protected _version: V2010,
     payload: LocalPayload,
     accountSid: string,
-    countryCode?: string
+    countryCode: string
   ) {
     this.friendlyName = payload.friendly_name;
     this.phoneNumber = payload.phone_number;

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/machineToMachine.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/machineToMachine.ts
@@ -475,7 +475,7 @@ export class MachineToMachineInstance {
     protected _version: V2010,
     payload: MachineToMachinePayload,
     accountSid: string,
-    countryCode?: string
+    countryCode: string
   ) {
     this.friendlyName = payload.friendly_name;
     this.phoneNumber = payload.phone_number;

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/mobile.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/mobile.ts
@@ -461,7 +461,7 @@ export class MobileInstance {
     protected _version: V2010,
     payload: MobilePayload,
     accountSid: string,
-    countryCode?: string
+    countryCode: string
   ) {
     this.friendlyName = payload.friendly_name;
     this.phoneNumber = payload.phone_number;

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/national.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/national.ts
@@ -463,7 +463,7 @@ export class NationalInstance {
     protected _version: V2010,
     payload: NationalPayload,
     accountSid: string,
-    countryCode?: string
+    countryCode: string
   ) {
     this.friendlyName = payload.friendly_name;
     this.phoneNumber = payload.phone_number;

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/sharedCost.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/sharedCost.ts
@@ -463,7 +463,7 @@ export class SharedCostInstance {
     protected _version: V2010,
     payload: SharedCostPayload,
     accountSid: string,
-    countryCode?: string
+    countryCode: string
   ) {
     this.friendlyName = payload.friendly_name;
     this.phoneNumber = payload.phone_number;

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/tollFree.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/tollFree.ts
@@ -463,7 +463,7 @@ export class TollFreeInstance {
     protected _version: V2010,
     payload: TollFreePayload,
     accountSid: string,
-    countryCode?: string
+    countryCode: string
   ) {
     this.friendlyName = payload.friendly_name;
     this.phoneNumber = payload.phone_number;

--- a/lib/rest/api/v2010/account/availablePhoneNumberCountry/voip.ts
+++ b/lib/rest/api/v2010/account/availablePhoneNumberCountry/voip.ts
@@ -461,7 +461,7 @@ export class VoipInstance {
     protected _version: V2010,
     payload: VoipPayload,
     accountSid: string,
-    countryCode?: string
+    countryCode: string
   ) {
     this.friendlyName = payload.friendly_name;
     this.phoneNumber = payload.phone_number;

--- a/lib/rest/api/v2010/account/balance.ts
+++ b/lib/rest/api/v2010/account/balance.ts
@@ -106,7 +106,7 @@ export class BalanceInstance {
   constructor(
     protected _version: V2010,
     payload: BalancePayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.balance = payload.balance;

--- a/lib/rest/api/v2010/account/call/event.ts
+++ b/lib/rest/api/v2010/account/call/event.ts
@@ -304,7 +304,7 @@ export class EventInstance {
     protected _version: V2010,
     payload: EventPayload,
     accountSid: string,
-    callSid?: string
+    callSid: string
   ) {
     this.request = payload.request;
     this.response = payload.response;

--- a/lib/rest/api/v2010/account/call/feedback.ts
+++ b/lib/rest/api/v2010/account/call/feedback.ts
@@ -195,7 +195,7 @@ export class FeedbackInstance {
     protected _version: V2010,
     payload: FeedbackPayload,
     accountSid: string,
-    callSid?: string
+    callSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.dateCreated = deserialize.rfc2822DateTime(payload.date_created);
@@ -204,7 +204,7 @@ export class FeedbackInstance {
     this.qualityScore = deserialize.integer(payload.quality_score);
     this.sid = payload.sid;
 
-    this._solution = { accountSid, callSid: callSid || this.callSid };
+    this._solution = { accountSid, callSid };
   }
 
   /**

--- a/lib/rest/api/v2010/account/call/userDefinedMessage.ts
+++ b/lib/rest/api/v2010/account/call/userDefinedMessage.ts
@@ -150,7 +150,7 @@ export class UserDefinedMessageInstance {
     protected _version: V2010,
     payload: UserDefinedMessagePayload,
     accountSid: string,
-    callSid?: string
+    callSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.callSid = payload.call_sid;

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/local.ts
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/local.ts
@@ -566,7 +566,7 @@ export class LocalInstance {
   constructor(
     protected _version: V2010,
     payload: LocalPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.addressSid = payload.address_sid;

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/mobile.ts
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/mobile.ts
@@ -566,7 +566,7 @@ export class MobileInstance {
   constructor(
     protected _version: V2010,
     payload: MobilePayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.addressSid = payload.address_sid;

--- a/lib/rest/api/v2010/account/incomingPhoneNumber/tollFree.ts
+++ b/lib/rest/api/v2010/account/incomingPhoneNumber/tollFree.ts
@@ -572,7 +572,7 @@ export class TollFreeInstance {
   constructor(
     protected _version: V2010,
     payload: TollFreePayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.addressSid = payload.address_sid;

--- a/lib/rest/api/v2010/account/message/feedback.ts
+++ b/lib/rest/api/v2010/account/message/feedback.ts
@@ -156,7 +156,7 @@ export class FeedbackInstance {
     protected _version: V2010,
     payload: FeedbackPayload,
     accountSid: string,
-    messageSid?: string
+    messageSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.messageSid = payload.message_sid;

--- a/lib/rest/api/v2010/account/newKey.ts
+++ b/lib/rest/api/v2010/account/newKey.ts
@@ -146,7 +146,7 @@ export class NewKeyInstance {
   constructor(
     protected _version: V2010,
     payload: NewKeyPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.sid = payload.sid;
     this.friendlyName = payload.friendly_name;

--- a/lib/rest/api/v2010/account/newSigningKey.ts
+++ b/lib/rest/api/v2010/account/newSigningKey.ts
@@ -150,7 +150,7 @@ export class NewSigningKeyInstance {
   constructor(
     protected _version: V2010,
     payload: NewSigningKeyPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.sid = payload.sid;
     this.friendlyName = payload.friendly_name;

--- a/lib/rest/api/v2010/account/token.ts
+++ b/lib/rest/api/v2010/account/token.ts
@@ -154,7 +154,7 @@ export class TokenInstance {
   constructor(
     protected _version: V2010,
     payload: TokenPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.dateCreated = deserialize.rfc2822DateTime(payload.date_created);

--- a/lib/rest/api/v2010/account/usage/record.ts
+++ b/lib/rest/api/v2010/account/usage/record.ts
@@ -714,7 +714,7 @@ export class RecordInstance {
   constructor(
     protected _version: V2010,
     payload: RecordPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.apiVersion = payload.api_version;

--- a/lib/rest/api/v2010/account/usage/record/allTime.ts
+++ b/lib/rest/api/v2010/account/usage/record/allTime.ts
@@ -592,7 +592,7 @@ export class AllTimeInstance {
   constructor(
     protected _version: V2010,
     payload: AllTimePayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.apiVersion = payload.api_version;

--- a/lib/rest/api/v2010/account/usage/record/daily.ts
+++ b/lib/rest/api/v2010/account/usage/record/daily.ts
@@ -592,7 +592,7 @@ export class DailyInstance {
   constructor(
     protected _version: V2010,
     payload: DailyPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.apiVersion = payload.api_version;

--- a/lib/rest/api/v2010/account/usage/record/lastMonth.ts
+++ b/lib/rest/api/v2010/account/usage/record/lastMonth.ts
@@ -594,7 +594,7 @@ export class LastMonthInstance {
   constructor(
     protected _version: V2010,
     payload: LastMonthPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.apiVersion = payload.api_version;

--- a/lib/rest/api/v2010/account/usage/record/monthly.ts
+++ b/lib/rest/api/v2010/account/usage/record/monthly.ts
@@ -592,7 +592,7 @@ export class MonthlyInstance {
   constructor(
     protected _version: V2010,
     payload: MonthlyPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.apiVersion = payload.api_version;

--- a/lib/rest/api/v2010/account/usage/record/thisMonth.ts
+++ b/lib/rest/api/v2010/account/usage/record/thisMonth.ts
@@ -594,7 +594,7 @@ export class ThisMonthInstance {
   constructor(
     protected _version: V2010,
     payload: ThisMonthPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.apiVersion = payload.api_version;

--- a/lib/rest/api/v2010/account/usage/record/today.ts
+++ b/lib/rest/api/v2010/account/usage/record/today.ts
@@ -592,7 +592,7 @@ export class TodayInstance {
   constructor(
     protected _version: V2010,
     payload: TodayPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.apiVersion = payload.api_version;

--- a/lib/rest/api/v2010/account/usage/record/yearly.ts
+++ b/lib/rest/api/v2010/account/usage/record/yearly.ts
@@ -592,7 +592,7 @@ export class YearlyInstance {
   constructor(
     protected _version: V2010,
     payload: YearlyPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.apiVersion = payload.api_version;

--- a/lib/rest/api/v2010/account/usage/record/yesterday.ts
+++ b/lib/rest/api/v2010/account/usage/record/yesterday.ts
@@ -594,7 +594,7 @@ export class YesterdayInstance {
   constructor(
     protected _version: V2010,
     payload: YesterdayPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.apiVersion = payload.api_version;

--- a/lib/rest/api/v2010/account/validationRequest.ts
+++ b/lib/rest/api/v2010/account/validationRequest.ts
@@ -163,7 +163,7 @@ export class ValidationRequestInstance {
   constructor(
     protected _version: V2010,
     payload: ValidationRequestPayload,
-    accountSid?: string
+    accountSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.callSid = payload.call_sid;

--- a/lib/rest/autopilot/v1/assistant/defaults.ts
+++ b/lib/rest/autopilot/v1/assistant/defaults.ts
@@ -175,14 +175,14 @@ export class DefaultsInstance {
   constructor(
     protected _version: V1,
     payload: DefaultsPayload,
-    assistantSid?: string
+    assistantSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.assistantSid = payload.assistant_sid;
     this.url = payload.url;
     this.data = payload.data;
 
-    this._solution = { assistantSid: assistantSid || this.assistantSid };
+    this._solution = { assistantSid };
   }
 
   /**

--- a/lib/rest/autopilot/v1/assistant/styleSheet.ts
+++ b/lib/rest/autopilot/v1/assistant/styleSheet.ts
@@ -175,14 +175,14 @@ export class StyleSheetInstance {
   constructor(
     protected _version: V1,
     payload: StyleSheetPayload,
-    assistantSid?: string
+    assistantSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.assistantSid = payload.assistant_sid;
     this.url = payload.url;
     this.data = payload.data;
 
-    this._solution = { assistantSid: assistantSid || this.assistantSid };
+    this._solution = { assistantSid };
   }
 
   /**

--- a/lib/rest/autopilot/v1/assistant/task/taskActions.ts
+++ b/lib/rest/autopilot/v1/assistant/task/taskActions.ts
@@ -180,7 +180,7 @@ export class TaskActionsInstance {
     protected _version: V1,
     payload: TaskActionsPayload,
     assistantSid: string,
-    taskSid?: string
+    taskSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.assistantSid = payload.assistant_sid;
@@ -188,7 +188,7 @@ export class TaskActionsInstance {
     this.url = payload.url;
     this.data = payload.data;
 
-    this._solution = { assistantSid, taskSid: taskSid || this.taskSid };
+    this._solution = { assistantSid, taskSid };
   }
 
   /**

--- a/lib/rest/autopilot/v1/assistant/task/taskStatistics.ts
+++ b/lib/rest/autopilot/v1/assistant/task/taskStatistics.ts
@@ -107,7 +107,7 @@ export class TaskStatisticsInstance {
     protected _version: V1,
     payload: TaskStatisticsPayload,
     assistantSid: string,
-    taskSid?: string
+    taskSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.assistantSid = payload.assistant_sid;
@@ -116,7 +116,7 @@ export class TaskStatisticsInstance {
     this.fieldsCount = deserialize.integer(payload.fields_count);
     this.url = payload.url;
 
-    this._solution = { assistantSid, taskSid: taskSid || this.taskSid };
+    this._solution = { assistantSid, taskSid };
   }
 
   /**

--- a/lib/rest/bulkexports/v1/export/day.ts
+++ b/lib/rest/bulkexports/v1/export/day.ts
@@ -141,6 +141,11 @@ interface DayPayload extends DayResource, Page.TwilioResponsePayload {}
 
 interface DayResource {
   redirect_to?: string | null;
+  day?: string | null;
+  size?: number | null;
+  create_date?: string | null;
+  friendly_name?: string | null;
+  resource_type?: string | null;
 }
 
 export class DayInstance {
@@ -154,11 +159,36 @@ export class DayInstance {
     day?: string
   ) {
     this.redirectTo = payload.redirect_to;
+    this.day = payload.day;
+    this.size = deserialize.integer(payload.size);
+    this.createDate = payload.create_date;
+    this.friendlyName = payload.friendly_name;
+    this.resourceType = payload.resource_type;
 
     this._solution = { resourceType, day: day || this.day };
   }
 
   redirectTo?: string | null;
+  /**
+   * The date of the data in the file
+   */
+  day?: string | null;
+  /**
+   * Size of the file in bytes
+   */
+  size?: number | null;
+  /**
+   * The date when resource is created
+   */
+  createDate?: string | null;
+  /**
+   * The friendly name specified when creating the job
+   */
+  friendlyName?: string | null;
+  /**
+   * The type of communication – Messages, Calls, Conferences, and Participants
+   */
+  resourceType?: string | null;
 
   private get _proxy(): DayContext {
     this._context =
@@ -192,6 +222,11 @@ export class DayInstance {
   toJSON() {
     return {
       redirectTo: this.redirectTo,
+      day: this.day,
+      size: this.size,
+      createDate: this.createDate,
+      friendlyName: this.friendlyName,
+      resourceType: this.resourceType,
     };
   }
 

--- a/lib/rest/bulkexports/v1/export/exportCustomJob.ts
+++ b/lib/rest/bulkexports/v1/export/exportCustomJob.ts
@@ -418,7 +418,7 @@ export class ExportCustomJobInstance {
   constructor(
     protected _version: V1,
     payload: ExportCustomJobPayload,
-    resourceType?: string
+    resourceType: string
   ) {
     this.friendlyName = payload.friendly_name;
     this.resourceType = payload.resource_type;

--- a/lib/rest/chat/v1/service/user/userChannel.ts
+++ b/lib/rest/chat/v1/service/user/userChannel.ts
@@ -315,7 +315,7 @@ export class UserChannelInstance {
     protected _version: V1,
     payload: UserChannelPayload,
     serviceSid: string,
-    userSid?: string
+    userSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.serviceSid = payload.service_sid;

--- a/lib/rest/chat/v3/channel.ts
+++ b/lib/rest/chat/v3/channel.ts
@@ -164,7 +164,7 @@ export class ChannelInstance {
   constructor(
     protected _version: V3,
     payload: ChannelPayload,
-    serviceSid: string,
+    serviceSid?: string,
     sid?: string
   ) {
     this.sid = payload.sid;
@@ -182,7 +182,10 @@ export class ChannelInstance {
     this.messagingServiceSid = payload.messaging_service_sid;
     this.url = payload.url;
 
-    this._solution = { serviceSid, sid: sid || this.sid };
+    this._solution = {
+      serviceSid: serviceSid || this.serviceSid,
+      sid: sid || this.sid,
+    };
   }
 
   /**

--- a/lib/rest/content/v1/content/approvalFetch.ts
+++ b/lib/rest/content/v1/content/approvalFetch.ts
@@ -98,14 +98,14 @@ export class ApprovalFetchInstance {
   constructor(
     protected _version: V1,
     payload: ApprovalFetchPayload,
-    sid?: string
+    sid: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;
     this.whatsapp = payload.whatsapp;
     this.url = payload.url;
 
-    this._solution = { sid: sid || this.sid };
+    this._solution = { sid };
   }
 
   /**

--- a/lib/rest/conversations/v1/service/configuration.ts
+++ b/lib/rest/conversations/v1/service/configuration.ts
@@ -196,7 +196,7 @@ export class ConfigurationInstance {
   constructor(
     protected _version: V1,
     payload: ConfigurationPayload,
-    chatServiceSid?: string
+    chatServiceSid: string
   ) {
     this.chatServiceSid = payload.chat_service_sid;
     this.defaultConversationCreatorRoleSid =
@@ -207,7 +207,7 @@ export class ConfigurationInstance {
     this.links = payload.links;
     this.reachabilityEnabled = payload.reachability_enabled;
 
-    this._solution = { chatServiceSid: chatServiceSid || this.chatServiceSid };
+    this._solution = { chatServiceSid };
   }
 
   /**

--- a/lib/rest/conversations/v1/service/configuration/notification.ts
+++ b/lib/rest/conversations/v1/service/configuration/notification.ts
@@ -238,7 +238,7 @@ export class NotificationInstance {
   constructor(
     protected _version: V1,
     payload: NotificationPayload,
-    chatServiceSid?: string
+    chatServiceSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.chatServiceSid = payload.chat_service_sid;
@@ -248,7 +248,7 @@ export class NotificationInstance {
     this.logEnabled = payload.log_enabled;
     this.url = payload.url;
 
-    this._solution = { chatServiceSid: chatServiceSid || this.chatServiceSid };
+    this._solution = { chatServiceSid };
   }
 
   /**

--- a/lib/rest/conversations/v1/service/configuration/webhook.ts
+++ b/lib/rest/conversations/v1/service/configuration/webhook.ts
@@ -191,7 +191,7 @@ export class WebhookInstance {
   constructor(
     protected _version: V1,
     payload: WebhookPayload,
-    chatServiceSid?: string
+    chatServiceSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.chatServiceSid = payload.chat_service_sid;
@@ -201,7 +201,7 @@ export class WebhookInstance {
     this.method = payload.method;
     this.url = payload.url;
 
-    this._solution = { chatServiceSid: chatServiceSid || this.chatServiceSid };
+    this._solution = { chatServiceSid };
   }
 
   /**

--- a/lib/rest/conversations/v1/service/participantConversation.ts
+++ b/lib/rest/conversations/v1/service/participantConversation.ts
@@ -360,7 +360,7 @@ export class ParticipantConversationInstance {
   constructor(
     protected _version: V1,
     payload: ParticipantConversationPayload,
-    chatServiceSid?: string
+    chatServiceSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.chatServiceSid = payload.chat_service_sid;

--- a/lib/rest/events/v1/sink/sinkTest.ts
+++ b/lib/rest/events/v1/sink/sinkTest.ts
@@ -97,7 +97,7 @@ interface SinkTestResource {
 }
 
 export class SinkTestInstance {
-  constructor(protected _version: V1, payload: SinkTestPayload, sid?: string) {
+  constructor(protected _version: V1, payload: SinkTestPayload, sid: string) {
     this.result = payload.result;
   }
 

--- a/lib/rest/events/v1/sink/sinkValidate.ts
+++ b/lib/rest/events/v1/sink/sinkValidate.ts
@@ -132,7 +132,7 @@ export class SinkValidateInstance {
   constructor(
     protected _version: V1,
     payload: SinkValidatePayload,
-    sid?: string
+    sid: string
   ) {
     this.result = payload.result;
   }

--- a/lib/rest/flexApi/v1/interaction/interactionChannel/interactionChannelInvite.ts
+++ b/lib/rest/flexApi/v1/interaction/interactionChannel/interactionChannelInvite.ts
@@ -408,7 +408,7 @@ export class InteractionChannelInviteInstance {
     protected _version: V1,
     payload: InteractionChannelInvitePayload,
     interactionSid: string,
-    channelSid?: string
+    channelSid: string
   ) {
     this.sid = payload.sid;
     this.interactionSid = payload.interaction_sid;

--- a/lib/rest/insights/v1/call/annotation.ts
+++ b/lib/rest/insights/v1/call/annotation.ts
@@ -213,7 +213,7 @@ export class AnnotationInstance {
   constructor(
     protected _version: V1,
     payload: AnnotationPayload,
-    callSid?: string
+    callSid: string
   ) {
     this.callSid = payload.call_sid;
     this.accountSid = payload.account_sid;
@@ -226,7 +226,7 @@ export class AnnotationInstance {
     this.incident = payload.incident;
     this.url = payload.url;
 
-    this._solution = { callSid: callSid || this.callSid };
+    this._solution = { callSid };
   }
 
   /**

--- a/lib/rest/insights/v1/call/callSummary.ts
+++ b/lib/rest/insights/v1/call/callSummary.ts
@@ -182,7 +182,7 @@ export class CallSummaryInstance {
   constructor(
     protected _version: V1,
     payload: CallSummaryPayload,
-    callSid?: string
+    callSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.callSid = payload.call_sid;
@@ -208,7 +208,7 @@ export class CallSummaryInstance {
     this.trust = payload.trust;
     this.annotation = payload.annotation;
 
-    this._solution = { callSid: callSid || this.callSid };
+    this._solution = { callSid };
   }
 
   accountSid?: string | null;

--- a/lib/rest/insights/v1/call/event.ts
+++ b/lib/rest/insights/v1/call/event.ts
@@ -323,7 +323,7 @@ interface EventResource {
 }
 
 export class EventInstance {
-  constructor(protected _version: V1, payload: EventPayload, callSid?: string) {
+  constructor(protected _version: V1, payload: EventPayload, callSid: string) {
     this.timestamp = payload.timestamp;
     this.callSid = payload.call_sid;
     this.accountSid = payload.account_sid;

--- a/lib/rest/insights/v1/call/metric.ts
+++ b/lib/rest/insights/v1/call/metric.ts
@@ -329,11 +329,7 @@ interface MetricResource {
 }
 
 export class MetricInstance {
-  constructor(
-    protected _version: V1,
-    payload: MetricPayload,
-    callSid?: string
-  ) {
+  constructor(protected _version: V1, payload: MetricPayload, callSid: string) {
     this.timestamp = payload.timestamp;
     this.callSid = payload.call_sid;
     this.accountSid = payload.account_sid;

--- a/lib/rest/ipMessaging/v1/service/user/userChannel.ts
+++ b/lib/rest/ipMessaging/v1/service/user/userChannel.ts
@@ -315,7 +315,7 @@ export class UserChannelInstance {
     protected _version: V1,
     payload: UserChannelPayload,
     serviceSid: string,
-    userSid?: string
+    userSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.serviceSid = payload.service_sid;

--- a/lib/rest/media/v1/playerStreamer/playbackGrant.ts
+++ b/lib/rest/media/v1/playerStreamer/playbackGrant.ts
@@ -171,7 +171,7 @@ export class PlaybackGrantInstance {
   constructor(
     protected _version: V1,
     payload: PlaybackGrantPayload,
-    sid?: string
+    sid: string
   ) {
     this.sid = payload.sid;
     this.url = payload.url;
@@ -179,7 +179,7 @@ export class PlaybackGrantInstance {
     this.dateCreated = deserialize.iso8601DateTime(payload.date_created);
     this.grant = payload.grant;
 
-    this._solution = { sid: sid || this.sid };
+    this._solution = { sid };
   }
 
   /**

--- a/lib/rest/messaging/v1/service/usAppToPersonUsecase.ts
+++ b/lib/rest/messaging/v1/service/usAppToPersonUsecase.ts
@@ -148,7 +148,7 @@ export class UsAppToPersonUsecaseInstance {
   constructor(
     protected _version: V1,
     payload: UsAppToPersonUsecasePayload,
-    messagingServiceSid?: string
+    messagingServiceSid: string
   ) {
     this.usAppToPersonUsecases = payload.us_app_to_person_usecases;
   }

--- a/lib/rest/notify/v1/service/notification.ts
+++ b/lib/rest/notify/v1/service/notification.ts
@@ -229,7 +229,7 @@ export class NotificationInstance {
   constructor(
     protected _version: V1,
     payload: NotificationPayload,
-    serviceSid?: string
+    serviceSid: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;

--- a/lib/rest/numbers/v2/regulatoryCompliance/bundle/bundleCopy.ts
+++ b/lib/rest/numbers/v2/regulatoryCompliance/bundle/bundleCopy.ts
@@ -394,7 +394,7 @@ export class BundleCopyInstance {
   constructor(
     protected _version: V2,
     payload: BundleCopyPayload,
-    bundleSid?: string
+    bundleSid: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;

--- a/lib/rest/numbers/v2/regulatoryCompliance/bundle/replaceItems.ts
+++ b/lib/rest/numbers/v2/regulatoryCompliance/bundle/replaceItems.ts
@@ -158,7 +158,7 @@ export class ReplaceItemsInstance {
   constructor(
     protected _version: V2,
     payload: ReplaceItemsPayload,
-    bundleSid?: string
+    bundleSid: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;

--- a/lib/rest/preview/hosted_numbers/authorizationDocument/dependentHostedNumberOrder.ts
+++ b/lib/rest/preview/hosted_numbers/authorizationDocument/dependentHostedNumberOrder.ts
@@ -422,7 +422,7 @@ export class DependentHostedNumberOrderInstance {
   constructor(
     protected _version: HostedNumbers,
     payload: DependentHostedNumberOrderPayload,
-    signingDocumentSid?: string
+    signingDocumentSid: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;

--- a/lib/rest/preview/understand/assistant/assistantFallbackActions.ts
+++ b/lib/rest/preview/understand/assistant/assistantFallbackActions.ts
@@ -193,14 +193,14 @@ export class AssistantFallbackActionsInstance {
   constructor(
     protected _version: Understand,
     payload: AssistantFallbackActionsPayload,
-    assistantSid?: string
+    assistantSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.assistantSid = payload.assistant_sid;
     this.url = payload.url;
     this.data = payload.data;
 
-    this._solution = { assistantSid: assistantSid || this.assistantSid };
+    this._solution = { assistantSid };
   }
 
   accountSid?: string | null;

--- a/lib/rest/preview/understand/assistant/assistantInitiationActions.ts
+++ b/lib/rest/preview/understand/assistant/assistantInitiationActions.ts
@@ -193,14 +193,14 @@ export class AssistantInitiationActionsInstance {
   constructor(
     protected _version: Understand,
     payload: AssistantInitiationActionsPayload,
-    assistantSid?: string
+    assistantSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.assistantSid = payload.assistant_sid;
     this.url = payload.url;
     this.data = payload.data;
 
-    this._solution = { assistantSid: assistantSid || this.assistantSid };
+    this._solution = { assistantSid };
   }
 
   accountSid?: string | null;

--- a/lib/rest/preview/understand/assistant/styleSheet.ts
+++ b/lib/rest/preview/understand/assistant/styleSheet.ts
@@ -175,14 +175,14 @@ export class StyleSheetInstance {
   constructor(
     protected _version: Understand,
     payload: StyleSheetPayload,
-    assistantSid?: string
+    assistantSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.assistantSid = payload.assistant_sid;
     this.url = payload.url;
     this.data = payload.data;
 
-    this._solution = { assistantSid: assistantSid || this.assistantSid };
+    this._solution = { assistantSid };
   }
 
   /**

--- a/lib/rest/preview/understand/assistant/task/taskActions.ts
+++ b/lib/rest/preview/understand/assistant/task/taskActions.ts
@@ -184,7 +184,7 @@ export class TaskActionsInstance {
     protected _version: Understand,
     payload: TaskActionsPayload,
     assistantSid: string,
-    taskSid?: string
+    taskSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.assistantSid = payload.assistant_sid;
@@ -192,7 +192,7 @@ export class TaskActionsInstance {
     this.url = payload.url;
     this.data = payload.data;
 
-    this._solution = { assistantSid, taskSid: taskSid || this.taskSid };
+    this._solution = { assistantSid, taskSid };
   }
 
   /**

--- a/lib/rest/preview/understand/assistant/task/taskStatistics.ts
+++ b/lib/rest/preview/understand/assistant/task/taskStatistics.ts
@@ -111,7 +111,7 @@ export class TaskStatisticsInstance {
     protected _version: Understand,
     payload: TaskStatisticsPayload,
     assistantSid: string,
-    taskSid?: string
+    taskSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.assistantSid = payload.assistant_sid;
@@ -120,7 +120,7 @@ export class TaskStatisticsInstance {
     this.fieldsCount = deserialize.integer(payload.fields_count);
     this.url = payload.url;
 
-    this._solution = { assistantSid, taskSid: taskSid || this.taskSid };
+    this._solution = { assistantSid, taskSid };
   }
 
   /**

--- a/lib/rest/preview/wireless/sim/usage.ts
+++ b/lib/rest/preview/wireless/sim/usage.ts
@@ -143,7 +143,7 @@ export class UsageInstance {
   constructor(
     protected _version: Wireless,
     payload: UsagePayload,
-    simSid?: string
+    simSid: string
   ) {
     this.simSid = payload.sim_sid;
     this.simUniqueName = payload.sim_unique_name;
@@ -155,7 +155,7 @@ export class UsageInstance {
     this.dataCosts = payload.data_costs;
     this.url = payload.url;
 
-    this._solution = { simSid: simSid || this.simSid };
+    this._solution = { simSid };
   }
 
   simSid?: string | null;

--- a/lib/rest/pricing/v1/messaging/country.ts
+++ b/lib/rest/pricing/v1/messaging/country.ts
@@ -32,6 +32,12 @@ export class PricingV1MessagingMessagingCountryInstanceOutboundSmsPrices {
   "prices"?: Array<PricingV1MessagingMessagingCountryInstanceOutboundSmsPricesPrices>;
 }
 
+export class PricingV1MessagingMessagingCountryInstanceOutboundSmsPricesPrices {
+  "basePrice"?: number;
+  "currentPrice"?: number;
+  "numberType"?: string;
+}
+
 /**
  * Options to pass to each
  *

--- a/lib/rest/serverless/v1/service/build/buildStatus.ts
+++ b/lib/rest/serverless/v1/service/build/buildStatus.ts
@@ -108,7 +108,7 @@ export class BuildStatusInstance {
     protected _version: V1,
     payload: BuildStatusPayload,
     serviceSid: string,
-    sid?: string
+    sid: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;
@@ -116,7 +116,7 @@ export class BuildStatusInstance {
     this.status = payload.status;
     this.url = payload.url;
 
-    this._solution = { serviceSid, sid: sid || this.sid };
+    this._solution = { serviceSid, sid };
   }
 
   /**

--- a/lib/rest/serverless/v1/service/function/functionVersion/functionVersionContent.ts
+++ b/lib/rest/serverless/v1/service/function/functionVersion/functionVersionContent.ts
@@ -121,7 +121,7 @@ export class FunctionVersionContentInstance {
     payload: FunctionVersionContentPayload,
     serviceSid: string,
     functionSid: string,
-    sid?: string
+    sid: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;
@@ -130,7 +130,7 @@ export class FunctionVersionContentInstance {
     this.content = payload.content;
     this.url = payload.url;
 
-    this._solution = { serviceSid, functionSid, sid: sid || this.sid };
+    this._solution = { serviceSid, functionSid, sid };
   }
 
   /**

--- a/lib/rest/studio/v1/flow/engagement/engagementContext.ts
+++ b/lib/rest/studio/v1/flow/engagement/engagementContext.ts
@@ -106,7 +106,7 @@ export class EngagementContextInstance {
     protected _version: V1,
     payload: EngagementContextPayload,
     flowSid: string,
-    engagementSid?: string
+    engagementSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.context = payload.context;
@@ -114,10 +114,7 @@ export class EngagementContextInstance {
     this.flowSid = payload.flow_sid;
     this.url = payload.url;
 
-    this._solution = {
-      flowSid,
-      engagementSid: engagementSid || this.engagementSid,
-    };
+    this._solution = { flowSid, engagementSid };
   }
 
   /**

--- a/lib/rest/studio/v1/flow/engagement/step/stepContext.ts
+++ b/lib/rest/studio/v1/flow/engagement/step/stepContext.ts
@@ -115,7 +115,7 @@ export class StepContextInstance {
     payload: StepContextPayload,
     flowSid: string,
     engagementSid: string,
-    stepSid?: string
+    stepSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.context = payload.context;
@@ -124,11 +124,7 @@ export class StepContextInstance {
     this.stepSid = payload.step_sid;
     this.url = payload.url;
 
-    this._solution = {
-      flowSid,
-      engagementSid,
-      stepSid: stepSid || this.stepSid,
-    };
+    this._solution = { flowSid, engagementSid, stepSid };
   }
 
   /**

--- a/lib/rest/studio/v1/flow/execution/executionContext.ts
+++ b/lib/rest/studio/v1/flow/execution/executionContext.ts
@@ -106,7 +106,7 @@ export class ExecutionContextInstance {
     protected _version: V1,
     payload: ExecutionContextPayload,
     flowSid: string,
-    executionSid?: string
+    executionSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.context = payload.context;
@@ -114,10 +114,7 @@ export class ExecutionContextInstance {
     this.executionSid = payload.execution_sid;
     this.url = payload.url;
 
-    this._solution = {
-      flowSid,
-      executionSid: executionSid || this.executionSid,
-    };
+    this._solution = { flowSid, executionSid };
   }
 
   /**

--- a/lib/rest/studio/v1/flow/execution/executionStep/executionStepContext.ts
+++ b/lib/rest/studio/v1/flow/execution/executionStep/executionStepContext.ts
@@ -117,7 +117,7 @@ export class ExecutionStepContextInstance {
     payload: ExecutionStepContextPayload,
     flowSid: string,
     executionSid: string,
-    stepSid?: string
+    stepSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.context = payload.context;
@@ -126,11 +126,7 @@ export class ExecutionStepContextInstance {
     this.stepSid = payload.step_sid;
     this.url = payload.url;
 
-    this._solution = {
-      flowSid,
-      executionSid,
-      stepSid: stepSid || this.stepSid,
-    };
+    this._solution = { flowSid, executionSid, stepSid };
   }
 
   /**

--- a/lib/rest/studio/v2/flow/execution/executionContext.ts
+++ b/lib/rest/studio/v2/flow/execution/executionContext.ts
@@ -106,7 +106,7 @@ export class ExecutionContextInstance {
     protected _version: V2,
     payload: ExecutionContextPayload,
     flowSid: string,
-    executionSid?: string
+    executionSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.context = payload.context;
@@ -114,10 +114,7 @@ export class ExecutionContextInstance {
     this.executionSid = payload.execution_sid;
     this.url = payload.url;
 
-    this._solution = {
-      flowSid,
-      executionSid: executionSid || this.executionSid,
-    };
+    this._solution = { flowSid, executionSid };
   }
 
   /**

--- a/lib/rest/studio/v2/flow/execution/executionStep/executionStepContext.ts
+++ b/lib/rest/studio/v2/flow/execution/executionStep/executionStepContext.ts
@@ -117,7 +117,7 @@ export class ExecutionStepContextInstance {
     payload: ExecutionStepContextPayload,
     flowSid: string,
     executionSid: string,
-    stepSid?: string
+    stepSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.context = payload.context;
@@ -126,11 +126,7 @@ export class ExecutionStepContextInstance {
     this.stepSid = payload.step_sid;
     this.url = payload.url;
 
-    this._solution = {
-      flowSid,
-      executionSid,
-      stepSid: stepSid || this.stepSid,
-    };
+    this._solution = { flowSid, executionSid, stepSid };
   }
 
   /**

--- a/lib/rest/studio/v2/flow/flowTestUser.ts
+++ b/lib/rest/studio/v2/flow/flowTestUser.ts
@@ -156,13 +156,13 @@ export class FlowTestUserInstance {
   constructor(
     protected _version: V2,
     payload: FlowTestUserPayload,
-    sid?: string
+    sid: string
   ) {
     this.sid = payload.sid;
     this.testUsers = payload.test_users;
     this.url = payload.url;
 
-    this._solution = { sid: sid || this.sid };
+    this._solution = { sid };
   }
 
   /**

--- a/lib/rest/supersim/v1/sim/billingPeriod.ts
+++ b/lib/rest/supersim/v1/sim/billingPeriod.ts
@@ -318,7 +318,7 @@ export class BillingPeriodInstance {
   constructor(
     protected _version: V1,
     payload: BillingPeriodPayload,
-    simSid?: string
+    simSid: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;

--- a/lib/rest/supersim/v1/sim/simIpAddress.ts
+++ b/lib/rest/supersim/v1/sim/simIpAddress.ts
@@ -306,7 +306,7 @@ export class SimIpAddressInstance {
   constructor(
     protected _version: V1,
     payload: SimIpAddressPayload,
-    simSid?: string
+    simSid: string
   ) {
     this.ipAddress = payload.ip_address;
     this.ipAddressVersion = payload.ip_address_version;

--- a/lib/rest/sync/v1/service/syncStream/streamMessage.ts
+++ b/lib/rest/sync/v1/service/syncStream/streamMessage.ts
@@ -141,7 +141,7 @@ export class StreamMessageInstance {
     protected _version: V1,
     payload: StreamMessagePayload,
     serviceSid: string,
-    streamSid?: string
+    streamSid: string
   ) {
     this.sid = payload.sid;
     this.data = payload.data;

--- a/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueueCumulativeStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueueCumulativeStatistics.ts
@@ -195,7 +195,7 @@ export class TaskQueueCumulativeStatisticsInstance {
     protected _version: V1,
     payload: TaskQueueCumulativeStatisticsPayload,
     workspaceSid: string,
-    taskQueueSid?: string
+    taskQueueSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.avgTaskAcceptanceTime = deserialize.integer(
@@ -235,10 +235,7 @@ export class TaskQueueCumulativeStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = {
-      workspaceSid,
-      taskQueueSid: taskQueueSid || this.taskQueueSid,
-    };
+    this._solution = { workspaceSid, taskQueueSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueueRealTimeStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueueRealTimeStatistics.ts
@@ -172,7 +172,7 @@ export class TaskQueueRealTimeStatisticsInstance {
     protected _version: V1,
     payload: TaskQueueRealTimeStatisticsPayload,
     workspaceSid: string,
-    taskQueueSid?: string
+    taskQueueSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.activityStatistics = payload.activity_statistics;
@@ -198,10 +198,7 @@ export class TaskQueueRealTimeStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = {
-      workspaceSid,
-      taskQueueSid: taskQueueSid || this.taskQueueSid,
-    };
+    this._solution = { workspaceSid, taskQueueSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueueStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueueStatistics.ts
@@ -166,7 +166,7 @@ export class TaskQueueStatisticsInstance {
     protected _version: V1,
     payload: TaskQueueStatisticsPayload,
     workspaceSid: string,
-    taskQueueSid?: string
+    taskQueueSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.cumulative = payload.cumulative;
@@ -175,10 +175,7 @@ export class TaskQueueStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = {
-      workspaceSid,
-      taskQueueSid: taskQueueSid || this.taskQueueSid,
-    };
+    this._solution = { workspaceSid, taskQueueSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueuesStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/taskQueue/taskQueuesStatistics.ts
@@ -373,7 +373,7 @@ export class TaskQueuesStatisticsInstance {
   constructor(
     protected _version: V1,
     payload: TaskQueuesStatisticsPayload,
-    workspaceSid?: string
+    workspaceSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.cumulative = payload.cumulative;

--- a/lib/rest/taskrouter/v1/workspace/worker/workerStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/worker/workerStatistics.ts
@@ -155,7 +155,7 @@ export class WorkerStatisticsInstance {
     protected _version: V1,
     payload: WorkerStatisticsPayload,
     workspaceSid: string,
-    workerSid?: string
+    workerSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.cumulative = payload.cumulative;
@@ -163,7 +163,7 @@ export class WorkerStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = { workspaceSid, workerSid: workerSid || this.workerSid };
+    this._solution = { workspaceSid, workerSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/worker/workersCumulativeStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/worker/workersCumulativeStatistics.ts
@@ -174,7 +174,7 @@ export class WorkersCumulativeStatisticsInstance {
   constructor(
     protected _version: V1,
     payload: WorkersCumulativeStatisticsPayload,
-    workspaceSid?: string
+    workspaceSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.startTime = deserialize.iso8601DateTime(payload.start_time);
@@ -201,7 +201,7 @@ export class WorkersCumulativeStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = { workspaceSid: workspaceSid || this.workspaceSid };
+    this._solution = { workspaceSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/worker/workersRealTimeStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/worker/workersRealTimeStatistics.ts
@@ -156,7 +156,7 @@ export class WorkersRealTimeStatisticsInstance {
   constructor(
     protected _version: V1,
     payload: WorkersRealTimeStatisticsPayload,
-    workspaceSid?: string
+    workspaceSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.activityStatistics = payload.activity_statistics;
@@ -164,7 +164,7 @@ export class WorkersRealTimeStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = { workspaceSid: workspaceSid || this.workspaceSid };
+    this._solution = { workspaceSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/worker/workersStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/worker/workersStatistics.ts
@@ -164,7 +164,7 @@ export class WorkersStatisticsInstance {
   constructor(
     protected _version: V1,
     payload: WorkersStatisticsPayload,
-    workspaceSid?: string
+    workspaceSid: string
   ) {
     this.realtime = payload.realtime;
     this.cumulative = payload.cumulative;
@@ -172,7 +172,7 @@ export class WorkersStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = { workspaceSid: workspaceSid || this.workspaceSid };
+    this._solution = { workspaceSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/workflow/workflowCumulativeStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/workflow/workflowCumulativeStatistics.ts
@@ -195,7 +195,7 @@ export class WorkflowCumulativeStatisticsInstance {
     protected _version: V1,
     payload: WorkflowCumulativeStatisticsPayload,
     workspaceSid: string,
-    workflowSid?: string
+    workflowSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.avgTaskAcceptanceTime = deserialize.integer(
@@ -236,10 +236,7 @@ export class WorkflowCumulativeStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = {
-      workspaceSid,
-      workflowSid: workflowSid || this.workflowSid,
-    };
+    this._solution = { workspaceSid, workflowSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/workflow/workflowRealTimeStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/workflow/workflowRealTimeStatistics.ts
@@ -167,7 +167,7 @@ export class WorkflowRealTimeStatisticsInstance {
     protected _version: V1,
     payload: WorkflowRealTimeStatisticsPayload,
     workspaceSid: string,
-    workflowSid?: string
+    workflowSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.longestTaskWaitingAge = deserialize.integer(
@@ -181,10 +181,7 @@ export class WorkflowRealTimeStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = {
-      workspaceSid,
-      workflowSid: workflowSid || this.workflowSid,
-    };
+    this._solution = { workspaceSid, workflowSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/workflow/workflowStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/workflow/workflowStatistics.ts
@@ -166,7 +166,7 @@ export class WorkflowStatisticsInstance {
     protected _version: V1,
     payload: WorkflowStatisticsPayload,
     workspaceSid: string,
-    workflowSid?: string
+    workflowSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.cumulative = payload.cumulative;
@@ -175,10 +175,7 @@ export class WorkflowStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = {
-      workspaceSid,
-      workflowSid: workflowSid || this.workflowSid,
-    };
+    this._solution = { workspaceSid, workflowSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/workspaceCumulativeStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/workspaceCumulativeStatistics.ts
@@ -187,7 +187,7 @@ export class WorkspaceCumulativeStatisticsInstance {
   constructor(
     protected _version: V1,
     payload: WorkspaceCumulativeStatisticsPayload,
-    workspaceSid?: string
+    workspaceSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.avgTaskAcceptanceTime = deserialize.integer(
@@ -227,7 +227,7 @@ export class WorkspaceCumulativeStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = { workspaceSid: workspaceSid || this.workspaceSid };
+    this._solution = { workspaceSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/workspaceRealTimeStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/workspaceRealTimeStatistics.ts
@@ -161,7 +161,7 @@ export class WorkspaceRealTimeStatisticsInstance {
   constructor(
     protected _version: V1,
     payload: WorkspaceRealTimeStatisticsPayload,
-    workspaceSid?: string
+    workspaceSid: string
   ) {
     this.accountSid = payload.account_sid;
     this.activityStatistics = payload.activity_statistics;
@@ -176,7 +176,7 @@ export class WorkspaceRealTimeStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = { workspaceSid: workspaceSid || this.workspaceSid };
+    this._solution = { workspaceSid };
   }
 
   /**

--- a/lib/rest/taskrouter/v1/workspace/workspaceStatistics.ts
+++ b/lib/rest/taskrouter/v1/workspace/workspaceStatistics.ts
@@ -158,7 +158,7 @@ export class WorkspaceStatisticsInstance {
   constructor(
     protected _version: V1,
     payload: WorkspaceStatisticsPayload,
-    workspaceSid?: string
+    workspaceSid: string
   ) {
     this.realtime = payload.realtime;
     this.cumulative = payload.cumulative;
@@ -166,7 +166,7 @@ export class WorkspaceStatisticsInstance {
     this.workspaceSid = payload.workspace_sid;
     this.url = payload.url;
 
-    this._solution = { workspaceSid: workspaceSid || this.workspaceSid };
+    this._solution = { workspaceSid };
   }
 
   /**

--- a/lib/rest/trunking/v1/trunk/recording.ts
+++ b/lib/rest/trunking/v1/trunk/recording.ts
@@ -184,12 +184,12 @@ export class RecordingInstance {
   constructor(
     protected _version: V1,
     payload: RecordingPayload,
-    trunkSid?: string
+    trunkSid: string
   ) {
     this.mode = payload.mode;
     this.trim = payload.trim;
 
-    this._solution = { trunkSid: trunkSid || this.trunkSid };
+    this._solution = { trunkSid };
   }
 
   mode?: RecordingRecordingMode;

--- a/lib/rest/verify/v2/service/entity/challenge/notification.ts
+++ b/lib/rest/verify/v2/service/entity/challenge/notification.ts
@@ -161,7 +161,7 @@ export class NotificationInstance {
     payload: NotificationPayload,
     serviceSid: string,
     identity: string,
-    challengeSid?: string
+    challengeSid: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;

--- a/lib/rest/verify/v2/service/entity/newFactor.ts
+++ b/lib/rest/verify/v2/service/entity/newFactor.ts
@@ -221,7 +221,7 @@ export class NewFactorInstance {
     protected _version: V2,
     payload: NewFactorPayload,
     serviceSid: string,
-    identity?: string
+    identity: string
   ) {
     this.sid = payload.sid;
     this.accountSid = payload.account_sid;

--- a/lib/rest/verify/v2/service/verificationCheck.ts
+++ b/lib/rest/verify/v2/service/verificationCheck.ts
@@ -174,7 +174,7 @@ export class VerificationCheckInstance {
   constructor(
     protected _version: V2,
     payload: VerificationCheckPayload,
-    serviceSid?: string
+    serviceSid: string
   ) {
     this.sid = payload.sid;
     this.serviceSid = payload.service_sid;

--- a/lib/rest/video/v1/room/participant/anonymize.ts
+++ b/lib/rest/video/v1/room/participant/anonymize.ts
@@ -114,7 +114,7 @@ export class AnonymizeInstance {
     protected _version: V1,
     payload: AnonymizePayload,
     roomSid: string,
-    sid?: string
+    sid: string
   ) {
     this.sid = payload.sid;
     this.roomSid = payload.room_sid;
@@ -128,7 +128,7 @@ export class AnonymizeInstance {
     this.duration = deserialize.integer(payload.duration);
     this.url = payload.url;
 
-    this._solution = { roomSid, sid: sid || this.sid };
+    this._solution = { roomSid, sid };
   }
 
   /**

--- a/lib/rest/video/v1/room/participant/subscribeRules.ts
+++ b/lib/rest/video/v1/room/participant/subscribeRules.ts
@@ -200,7 +200,7 @@ export class SubscribeRulesInstance {
     protected _version: V1,
     payload: SubscribeRulesPayload,
     roomSid: string,
-    participantSid?: string
+    participantSid: string
   ) {
     this.participantSid = payload.participant_sid;
     this.roomSid = payload.room_sid;

--- a/lib/rest/video/v1/room/recordingRules.ts
+++ b/lib/rest/video/v1/room/recordingRules.ts
@@ -193,7 +193,7 @@ export class RecordingRulesInstance {
   constructor(
     protected _version: V1,
     payload: RecordingRulesPayload,
-    roomSid?: string
+    roomSid: string
   ) {
     this.roomSid = payload.room_sid;
     this.rules = payload.rules;

--- a/lib/rest/voice/v1/dialingPermissions/country/highriskSpecialPrefix.ts
+++ b/lib/rest/voice/v1/dialingPermissions/country/highriskSpecialPrefix.ts
@@ -322,7 +322,7 @@ export class HighriskSpecialPrefixInstance {
   constructor(
     protected _version: V1,
     payload: HighriskSpecialPrefixPayload,
-    isoCode?: string
+    isoCode: string
   ) {
     this.prefix = payload.prefix;
   }

--- a/lib/rest/wireless/v1/sim/dataSession.ts
+++ b/lib/rest/wireless/v1/sim/dataSession.ts
@@ -318,7 +318,7 @@ export class DataSessionInstance {
   constructor(
     protected _version: V1,
     payload: DataSessionPayload,
-    simSid?: string
+    simSid: string
   ) {
     this.sid = payload.sid;
     this.simSid = payload.sim_sid;

--- a/lib/rest/wireless/v1/sim/usageRecord.ts
+++ b/lib/rest/wireless/v1/sim/usageRecord.ts
@@ -333,7 +333,7 @@ export class UsageRecordInstance {
   constructor(
     protected _version: V1,
     payload: UsageRecordPayload,
-    simSid?: string
+    simSid: string
   ) {
     this.simSid = payload.sim_sid;
     this.accountSid = payload.account_sid;


### PR DESCRIPTION
Path parameters now marked as required and not pulled from the instance payload when instantiating an instance if the parameters came from the parent path. Also, resources with different instance properties now have those additional properties added to the instance class.