### PR TITLE
chore: update package.json to include TS declarations in ESM exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./lib-esm/index.js",
       "require": "./lib/index.js"
     }


### PR DESCRIPTION
## Problem #
After #1130, consumers using TypeScript with moduleResolution: node16/nodenext/bundler get
TS7016 ... implicitly has an 'any' type ... could not be resolved when respecting package.json "exports" when importing twilio.

## Cause #
Type declarations aren’t exported via package.json "exports", so TS refuses to load them when respecting exports  ([discussion here](https://github.com/microsoft/TypeScript/issues/52363)).

## Fixes #

Add a "types" condition to the "." export so TypeScript can resolve ./index.d.ts while Node keeps using the JS entry points. TS docs describe this mechanism and [recommend](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing) putting "types" first in the condition list. 

## Runtime impact
None. Node ignores "types". make test passes locally.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

