### PR TITLE
fix(webhooks): validate Twilio signatures with escaped and unescaped query string values fixes #1059

### DIFF
--- a/spec/unit/webhooks/webhooks.spec.js
+++ b/spec/unit/webhooks/webhooks.spec.js
@@ -1,0 +1,105 @@
+import { getExpectedTwilioSignature, validateRequest } from "../../../src";
+
+describe("webhooks", () => {
+  const authToken = "s3cr3t";
+
+  describe("validateRequest()", () => {
+    it("should return false when the signature URL does not match the target URL", () => {
+      const serverUrl = "https://example.com/path?test=param";
+      const targetUrl = "https://example.com/path?test=param2";
+
+      const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+      const result = validateRequest(authToken, signature, targetUrl, {});
+
+      expect(result).toBe(false);
+    });
+
+    describe("when the signature is derived from an URL with port", () => {
+      it("should return true when the target url contains the port", () => {
+        const serverUrl = "https://example.com:443/path?test=param";
+        const targetUrl = "https://example.com:443/path?test=param";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+
+      it("should return true when the target url does not contain the port", () => {
+        const serverUrl = "https://example.com:443/path?test=param";
+        const targetUrl = "https://example.com/path?test=param";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("when the signature is derived from an URL without port", () => {
+      it("should return true when the target url does not contain the port", () => {
+        const serverUrl = "https://example.com/path?test=param";
+        const targetUrl = "https://example.com/path?test=param";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+
+      it("should return true when the target url contains the port", () => {
+        const serverUrl = "https://example.com/path?test=param";
+        const targetUrl = "https://example.com:443/path?test=param";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("when the signature is derived from an URL with a query param containing an unescaped single quote", () => {
+      it("should return true when the target url contains the unescaped single quote", () => {
+        const serverUrl = "https://example.com/path?test=param'WithQuote";
+        const targetUrl = "https://example.com/path?test=param'WithQuote";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+
+      it("should return true when the target url contains the escaped single quote", () => {
+        const serverUrl = "https://example.com/path?test=param'WithQuote";
+        const targetUrl = "https://example.com/path?test=param%27WithQuote";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("when the signature is derived from an URL with a query param containing an escaped single quote", () => {
+      it("should return true when the target url contains the unescaped single quote", () => {
+        const serverUrl = "https://example.com/path?test=param%27WithQuote";
+        const targetUrl = "https://example.com/path?test=param'WithQuote";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+
+      it("should return true when the target url contains the escaped single quote", () => {
+        const serverUrl = "https://example.com/path?test=param%27WithQuote";
+        const targetUrl = "https://example.com/path?test=param%27WithQuote";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+    });
+  });
+});

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -200,32 +200,47 @@ export function validateRequest(
    *  and with and without the legacy querystring (special chars are encoded when using `new URL()`)
    *  since signature generation on the back end is inconsistent
    */
-  return (
-    validateSignatureWithUrl(
-      authToken,
-      twilioHeader,
-      removePort(urlObject),
-      params
-    ) ||
-    validateSignatureWithUrl(
-      authToken,
-      twilioHeader,
-      addPort(urlObject),
-      params
-    ) ||
-    validateSignatureWithUrl(
-      authToken,
-      twilioHeader,
-      withLegacyQuerystring(removePort(urlObject)),
-      params
-    ) ||
-    validateSignatureWithUrl(
-      authToken,
-      twilioHeader,
-      withLegacyQuerystring(addPort(urlObject)),
-      params
-    )
+  const isValidSignatureWithoutPort = validateSignatureWithUrl(
+    authToken,
+    twilioHeader,
+    removePort(urlObject),
+    params
   );
+
+  if (isValidSignatureWithoutPort) {
+    return true;
+  }
+
+  const isValidSignatureWithPort = validateSignatureWithUrl(
+    authToken,
+    twilioHeader,
+    addPort(urlObject),
+    params
+  );
+
+  if (isValidSignatureWithPort) {
+    return true;
+  }
+
+  const isValidSignatureWithLegacyQuerystringWithoutPort = validateSignatureWithUrl(
+    authToken,
+    twilioHeader,
+    withLegacyQuerystring(removePort(urlObject)),
+    params
+  );
+
+  if (isValidSignatureWithLegacyQuerystringWithoutPort) {
+    return true;
+  }
+
+  const isValidSignatureWithLegacyQuerystringWithPort = validateSignatureWithUrl(
+    authToken,
+    twilioHeader,
+    withLegacyQuerystring(addPort(urlObject)),
+    params
+  );
+
+  return isValidSignatureWithLegacyQuerystringWithPort;
 }
 
 function validateSignatureWithUrl(
@@ -233,7 +248,7 @@ function validateSignatureWithUrl(
   twilioHeader: string,
   url: string,
   params: Record<string, any>
-) {
+): boolean {
   const signatureWithoutPort = getExpectedTwilioSignature(
     authToken,
     url,

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -99,6 +99,8 @@ function addPort(parsedUrl: URL): string {
  @returns URL without port
  */
 function removePort(parsedUrl: URL): string {
+  parsedUrl = new URL(parsedUrl); // prevent mutation of original URL object
+
   parsedUrl.port = "";
   return parsedUrl.toString();
 }

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -222,23 +222,25 @@ export function validateRequest(
     return true;
   }
 
-  const isValidSignatureWithLegacyQuerystringWithoutPort = validateSignatureWithUrl(
-    authToken,
-    twilioHeader,
-    withLegacyQuerystring(removePort(urlObject)),
-    params
-  );
+  const isValidSignatureWithLegacyQuerystringWithoutPort =
+    validateSignatureWithUrl(
+      authToken,
+      twilioHeader,
+      withLegacyQuerystring(removePort(urlObject)),
+      params
+    );
 
   if (isValidSignatureWithLegacyQuerystringWithoutPort) {
     return true;
   }
 
-  const isValidSignatureWithLegacyQuerystringWithPort = validateSignatureWithUrl(
-    authToken,
-    twilioHeader,
-    withLegacyQuerystring(addPort(urlObject)),
-    params
-  );
+  const isValidSignatureWithLegacyQuerystringWithPort =
+    validateSignatureWithUrl(
+      authToken,
+      twilioHeader,
+      withLegacyQuerystring(addPort(urlObject)),
+      params
+    );
 
   return isValidSignatureWithLegacyQuerystringWithPort;
 }


### PR DESCRIPTION


<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2

Note: If you made changes to the Request Validation logic, please run `npm run webhook-test` locally and ensure all test cases pass
-->

# Fixes #1059 

Update the `validateRequest()` function to fallback to a query string parser that does not escape single quotes if the request validation fails.

**Why?**
Query string values that contain single quotes (`'`) are escaped when using `new URL()`, but the Twilio server seems to generate the signature with the unescaped single quote value, causing the validation to fail in the scenario described in #1059



### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
