### PR TITLE
chore: replace scmp with crypto.timingSafeEqual

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "^9.0.3",
     "qs": "^6.14.1",
-    "scmp": "^2.1.0",
     "xmlbuilder": "^13.0.2"
   },
   "devDependencies": {

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -1,4 +1,3 @@
-const scmp = require("scmp");
 import crypto from "crypto";
 import urllib from "url";
 import { IncomingHttpHeaders } from "http2";
@@ -257,7 +256,10 @@ function validateSignatureWithUrl(
     params
   );
 
-  return scmp(Buffer.from(twilioHeader), Buffer.from(signatureWithoutPort));
+  return timingSafeEqual(
+    Buffer.from(twilioHeader),
+    Buffer.from(signatureWithoutPort)
+  );
 }
 
 export function validateBody(
@@ -265,7 +267,19 @@ export function validateBody(
   bodyHash: any[] | string | Buffer
 ): boolean {
   var expectedHash = getExpectedBodyHash(body);
-  return scmp(Buffer.from(bodyHash), Buffer.from(expectedHash));
+  return timingSafeEqual(Buffer.from(bodyHash), Buffer.from(expectedHash));
+}
+
+function timingSafeEqual(userValue: Buffer, secretValue: Buffer) {
+  // Do not return early when lengths differ — that leaks the secret's
+  // length through timing.  Instead, always perform a constant-time
+  // comparison: when the lengths match compare directly; otherwise
+  // compare the user input against itself (always true) and negate.
+  // Source: https://developers.cloudflare.com/workers/examples/protect-against-timing-attacks/
+  const lengthsMatch = userValue.length === secretValue.length;
+  return lengthsMatch
+    ? crypto.timingSafeEqual(userValue, secretValue)
+    : !crypto.timingSafeEqual(userValue, userValue);
 }
 
 /**


### PR DESCRIPTION
# Fixes #1168

scmp is now deprecated and is equivalent to `crypto.timingSafeEqual` (which is supported by Node.js >=6.6.0)

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
