### PR TITLE
fix: stringify non-string path param response properties

### DIFF
--- a/lib/rest/studio/v2/flow/flowRevision.ts
+++ b/lib/rest/studio/v2/flow/flowRevision.ts
@@ -190,7 +190,7 @@ export class FlowRevisionInstance {
     this.dateUpdated = deserialize.iso8601DateTime(payload.date_updated);
     this.url = payload.url;
 
-    this._solution = { sid, revision: revision || this.revision };
+    this._solution = { sid, revision: revision || this.revision.toString() };
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jshint": "jshint lib/rest/** lib/base/** lib/http/**",
     "jscs": "eslint lib/base/**/**.js lib/http/**/**.js --fix",
     "prepublish": "npm run build",
-    "build": "tsc || true && cp package.json dist/",
+    "build": "tsc && cp package.json dist/",
     "check": "npm run jshint && npm run jscs",
     "ci": "npm run test && npm run nsp && npm run prettier-check",
     "jsdoc": "jsdoc -r lib -d docs",


### PR DESCRIPTION
This removes TypeScript errors for non-matching types.