### PR TITLE
feat: Add auto-retry with exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ const client = require('twilio')(accountSid, authToken, {
 });
 ```
 
+### Enable Auto-Retry with Exponential Backoff
+
+`twilio-node` supports automatic retry with exponential backoff when API requests receive an [Error 429 response](https://support.twilio.com/hc/en-us/articles/360044308153-Twilio-API-response-Error-429-Too-Many-Requests-). This retry with exponential backoff feature is disabled by default. To enable this feature, instantiate the Twilio client with the `autoRetry` flag set to `true`.
+
+Optionally, the maximum number of retries performed by this feature can be set with the `maxRetries` flag. The default maximum number of retries is `3`.
+
+```javascript
+var accountSid = process.env.TWILIO_ACCOUNT_SID; // Your Account SID from www.twilio.com/console
+var authToken = process.env.TWILIO_AUTH_TOKEN;   // Your Auth Token from www.twilio.com/console
+
+const client = require('twilio')(accountSid, authToken, {
+    autoRetry: true,
+    maxRetries: 3
+});
+```
+
 ### Specify Region and/or Edge
 
 To take advantage of Twilio's [Global Infrastructure](https://www.twilio.com/docs/global-infrastructure), specify the target Region and/or Edge for the client:

--- a/lib/base/BaseTwilio.ts
+++ b/lib/base/BaseTwilio.ts
@@ -16,6 +16,8 @@ export interface ClientOpts {
   lazyLoading?: boolean;
   logLevel?: string;
   userAgentExtensions?: string[];
+  autoRetry?: boolean;
+  maxRetries?: number;
 }
 
 export interface RequestOpts {
@@ -46,6 +48,8 @@ export class BaseTwilio {
   edge?: string;
   region?: string;
   logLevel?: string;
+  autoRetry: boolean;
+  maxRetries?: number;
   userAgentExtensions?: string[];
   _httpClient?: RequestClient;
 
@@ -84,6 +88,8 @@ export class BaseTwilio {
     this.edge = this.opts.edge || this.env.TWILIO_EDGE;
     this.region = this.opts.region || this.env.TWILIO_REGION;
     this.logLevel = this.opts.logLevel || this.env.TWILIO_LOG_LEVEL;
+    this.autoRetry = this.opts.autoRetry || false;
+    this.maxRetries = this.opts.maxRetries;
     this.userAgentExtensions = this.opts.userAgentExtensions || [];
     this._httpClient = this.opts.httpClient;
 
@@ -102,7 +108,10 @@ export class BaseTwilio {
 
   get httpClient() {
     if (!this._httpClient) {
-      this._httpClient = new RequestClient();
+      this._httpClient = new RequestClient({
+        autoRetry: this.autoRetry,
+        maxRetries: this.maxRetries,
+      });
     }
     return this._httpClient;
   }

--- a/spec/integration.spec.js
+++ b/spec/integration.spec.js
@@ -29,4 +29,21 @@ describe("twilio", function () {
     var client = new twilio.Twilio(accountSid, token);
     expect(client.api.v2010.account.calls.each).toBeTruthy();
   });
+
+  it("should disable HTTP client auto-retry with exponential backoff by default", function () {
+    var client = new twilio.Twilio(accountSid, token);
+    expect(client.autoRetry).toBe(false);
+    expect(client.httpClient.autoRetry).toBe(false);
+  });
+
+  it("should set Twilio and HTTP client auto-retry with exponential backoff properties", function () {
+    var client = new twilio.Twilio(accountSid, token, {
+      autoRetry: true,
+      maxRetries: 5,
+    });
+    expect(client.autoRetry).toBe(true);
+    expect(client.maxRetries).toBe(5);
+    expect(client.httpClient.autoRetry).toBe(true);
+    expect(client.httpClient.maxRetries).toBe(5);
+  });
 });


### PR DESCRIPTION
Adds auto-retry with exponential backoff feature to auto-retry requests to the API when the API returns a 429 Too Many Requests error response. This feature is disabled by default.

Adds how-to docs for this feature to the README.

This PR is based on changes made in #741 (Thanks, @bobtfish!)