### PR TITLE
fix: update jsonwebtoken to v9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "axios": "^0.26.1",
     "dayjs": "^1.8.29",
     "https-proxy-agent": "^5.0.0",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
     "q": "2.0.x",
     "qs": "^6.9.4",


### PR DESCRIPTION


# Fixes #884 

Raises jsonwebtoken in package.json to 9.0.0 to move past the v8 with newly found security vulnerabilities. 

https://unit42.paloaltonetworks.com/jsonwebtoken-vulnerability-cve-2022-23529/

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x ] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x ] I have titled the PR appropriately
- [ x] I have updated my branch with the main branch
- [ x] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
