### PR TITLE
fix: validate the received url before its re-encoded variants

### DIFF
--- a/spec/unit/webhooks/webhooks.spec.js
+++ b/spec/unit/webhooks/webhooks.spec.js
@@ -101,5 +101,37 @@ describe("webhooks", () => {
         expect(result).toBe(true);
       });
     });
+
+    describe("when the signature is derived from an URL with a query param containing a single quote and a space encoded as +", () => {
+      it("should return true when the target url is identical to the signed url", () => {
+        const serverUrl = "https://example.com/path?name=William+O'hara";
+        const targetUrl = "https://example.com/path?name=William+O'hara";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+
+      it("should return true when the target url contains the port", () => {
+        const serverUrl = "https://example.com/path?name=William+O'hara";
+        const targetUrl = "https://example.com:443/path?name=William+O'hara";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+
+      it("should return true when the target url does not contain the port", () => {
+        const serverUrl = "https://example.com:443/path?name=William+O'hara";
+        const targetUrl = "https://example.com/path?name=William+O'hara";
+
+        const signature = getExpectedTwilioSignature(authToken, serverUrl, {});
+        const result = validateRequest(authToken, signature, targetUrl, {});
+
+        expect(result).toBe(true);
+      });
+    });
   });
 });

--- a/src/webhooks/webhooks.ts
+++ b/src/webhooks/webhooks.ts
@@ -105,6 +105,43 @@ function removePort(parsedUrl: URL): string {
   return parsedUrl.toString();
 }
 
+/**
+ Utility function to add or remove the port on a URL string without rebuilding
+ it from a parsed URL object, so the path and query string keep the exact
+ characters Twilio signed
+
+ @param url - The raw URL string that Twilio requested on your server
+ @param parsedUrl - The same URL, already parsed, used to read the protocol
+ @returns URL without its port if it had one, or with the standard port for its
+ protocol if it did not
+ */
+function togglePortPreservingEncoding(url: string, parsedUrl: URL): string {
+  const match = /^([a-z][a-z0-9+.-]*:\/\/)([^/?#]*)/i.exec(url);
+
+  if (!match) {
+    return url;
+  }
+
+  const [prefix, scheme, authority] = match;
+  const rest = url.slice(prefix.length);
+
+  const userInfoEnd = authority.lastIndexOf("@");
+  const userInfo =
+    userInfoEnd === -1 ? "" : authority.slice(0, userInfoEnd + 1);
+  const hostWithPort = authority.slice(userInfoEnd + 1);
+
+  // A colon delimits the port only when it comes after the closing bracket of
+  // an IPv6 literal, or when there is no IPv6 literal at all
+  const ipv6End = hostWithPort.lastIndexOf("]");
+  const portStart = hostWithPort.indexOf(":", ipv6End === -1 ? 0 : ipv6End);
+  const host =
+    portStart === -1 ? hostWithPort : hostWithPort.slice(0, portStart);
+  const port =
+    portStart === -1 ? (parsedUrl.protocol === "https:" ? ":443" : ":80") : "";
+
+  return scheme + userInfo + host + port + rest;
+}
+
 function withLegacyQuerystring(url: string): string {
   const parsedUrl = new URL(url);
 
@@ -194,6 +231,35 @@ export function validateRequest(
 ): boolean {
   twilioHeader = twilioHeader || "";
   const urlObject = new URL(url);
+
+  /*
+   *  Check the url exactly as it was received first, since that is the string
+   *  Twilio signed. Every variant below is rebuilt from `new URL()`, which
+   *  percent-encodes characters the back end leaves alone (`'` becomes `%27`),
+   *  and the legacy querystring round trip rewrites `+` as `%20`, so none of
+   *  them can reproduce a url containing those characters
+   */
+  const isValidSignatureWithReceivedUrl = validateSignatureWithUrl(
+    authToken,
+    twilioHeader,
+    url,
+    params
+  );
+
+  if (isValidSignatureWithReceivedUrl) {
+    return true;
+  }
+
+  const isValidSignatureWithReceivedUrlAndTogglePort = validateSignatureWithUrl(
+    authToken,
+    twilioHeader,
+    togglePortPreservingEncoding(url, urlObject),
+    params
+  );
+
+  if (isValidSignatureWithReceivedUrlAndTogglePort) {
+    return true;
+  }
 
   /*
    *  Check signature of the url with and without the port number


### PR DESCRIPTION
# Fixes #1183

`validateRequest()` rebuilds every candidate URL from `new URL(url)`, so the string it hashes is never the string Twilio actually signed. Two separate normalizations get in the way:

- `new URL()` percent-encodes characters the back end leaves as-is, so `'` becomes `%27`
- `withLegacyQuerystring()` round-trips through `querystring.parse`/`stringify`, which decodes `+` to a space and re-encodes it as `%20`

Each of the four existing variants goes through at least one of those, so a URL whose query contains **both** a space encoded as `+` and a single quote cannot be reproduced by any of them, and a validly signed request is rejected.

The existing single-quote tests pass only by coincidence: Node's `querystring.escape` does not escape `'`, so the legacy-querystring variant happens to reproduce the raw string. Add a `+` to the same query and that coincidence disappears — which is exactly the `?name=William+O'hara` case in #1183.

### Change

Check the URL exactly as received **first**, since that is the string Twilio signed, followed by a port-toggled form of it. The port toggle is done with string surgery on the authority component only (handling `userinfo@` and IPv6 literals), so the path and query keep their exact bytes rather than being rebuilt from a parsed object.

The four existing variants are left untouched and still run afterwards, so URLs that only validate in a normalized form keep working. The change is purely additive — it accepts signatures that are already valid, and every candidate is still verified against the auth token through the same constant-time comparison.

### Testing

Added three cases covering `?name=William+O'hara` — identical URL, target with the port, and target without the port. All three fail on `main` and pass with this change.

```
Tests:       432 passed, 432 total
Test Suites: 28 passed, 28 total
```

`npm run test:typescript` (`tsc --noEmit`) and `prettier --check` are both clean.

Note: `PULL_REQUEST_TEMPLATE.md` asks to run `npm run webhook-test` for Request Validation changes, but no such script exists in `package.json`. The equivalent `spec/cluster/webhook.spec.ts` needs live credentials (`TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_API_KEY`, `TWILIO_API_SECRET`) plus localtunnel and makes real API calls, so I did not run it. Happy to if a maintainer can run it against CI credentials.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-node/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file — no public API or behaviour change to document; this restores documented behaviour
- [x] I have added inline documentation to the code I modified
