### PR TITLE
fix: bump dayjs version (fixes #934)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "axios": "^0.26.1",
-    "dayjs": "^1.8.29",
+    "dayjs": "^1.11.9",
     "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "^9.0.0",
     "qs": "^6.9.4",


### PR DESCRIPTION
Per https://github.com/twilio/twilio-node/issues/934#issuecomment-1615975913 the version of `dayjs` should be at least `v1.11.9` to avoid an error.