### PR TITLE
fix: cluster tests' twilio relative path dependency

### DIFF
--- a/spec/cluster/package.json
+++ b/spec/cluster/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "jest": "^29.4.3",
     "localtunnel": "^2.0.2",
-    "twilio": "../../package"
+    "twilio": "../../"
   },
   "scripts": {
     "prepare": "tsc",


### PR DESCRIPTION
Fixes the relative path used to install the twilio package from the parent directory for the cluster tests.

Closes #926 
