### PR TITLE
fix: restore test-docker rule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,4 @@ COPY index.* package.json babel.config.js tsconfig.json ./
 RUN npm config set unsafe-perm true # Needed to run prepublish as root.
 
 RUN npm install . --include=dev
+RUN npm install -g .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,3 @@ COPY index.* package.json babel.config.js tsconfig.json ./
 RUN npm config set unsafe-perm true # Needed to run prepublish as root.
 
 RUN npm install . --include=dev
-RUN npm install -g .

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ install:
 test:
 	npm test
 
+test-docker:
+	docker build -t twilio/twilio-node .
+	docker run twilio/twilio-node npm run ci
+
 docs:
 	npm run typedoc
 


### PR DESCRIPTION
The `test-docker` make rule got lost when we merged in the RC branch, restoring it here