### PR TITLE
fix: update SMS messaging parse error

### DIFF
--- a/lib/base/RestException.ts
+++ b/lib/base/RestException.ts
@@ -9,15 +9,39 @@ export default class RestException extends Error {
 
   constructor(response) {
     super("[HTTP " + response.statusCode + "] Failed to execute request");
+    const [body, bodyParseError] = parseResponseBody(response.body);
 
-    const body =
-      typeof response.body === "string"
-        ? JSON.parse(response.body)
-        : response.body;
     this.status = response.statusCode;
-    this.message = body.message;
-    this.code = body.code;
-    this.moreInfo = body.more_info; /* jshint ignore:line */
-    this.details = body.details;
+    if (body) {
+      this.message = body.message;
+      this.code = body.code;
+      this.moreInfo = body.more_info; /* jshint ignore:line */
+      this.details = body.details;
+    }
+    if (body === null) {
+      this.message = "Failed to parse response body";
+      this.code = 12100;
+      this.moreInfo = "https://www.twilio.com/docs/api/errors/12100";
+      this.details = { error: bodyParseError };
+    }
   }
+}
+/**
+ * @param {serialized object | object} response_body
+ * @desc returns a tuple containing the reponse_body in object form or null
+ * and an json parse error.
+ * @returns {[responseBody: object | null , err]} err is the json parse error
+ */
+function parseResponseBody(response_body) {
+  let body = {};
+  let err = null;
+  try {
+    body = JSON.parse(response_body);
+  } catch (catchError) {
+    const isObject =
+      Object.prototype.toString.call(response_body) === "[object Object]";
+    body = isObject ? response_body : null;
+    err = catchError;
+  }
+  return [body, err];
 }

--- a/spec/unit/base/RestException.spec.ts
+++ b/spec/unit/base/RestException.spec.ts
@@ -18,16 +18,15 @@ describe("exception gets created from string", function () {
   it("should test serialize from improper json string", function () {
     const response = {
       statusCode: 200,
-      body: '{message":test", "code:81022,"more_info": "https://www.twilio.com/docs/errors/12100"}',
+      body: '{message":test", "code:81022,"more_info": "https://www.twilio.com/docs/errors/81022"}',
     };
     const exception = new RestException(response);
     expect(exception.status).toEqual(200);
-    expect(exception.message).toEqual("Failed to parse response body");
-    expect(exception.code).toEqual(12100);
-    expect(exception.moreInfo).toEqual(
-      "https://www.twilio.com/docs/api/errors/12100"
+    expect(exception.message).toEqual(
+      `[HTTP ${response.statusCode}] Failed to execute request`
     );
-    expect(exception.details["error"] instanceof Error).toBe(true);
+    expect(exception.code).toEqual(undefined);
+    expect(exception.moreInfo).toEqual(undefined);
   });
 });
 

--- a/spec/unit/base/RestException.spec.ts
+++ b/spec/unit/base/RestException.spec.ts
@@ -6,6 +6,7 @@ describe("exception gets created from string", function () {
       statusCode: 200,
       body: '{"message":"test", "code":81022,"more_info": "https://www.twilio.com/docs/errors/81022"}',
     };
+
     const exception = new RestException(response);
     expect(exception.status).toEqual(200);
     expect(exception.message).toEqual("test");
@@ -13,6 +14,20 @@ describe("exception gets created from string", function () {
     expect(exception.moreInfo).toEqual(
       "https://www.twilio.com/docs/errors/81022"
     );
+  });
+  it("should test serialize from improper json string", function () {
+    const response = {
+      statusCode: 200,
+      body: '{message":test", "code:81022,"more_info": "https://www.twilio.com/docs/errors/12100"}',
+    };
+    const exception = new RestException(response);
+    expect(exception.status).toEqual(200);
+    expect(exception.message).toEqual("Failed to parse response body");
+    expect(exception.code).toEqual(12100);
+    expect(exception.moreInfo).toEqual(
+      "https://www.twilio.com/docs/api/errors/12100"
+    );
+    expect(exception.details["error"] instanceof Error).toBe(true);
   });
 });
 


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

Fixes https://github.com/twilio/twilio-node/issues/715

if the messageBody is malformed then there will be a json parse error since the only check to allow parse is whether the body be a string or not. If we wrap the parse in a try catch, we can code a gentler response.

- Assumptions
  - ~~**1: Assuming that details is where the error details are located**~~
    - ~~I have populated the details property inside the exception object with the parse error `{error: bodyParseError}`. For more information, peruse the new unit test described with "should test serialize from improper json string".~~ 
    - on malformed json response_body, the exception should contain undefined properties except for message which is overwritten by the call to super.
  - **2: Assuming that the logger is catching the RestException and not another area of code:**
    - Because this is an intermittent bug, i cannot be fully certain that this PR fixes the parse issue.
    - The lacking string-checking pattern is also found in other locations: 
      - [twilio-node/Version.ts at 5e93c1379fbcb4ea0f7bdc771597755a20950369 · twilio/twilio-node · GitHub](https://github.com/twilio/twilio-node/blob/5e93c1379fbcb4ea0f7bdc771597755a20950369/lib/base/Version.ts#L104)
    - I have contained the scope of this PR to only the RestException

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
