### PR TITLE
fix: use correct Headers type

### DIFF
--- a/src/base/BaseTwilio.ts
+++ b/src/base/BaseTwilio.ts
@@ -1,5 +1,6 @@
 import RequestClient from "./RequestClient"; /* jshint ignore:line */
 import { HttpMethod } from "../interfaces"; /* jshint ignore:line */
+import { Headers } from "../http/request"; /* jshint ignore:line */
 
 const os = require("os"); /* jshint ignore:line */
 const url = require("url"); /* jshint ignore:line */
@@ -143,7 +144,7 @@ namespace Twilio {
       const username = opts.username || this.username;
       const password = opts.password || this.password;
 
-      const headers: any = opts.headers || {};
+      const headers = opts.headers || {};
 
       const pkgVersion = moduleInfo.version;
       const osName = os.platform();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
+    "lib": ["es2020"],
     "module": "commonjs",
     "declaration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
# Fixes #

The `RequestOpts` interface was incorrectly using the `Headers` type from the DOM lib. This produces an error for TypeScript users if they have `skipLibCheck` set to `false` and are not including the DOM TypeScript lib:

```
node_modules/twilio/lib/base/BaseTwilio.d.ts:22:19 - error TS2304: Cannot find name 'Headers'.

22         headers?: Headers;
                     ~~~~~~~


Found 1 error in node_modules/twilio/lib/base/BaseTwilio.d.ts:22
```

This PR also updates the `lib` in `tsconfig.json` to match the target. This makes it so that the DOM TypeScript lib is not included, since by default the DOM lib is included unless specified otherwise. I verified that this change would have caught this issue.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
