### PR TITLE
fix: use break() for method names rather than break_()

### DIFF
--- a/lib/twiml/VoiceResponse.ts
+++ b/lib/twiml/VoiceResponse.ts
@@ -1264,7 +1264,7 @@ namespace VoiceResponse {
   }
 
   /**
-   * Attributes to pass to break_
+   * Attributes to pass to break
    */
   export interface SsmlBreakAttributes {
     /** strength - Set a pause based on strength */
@@ -1338,7 +1338,7 @@ namespace VoiceResponse {
   }
 
   /**
-   * Attributes to pass to break_
+   * Attributes to pass to break
    */
   export interface SsmlBreakAttributes {
     /** strength - Set a pause based on strength */
@@ -1396,81 +1396,7 @@ namespace VoiceResponse {
   }
 
   /**
-   * Attributes to pass to break_
-   */
-  export interface SsmlBreakAttributes {
-    /** strength - Set a pause based on strength */
-    strength?: SsmlBreakStrength;
-    /** time - Set a pause to a specific length of time in seconds or milliseconds, available values: [number]s, [number]ms */
-    time?: string;
-  }
-
-  /**
-   * Attributes to pass to emphasis
-   */
-  export interface SsmlEmphasisAttributes {
-    /** level - Specify the degree of emphasis */
-    level?: SsmlEmphasisLevel;
-  }
-
-  /**
-   * Attributes to pass to lang
-   */
-  export interface SsmlLangAttributes {
-    /** xml:lang - Specify the language */
-    "xml:lang"?: SsmlLangXmlLang;
-  }
-
-  /**
-   * Attributes to pass to phoneme
-   */
-  export interface SsmlPhonemeAttributes {
-    /** alphabet - Specify the phonetic alphabet */
-    alphabet?: SsmlPhonemeAlphabet;
-    /** ph - Specifiy the phonetic symbols for pronunciation */
-    ph?: string;
-  }
-
-  /**
-   * Attributes to pass to prosody
-   */
-  export interface SsmlProsodyAttributes {
-    /** pitch - Specify the pitch, available values: default, x-low, low, medium, high, x-high, +n%, -n% */
-    pitch?: string;
-    /** rate - Specify the rate, available values: x-slow, slow, medium, fast, x-fast, n% */
-    rate?: string;
-    /** volume - Specify the volume, available values: default, silent, x-soft, soft, medium, loud, x-loud, +ndB, -ndB */
-    volume?: string;
-  }
-
-  /**
-   * Attributes to pass to sayAs
-   */
-  export interface SsmlSayAsAttributes {
-    /** format - Specify the format of the date when interpret-as is set to date */
-    format?: SsmlSayAsFormat;
-    /** interpret-as - Specify the type of words are spoken */
-    "interpret-as"?: SsmlSayAsInterpretAs;
-  }
-
-  /**
-   * Attributes to pass to sub
-   */
-  export interface SsmlSubAttributes {
-    /** alias - Substitute a different word (or pronunciation) for selected text such as an acronym or abbreviation */
-    alias?: string;
-  }
-
-  /**
-   * Attributes to pass to w
-   */
-  export interface SsmlWAttributes {
-    /** role - Customize the pronunciation of words by specifying the word’s part of speech or alternate meaning */
-    role?: string;
-  }
-
-  /**
-   * Attributes to pass to break_
+   * Attributes to pass to break
    */
   export interface SsmlBreakAttributes {
     /** strength - Set a pause based on strength */
@@ -1544,7 +1470,7 @@ namespace VoiceResponse {
   }
 
   /**
-   * Attributes to pass to break_
+   * Attributes to pass to break
    */
   export interface SsmlBreakAttributes {
     /** strength - Set a pause based on strength */
@@ -1618,7 +1544,7 @@ namespace VoiceResponse {
   }
 
   /**
-   * Attributes to pass to break_
+   * Attributes to pass to break
    */
   export interface SsmlBreakAttributes {
     /** strength - Set a pause based on strength */
@@ -1692,7 +1618,81 @@ namespace VoiceResponse {
   }
 
   /**
-   * Attributes to pass to break_
+   * Attributes to pass to break
+   */
+  export interface SsmlBreakAttributes {
+    /** strength - Set a pause based on strength */
+    strength?: SsmlBreakStrength;
+    /** time - Set a pause to a specific length of time in seconds or milliseconds, available values: [number]s, [number]ms */
+    time?: string;
+  }
+
+  /**
+   * Attributes to pass to emphasis
+   */
+  export interface SsmlEmphasisAttributes {
+    /** level - Specify the degree of emphasis */
+    level?: SsmlEmphasisLevel;
+  }
+
+  /**
+   * Attributes to pass to lang
+   */
+  export interface SsmlLangAttributes {
+    /** xml:lang - Specify the language */
+    "xml:lang"?: SsmlLangXmlLang;
+  }
+
+  /**
+   * Attributes to pass to phoneme
+   */
+  export interface SsmlPhonemeAttributes {
+    /** alphabet - Specify the phonetic alphabet */
+    alphabet?: SsmlPhonemeAlphabet;
+    /** ph - Specifiy the phonetic symbols for pronunciation */
+    ph?: string;
+  }
+
+  /**
+   * Attributes to pass to prosody
+   */
+  export interface SsmlProsodyAttributes {
+    /** pitch - Specify the pitch, available values: default, x-low, low, medium, high, x-high, +n%, -n% */
+    pitch?: string;
+    /** rate - Specify the rate, available values: x-slow, slow, medium, fast, x-fast, n% */
+    rate?: string;
+    /** volume - Specify the volume, available values: default, silent, x-soft, soft, medium, loud, x-loud, +ndB, -ndB */
+    volume?: string;
+  }
+
+  /**
+   * Attributes to pass to sayAs
+   */
+  export interface SsmlSayAsAttributes {
+    /** format - Specify the format of the date when interpret-as is set to date */
+    format?: SsmlSayAsFormat;
+    /** interpret-as - Specify the type of words are spoken */
+    "interpret-as"?: SsmlSayAsInterpretAs;
+  }
+
+  /**
+   * Attributes to pass to sub
+   */
+  export interface SsmlSubAttributes {
+    /** alias - Substitute a different word (or pronunciation) for selected text such as an acronym or abbreviation */
+    alias?: string;
+  }
+
+  /**
+   * Attributes to pass to w
+   */
+  export interface SsmlWAttributes {
+    /** role - Customize the pronunciation of words by specifying the word’s part of speech or alternate meaning */
+    role?: string;
+  }
+
+  /**
+   * Attributes to pass to break
    */
   export interface SsmlBreakAttributes {
     /** strength - Set a pause based on strength */
@@ -2798,7 +2798,7 @@ namespace VoiceResponse {
      *
      * @param attributes - TwiML attributes
      */
-    break_(
+    break(
       attributes?: VoiceResponse.SsmlBreakAttributes
     ): VoiceResponse.SsmlBreak {
       return new VoiceResponse.SsmlBreak(this.say.ele("break", attributes));
@@ -3079,7 +3079,7 @@ namespace VoiceResponse {
      *
      * @param attributes - TwiML attributes
      */
-    break_(
+    break(
       attributes?: VoiceResponse.SsmlBreakAttributes
     ): VoiceResponse.SsmlBreak {
       return new VoiceResponse.SsmlBreak(
@@ -3264,7 +3264,7 @@ namespace VoiceResponse {
      *
      * @param attributes - TwiML attributes
      */
-    break_(
+    break(
       attributes?: VoiceResponse.SsmlBreakAttributes
     ): VoiceResponse.SsmlBreak {
       return new VoiceResponse.SsmlBreak(
@@ -3477,7 +3477,7 @@ namespace VoiceResponse {
      *
      * @param attributes - TwiML attributes
      */
-    break_(
+    break(
       attributes?: VoiceResponse.SsmlBreakAttributes
     ): VoiceResponse.SsmlBreak {
       return new VoiceResponse.SsmlBreak(this.ssmlP.ele("break", attributes));
@@ -3685,7 +3685,7 @@ namespace VoiceResponse {
      *
      * @param attributes - TwiML attributes
      */
-    break_(
+    break(
       attributes?: VoiceResponse.SsmlBreakAttributes
     ): VoiceResponse.SsmlBreak {
       return new VoiceResponse.SsmlBreak(
@@ -3904,7 +3904,7 @@ namespace VoiceResponse {
      *
      * @param attributes - TwiML attributes
      */
-    break_(
+    break(
       attributes?: VoiceResponse.SsmlBreakAttributes
     ): VoiceResponse.SsmlBreak {
       return new VoiceResponse.SsmlBreak(this.ssmlS.ele("break", attributes));
@@ -4109,7 +4109,7 @@ namespace VoiceResponse {
      *
      * @param attributes - TwiML attributes
      */
-    break_(
+    break(
       attributes?: VoiceResponse.SsmlBreakAttributes
     ): VoiceResponse.SsmlBreak {
       return new VoiceResponse.SsmlBreak(this.ssmlW.ele("break", attributes));


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2

Note: If you made changes to the Request Validation logic, please run `npm run webhook-test` locally and ensure all test cases pass
-->

# Fixes #

`break` is a keyword in JS, but it is allowed for method names. Therefore we want to rename `break_()` methods to `break()`

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
