### PR TITLE
fix: use speechTimeout casing on ConversationRelay

### DIFF
--- a/spec/unit/twiml/VoiceResponse.spec.js
+++ b/spec/unit/twiml/VoiceResponse.spec.js
@@ -333,4 +333,16 @@ describe("create voice response TwiML", function () {
       '<?xml version="1.0" encoding="UTF-8"?><Response/><!-- Hello World -->'
     );
   });
+
+  it("should emit speechTimeout on ConversationRelay", function () {
+    var actual = new VoiceResponse();
+    actual.connect().conversationRelay({
+      url: "wss://example.test/ws",
+      speechTimeout: "2000",
+    });
+
+    expect(actual.toString()).toEqual(
+      '<?xml version="1.0" encoding="UTF-8"?><Response><Connect><ConversationRelay url="wss://example.test/ws" speechTimeout="2000"/></Connect></Response>'
+    );
+  });
 });

--- a/src/twiml/VoiceResponse.ts
+++ b/src/twiml/VoiceResponse.ts
@@ -3164,8 +3164,8 @@ namespace VoiceResponse {
     reportInputDuringAgentSpeech?: boolean;
     /** speechModel - Speech model to be used for transcription */
     speechModel?: string;
-    /** speechtimeout - Set the duration of silence that indicates the end of speech */
-    speechtimeout?: string;
+    /** speechTimeout - Set the duration of silence that indicates the end of speech */
+    speechTimeout?: string;
     /** transcriptionLanguage - Language to be used for transcription */
     transcriptionLanguage?: string;
     /** transcriptionProvider - Provider to be used for transcription */


### PR DESCRIPTION
Fixes #1192

## Summary
- Rename `ConversationRelayAttributes.speechtimeout` to `speechTimeout` so the TypeScript type matches the TwiML spec and CHANGES.md
- Add a unit test that asserts generated TwiML emits `speechTimeout`

Without this, following the types produces invalid TwiML that Twilio rejects. Passing the correct camelCase name already worked at runtime but failed type-checking.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the Contribution Guidelines and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
