### PR TITLE
feat: migrate to picoquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dayjs": "^1.11.9",
     "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "^9.0.2",
-    "qs": "^6.9.4",
+    "picoquery": "^1.0.0",
     "scmp": "^2.1.0",
     "xmlbuilder": "^13.0.2"
   },
@@ -34,7 +34,6 @@
     "@types/jest": "^29.5.5",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/node": "^18.11.18",
-    "@types/qs": "^6.9.7",
     "babel-plugin-replace-ts-export-assignment": "^0.0.2",
     "eslint": "^8.31.0",
     "express": "^4.17.1",
@@ -45,8 +44,8 @@
     "node-mocks-http": "^1.8.1",
     "prettier": "^2.7.1",
     "ts-jest": "^29.1.1",
-    "typescript": "^4.7.2",
-    "typedoc": "^0.23.21"
+    "typedoc": "^0.23.21",
+    "typescript": "^4.7.2"
   },
   "scripts": {
     "test": "npm run test:javascript && npm run test:typescript",

--- a/src/base/RequestClient.ts
+++ b/src/base/RequestClient.ts
@@ -2,7 +2,7 @@ import { HttpMethod } from "../interfaces";
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import * as fs from "fs";
 import HttpsProxyAgent from "https-proxy-agent";
-import qs from "qs";
+import * as pq from "picoquery";
 import * as https from "https";
 import Response from "../http/response";
 import Request, {
@@ -194,7 +194,7 @@ class RequestClient {
       if (
         options.headers["Content-Type"] === "application/x-www-form-urlencoded"
       ) {
-        options.data = qs.stringify(opts.data, { arrayFormat: "repeat" });
+        options.data = pq.stringify(opts.data, { arrayRepeat: true, arrayRepeatSyntax: "repeat" });
       } else if (options.headers["Content-Type"] === "application/json") {
         options.data = opts.data;
       }
@@ -203,7 +203,7 @@ class RequestClient {
     if (opts.params) {
       options.params = opts.params;
       options.paramsSerializer = (params) => {
-        return qs.stringify(params, { arrayFormat: "repeat" });
+        return pq.stringify(params, { arrayRepeat: true, arrayRepeatSyntax: "repeat" });
       };
     }
 


### PR DESCRIPTION
Migrates away from `qs` to `picoquery`, a much lighter (594K vs 41K) and faster alternative.

I actually made this branch to prove out picoquery during development, so if you'd rather stick with the existing dependencies, just let me know and we can close this PR.

While I am (currently) maintainer of picoquery, its part of a wider effort to contribute to performance changes across the ecosystem. In this case, reducing the twilio library's package size and increasing speed.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works (**existing tests should suffice**)
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
