### PR TITLE
chore: mvr 6.0.0 release prep

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        node: [ 14, 16, 18, 20, 22, lts/* ]
+        node: [20, 22, 24, lts/* ]
     steps:
       - name: Checkout twilio-node
         uses: actions/checkout@v3
@@ -74,12 +74,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout twilio-node
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
 
@@ -90,7 +90,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_AUTH_TOKEN }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 twilio-node changelog
 =====================
 
+[2026-04-16] Version 6.0.0
+---------------------------
+**Library - Breaking Changes**
+- Bump version to 6.0.0 (major version release)
+- Raise minimum Node.js engine from >=14.0 to >=20.0
+
 [2026-04-14] Version 5.13.2
 ---------------------------
 **Twiml**

--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ The Node library documentation can be found [here][libdocs].
 
 This library supports the following Node.js implementations:
 
-- Node.js 14
-- Node.js 16
-- Node.js 18
 - Node.js 20
-- Node.js lts(22)
+- Node.js 22
+- Node.js 24 (lts)
 
 TypeScript is supported for TypeScript version 2.9 and above.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,18 @@
 
 _All `MAJOR` version bumps will have upgrade notes posted here._
 
+## [2026-04-16] 5.x.x to 6.x.x
+---
+### Overview
+
+Twilio Node Helper Library’s major version 6.0.0 is now available. We ensured that you can upgrade to Node Helper Library 6.0.0 version without any breaking changes to existing APIs.
+
+### Breaking Changes
+
+- **Minimum Node.js version raised to 20**
+  - Dropped support for Node.js 14, 16, and 18
+  - Upgrade to Node.js >= 20 before updating to `twilio` 6.x
+
 ## [2024-03-07] 4.x.x to 5.x.x
 
 ---

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,7 +2,7 @@
 
 _All `MAJOR` version bumps will have upgrade notes posted here._
 
-## [2026-04-16] 5.x.x to 6.x.x
+## [2026-04-20] 5.x.x to 6.x.x
 ---
 ### Overview
 
@@ -11,8 +11,8 @@ Twilio Node Helper Library’s major version 6.0.0 is now available. We ensured 
 ### Breaking Changes
 
 - **Minimum Node.js version raised to 20**
-  - Dropped support for Node.js 14, 16, and 18
-  - Upgrade to Node.js >= 20 before updating to `twilio` 6.x
+  - Dropped support for Node.js versions below 20
+  - Upgrade to Node.js >= 20 before updating to `twilio` 6.x.x
 
 ## [2024-03-07] 4.x.x to 5.x.x
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "main": "./lib",
   "types": "./index.d.ts",
   "engines": {
-    "node": ">=20.0"
+    "node": ">=20.0.0"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twilio",
   "description": "A Twilio helper library",
-  "version": "5.13.2",
+  "version": "6.0.0",
   "author": "API Team <api@twilio.com>",
   "contributors": [
     {
@@ -71,7 +71,7 @@
   "main": "./lib",
   "types": "./index.d.ts",
   "engines": {
-    "node": ">=14.0"
+    "node": ">=20.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
  Title: Drop Node.js 14/16/18 support, bump to 6.0.0
                                                                                                                              
  Body:                                                                                                                     
                                                                                                                              
  Summary                                                                                                                     
                                                                                                                              
  - Bump version to 6.0.0 (major version release)                                                                             
  - Raise minimum Node.js engine from >=14.0 to >=20.0                                                                        
  - Update CI test matrix from [14, 16, 18, 20, 22, lts/*] to [20, 22, 24, lts/*]                                             
  - Update GitHub Actions in deploy job: actions/checkout@v4, actions/setup-node@v4, docker/login-action@v3                   
  - Update README.md supported versions: Node.js 20, 22, 24                                                                   
  - Add UPGRADE.md entry for 5.x.x to 6.x.x migration                                                                         
                                                                                                                              
  Test plan                                                                                                                   
                                                                                                                              
  - CI passes for Node.js 20, 22, 24, and lts/*                                                                               
  - Unit tests pass on all matrix versions                                                                                  
  - Cluster tests pass on all matrix versions              