### PR TITLE
test: bypass audit failures until v4 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ci": "npm run nyc && npm run nsp",
     "coverage": "nyc npm test",
     "jsdoc": "jsdoc -r lib -d docs",
-    "nsp": "if [ `npm --version | cut -d'.' -f1` -ge \"6\" ]; then npm audit --production; else echo \"npm audit is not available for npm < 6.0\"; fi",
+    "nsp": "if [ `npm --version | cut -d'.' -f1` -ge \"6\" ]; then npm audit --production || true; else echo \"npm audit is not available for npm < 6.0\"; fi",
     "nyc": "if [ `node --version | cut -d'.' -f1 | cut -c2-` -ge \"8\" ]; then npm run coverage; else npm test; fi"
   },
   "files": [


### PR DESCRIPTION
Relates to https://github.com/twilio/twilio-node/issues/846 and https://github.com/twilio/twilio-node/pull/847

twilio-node v3 supports Node v6/8/10 which are not supported by jsonwebtoken v9. But, after reviewing the vulnerabilities in jsonwebtoken v8, our helper lib is not affected (we don’t verify signatures, only do the signing, and we use default algorithms). This change is to bypass audit failures for v3. Note that v4 does not bypass the audit and uses jsonwebtoken v9.