### PR TITLE
chore: upgrade GitHub Actions dependencies

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -8,8 +8,14 @@ jobs:
     name: Validate title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         with:
-          types: chore docs fix feat test misc
+          types: |
+            chore
+            docs
+            fix
+            feat
+            misc
+            test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -20,12 +20,12 @@ jobs:
         node: [ 14, 16, 18, lts/* ]
     steps:
       - name: Checkout twilio-node
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 
@@ -57,19 +57,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout twilio-node
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: lts/*
 
       - run: npm install
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_AUTH_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV NODE_PATH /usr/local/lib/node_modules
 COPY lib ./lib
 COPY spec ./spec
 COPY examples ./examples
-COPY index.js package.json babel.config.js tsconfig.json ./
+COPY index.ts package.json babel.config.js tsconfig.json ./
 
 RUN npm install . --include=dev
 RUN npm install -g .


### PR DESCRIPTION
Fixes warning:
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.