### PR TITLE
chore: fix SMS messaging parse error

### DIFF
--- a/lib/base/RestException.js
+++ b/lib/base/RestException.js
@@ -3,14 +3,34 @@
 class RestException extends Error {
   constructor(response) {
     super('[HTTP ' + response.statusCode + '] Failed to execute request');
+    const [body, err] = parseResponseBody(response.body);
 
-    const body = typeof response.body === 'string' ? JSON.parse(response.body) : response.body;
     this.status = response.statusCode;
-    this.message = body.message;
-    this.code = body.code;
-    this.moreInfo = body.more_info; /* jshint ignore:line */
-    this.details = body.details;
+    if (body) {
+      this.message = body.message;
+      this.code = body.code;
+      this.moreInfo = body.more_info; /* jshint ignore:line */
+      this.details = body.details;
+    }
   }
 }
-
+/**
+ * @param {serialized object | object} response_body
+ * @desc returns a tuple containing the reponse_body in object form or null
+ * and an json parse error.
+ * @returns {[responseBody: object | null , err]} err is the json parse error
+ */
+function parseResponseBody(response_body) {
+  let body = {};
+  let err = null;
+  try {
+    body = JSON.parse(response_body);
+  } catch (err) {
+    const isObject =
+      Object.prototype.toString.call(response_body) === '[object Object]';
+    body = isObject ? response_body : null;
+    err = err;
+  }
+  return [body, err];
+}
 module.exports = RestException;


### PR DESCRIPTION
Chore: fix SMS messaging parse error.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

A short description of what this PR does.

If the JSON.parse ever parses a malformed stringed response , error class will not populate its member variables.
The goal is to always produce an object to populate the member variables or produce a null to flag a no-op.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
