### PR TITLE
chore: cleanup CA bundle setting of request client

### DIFF
--- a/lib/base/RequestClient.ts
+++ b/lib/base/RequestClient.ts
@@ -97,7 +97,6 @@ export interface RequestClientOptions {
 export default class RequestClient {
   defaultTimeout: number;
   axios: AxiosInstance;
-  ca?: string | Buffer;
   lastResponse?: Response<any>;
   lastRequest?: Request<any>;
 
@@ -131,9 +130,8 @@ export default class RequestClient {
     // sets https agent CA bundle if defined in CA bundle filepath env variable
     if (process.env.TWILIO_CA_BUNDLE !== undefined) {
       if (agentOpts.ca === undefined) {
-        this.ca = fs.readFileSync(process.env.TWILIO_CA_BUNDLE);
+        agentOpts.ca = fs.readFileSync(process.env.TWILIO_CA_BUNDLE);
       }
-      agentOpts.ca = this.ca;
     }
 
     let agent;
@@ -192,7 +190,7 @@ export default class RequestClient {
       headers.Authorization = "Basic " + auth;
     }
 
-    var options: AxiosRequestConfig = {
+    const options: AxiosRequestConfig = {
       timeout: opts.timeout || this.defaultTimeout,
       maxRedirects: opts.allowRedirects ? 10 : 0,
       url: opts.uri,
@@ -213,21 +211,20 @@ export default class RequestClient {
       };
     }
 
-    var requestOptions: LastRequestOptions<TData> = {
+    const requestOptions: LastRequestOptions<TData> = {
       method: opts.method,
       url: opts.uri,
       auth: auth,
       params: options.params,
       data: opts.data,
       headers: opts.headers,
-      ca: this.ca,
     };
 
     if (opts.logLevel === "debug") {
       this.logRequest(requestOptions);
     }
 
-    var _this = this;
+    const _this = this;
     this.lastResponse = undefined;
     this.lastRequest = new Request(requestOptions);
 

--- a/lib/http/request.ts
+++ b/lib/http/request.ts
@@ -7,7 +7,6 @@ export interface RequestOptions<TData> {
   params?: string;
   data?: TData | "*";
   headers?: Headers | "*";
-  ca?: string | Buffer;
 }
 
 export interface Headers {
@@ -21,7 +20,6 @@ export default class Request<TData> {
   params: string;
   data: TData | "*";
   headers: Headers | "*";
-  ca?: string | Buffer;
 
   constructor(opts?: RequestOptions<TData>) {
     opts = opts || {};
@@ -32,7 +30,6 @@ export default class Request<TData> {
     this.params = opts.params || this.ANY;
     this.data = opts.data || this.ANY;
     this.headers = opts.headers || this.ANY;
-    this.ca = opts.ca;
   }
 
   get ANY(): "*" {

--- a/spec/unit/base/RequestClient.spec.js
+++ b/spec/unit/base/RequestClient.spec.js
@@ -72,6 +72,7 @@ describe("RequestClient constructor", function () {
     expect(requestClient.axios.defaults.httpsAgent.options.scheduling).toBe(
       undefined
     );
+    expect(requestClient.axios.defaults.httpsAgent.options.ca).toBe(undefined);
   });
 
   it("should initialize with a proxy", function () {
@@ -282,19 +283,8 @@ describe("lastRequest defined, lastResponse undefined", function () {
 });
 
 describe("User specified CA bundle", function () {
-  let options;
   beforeEach(function () {
-    axios.create.mockReturnValue(createMockAxios(Promise.reject("failed")));
-
-    options = {
-      method: "GET",
-      uri: "test-uri",
-      username: "test-username",
-      password: "test-password",
-      headers: { "test-header-key": "test-header-value" },
-      params: { "test-param-key": "test-param-value" },
-      data: { "test-data-key": "test-data-value" },
-    };
+    axios.create.mockReturnValue(createMockAxios(Promise.resolve()));
 
     mockfs({
       "/path/to/ca": {
@@ -307,39 +297,13 @@ describe("User specified CA bundle", function () {
     mockfs.restore();
   });
 
-  it("should not modify CA if not specified", function () {
-    let client = new RequestClient();
-
-    return client.request(options).catch(() => {
-      expect(client.lastRequest.ca).toBeUndefined();
-    });
-  });
-
   it("should use CA if it is specified", function () {
     process.env.TWILIO_CA_BUNDLE = "/path/to/ca/test-ca.pem";
     let client = new RequestClient();
+    delete process.env.TWILIO_CA_BUNDLE;
 
-    return client.request(options).catch(() => {
-      expect(client.lastRequest.ca.toString()).toEqual("test ca data");
-      delete process.env.TWILIO_CA_BUNDLE;
-    });
+    return expect(
+      client.axios.defaults.httpsAgent.options.ca.toString()
+    ).toEqual("test ca data");
   });
-
-  /* This doesn't make sense because Axios requires the CA to be set in a custom HTTP agent */
-  /* See: https://stackoverflow.com/questions/51363855/how-to-configure-axios-to-use-ssl-certificate */
-  /* See (doesn't specify SSL CA certificates in the request): https://axios-http.com/docs/req_config */
-  // it("should cache the CA after loading it for the first time", function () {
-  //   process.env.TWILIO_CA_BUNDLE = "/path/to/ca/test-ca.pem";
-  //   return client.request(options).catch(() => {
-  //     mockfs({
-  //       "/path/to/ca": {
-  //         "test-ca.pem": null,
-  //       },
-  //     });
-  //     return client.request(options).catch(() => {
-  //       expect(client.lastRequest.ca.toString()).toEqual("test ca data");
-  //       delete process.env.TWILIO_CA_BUNDLE;
-  //     });
-  //   });
-  // });
 });


### PR DESCRIPTION
No longer store the CA bundle in the `LastRequestOptions` as it doesn't change from request to request. Also update tests.